### PR TITLE
Enable wave and hydrodynamics params in Ignition

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,44 @@ The session should include a wave field and the floating objects depicted in the
 
 There are some changes to the plugin SDF schema for hydrodynamics and waves.   
 
+### Waves model and visual plugins
+
+- The `filename` and `name` attributes for the wave model and visal plugins have changed.
+- The `<size>` element has been renamed to `<tile_size>` and moved into `<waves>`
+- The `<cell_count>` element has been moved into `<waves>`
+- Add new element `<algorithm>` to specify the wave generation algorithm. Valid options are: `sinusoid`, `trochoid` and `fft`.
+- Add new element `<wind_velocity>` for use with the `fft` algorithm.
+
+```xml
+<plugin
+    filename="ignition-marine1-waves-model-system"
+    name="ignition::gazebo::systems::WavesModel">
+    <static>0</static>
+    <update_rate>30</update_rate>
+    <wave>
+      <!-- Algorithm: sinusoid, trochoid, fft  -->
+      <algorithm>fft</algorithm>
+
+      <!-- Cell count must be a power of 2 for fft waves -->
+      <tile_size>256</tile_size>
+      <cell_count>128</cell_count>
+      
+      <!-- `fft` waves parameters -->
+      <wind_velocity>5 0</wind_velocity>
+
+      <!-- `trochoid` waves parameters -->
+      <number>3</number>
+      <scale>1.5</scale>
+      <angle>0.4</angle>
+      <amplitude>0.4</amplitude>
+      <period>8.0</period>
+      <phase>0.0</phase>
+      <steepness>1.0</steepness>
+      <direction>1 0</direction>
+    </wave>
+</plugin>
+```
+
 ### Hydrodynamics plugin
 
 - The `filename` and `name` attributes for the hydrodynamics plugin have changed.
@@ -163,7 +201,7 @@ There are some changes to the plugin SDF schema for hydrodynamics and waves.
 <plugin
   filename="ignition-marine1-hydrodynamics-system"
   name="ignition::gazebo::systems::Hydrodynamics">
-  
+
    <!-- Hydrodynamics -->
    <hydrodynamics>
     <damping_on>1</damping_on>
@@ -175,7 +213,7 @@ There are some changes to the plugin SDF schema for hydrodynamics and waves.
     <cDampL2>1.0E-6</cDampL2>
     <cDampR1>1.0E-6</cDampR1>
     <cDampR2>1.0E-6</cDampR2>
-  
+
     <!-- 'Pressure' Drag -->
     <cPDrag1>1.0E+2</cPDrag1>
     <cPDrag2>1.0E+2</cPDrag2>

--- a/README.md
+++ b/README.md
@@ -148,6 +148,47 @@ ign gazebo -v4 -g
 
 The session should include a wave field and the floating objects depicted in the image at head of this document.
 
+## Changes
+
+There are some changes to the plugin SDF schema for hydrodynamics and waves.   
+
+### Hydrodynamics plugin
+
+- The `filename` and `name` attributes for the hydrodynamics plugin have changed.
+- The hydrodynamics parameters are now scoped in an additional `<hydrodynamics>` element.
+- The `<wave_model>` element is not currently used.
+- The `<markers>` element is not currently used (not implemented).
+
+```xml
+<plugin
+  filename="ignition-marine1-hydrodynamics-system"
+  name="ignition::gazebo::systems::Hydrodynamics">
+  
+   <!-- Hydrodynamics -->
+   <hydrodynamics>
+    <damping_on>1</damping_on>
+    <viscous_drag_on>1</viscous_drag_on>
+    <pressure_drag_on>1</pressure_drag_on>
+
+    <!-- Linear and Angular Damping -->  
+    <cDampL1>1.0E-6</cDampL1>
+    <cDampL2>1.0E-6</cDampL2>
+    <cDampR1>1.0E-6</cDampR1>
+    <cDampR2>1.0E-6</cDampR2>
+  
+    <!-- 'Pressure' Drag -->
+    <cPDrag1>1.0E+2</cPDrag1>
+    <cPDrag2>1.0E+2</cPDrag2>
+    <fPDrag>0.4</fPDrag>
+    <cSDrag1>1.0E+2</cSDrag1>
+    <cSDrag2>1.0E+2</cSDrag2>
+    <fSDrag>0.4</fSDrag>
+    <vRDrag>1.0</vRDrag>
+  </hydrodynamics>
+</plugin>
+```
+
+
 
 ## Build Status
 

--- a/ign-marine-models/models/wam-v/model.sdf
+++ b/ign-marine-models/models/wam-v/model.sdf
@@ -323,6 +323,26 @@
     <plugin
         filename="ignition-marine1-hydrodynamics-system"
         name="ignition::gazebo::systems::Hydrodynamics">
+        <hydrodynamics>
+          <damping_on>1</damping_on>
+          <viscous_drag_on>1</viscous_drag_on>
+          <pressure_drag_on>1</pressure_drag_on>
+        
+          <!-- Linear and Angular Damping -->
+          <cDampL1>1.0E-6</cDampL1>
+          <cDampL2>1.0E-6</cDampL2>
+          <cDampR1>1.0E-6</cDampR1>
+          <cDampR2>1.0E-6</cDampR2>
+        
+          <!-- 'Pressure' Drag -->
+          <cPDrag1>1.0E+2</cPDrag1>
+          <cPDrag2>1.0E+2</cPDrag2>
+          <fPDrag>0.4</fPDrag>
+          <cSDrag1>1.0E+2</cSDrag1>
+          <cSDrag2>1.0E+2</cSDrag2>
+          <fSDrag>0.4</fSDrag>
+          <vRDrag>1.0</vRDrag>
+        </hydrodynamics>
     </plugin>
 
     <!-- ArduPilot plugin -->

--- a/ign-marine-models/world_models/waves/model.sdf
+++ b/ign-marine-models/world_models/waves/model.sdf
@@ -6,6 +6,24 @@
     <plugin
         filename="ignition-marine1-waves-model-system"
         name="ignition::gazebo::systems::WavesModel">
+        <static>0</static>
+        <update_rate>30</update_rate>
+        <wave>
+          <algorithm>fft</algorithm>
+          <tile_size>256</tile_size>
+          <cell_count>128</cell_count>
+          <wind_velocity>5 0</wind_velocity>
+          <!-- unused by FFT waves
+          <number>3</number>
+          <scale>1.5</scale>
+          <angle>0.4</angle>
+          <amplitude>0.4</amplitude>
+          <period>8.0</period>
+          <phase>0.0</phase>
+          <steepness>1.0</steepness>
+          <direction>1 0</direction>
+          -->
+        </wave>
     </plugin>
 
     <link name="base_link">
@@ -50,9 +68,17 @@
           </pbr>
         </material>
 
+        <!-- \todo remove duplicate params; populate from service instead -->
         <plugin
             filename="ignition-marine1-waves-visual-system"
             name="ignition::gazebo::systems::WavesVisual">
+            <static>0</static>
+            <wave>
+              <algorithm>fft</algorithm>
+              <tile_size>256</tile_size>
+              <cell_count>128</cell_count>
+              <wind_velocity>5 0</wind_velocity>
+            </wave>
         </plugin>
 
         <!-- 

--- a/ign-marine-models/worlds/waves.sdf
+++ b/ign-marine-models/worlds/waves.sdf
@@ -1,23 +1,22 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="waves">
-    <plugin
-      filename="ignition-gazebo-physics-system"
-      name="ignition::gazebo::systems::Physics">
+    <plugin filename="ignition-gazebo-physics-system"
+            name="ignition::gazebo::systems::Physics">
     </plugin>
-    <plugin
-      filename="ignition-gazebo-sensors-system"
-      name="ignition::gazebo::systems::Sensors">
+    <plugin filename="ignition-gazebo-sensors-system"
+            name="ignition::gazebo::systems::Sensors">
       <render_engine>ogre2</render_engine>
       <background_color>0.8 0.8 0.8</background_color>
     </plugin>
-    <plugin
-      filename="ignition-gazebo-scene-broadcaster-system"
-      name="ignition::gazebo::systems::SceneBroadcaster">
+    <plugin filename="ignition-gazebo-scene-broadcaster-system"
+            name="ignition::gazebo::systems::SceneBroadcaster">
     </plugin>
-    <plugin
-      filename="ignition-gazebo-user-commands-system"
-      name="ignition::gazebo::systems::UserCommands">
+    <plugin filename="ignition-gazebo-user-commands-system"
+            name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin filename="libignition-gazebo-imu-system.so"
+            name="ignition::gazebo::systems::Imu">
     </plugin>
 
     <scene>

--- a/ign-marine/include/ignition/marine/WaveParameters.hh
+++ b/ign-marine/include/ignition/marine/WaveParameters.hh
@@ -24,6 +24,7 @@
 #include <sdf/sdf.hh>
 
 #include <memory>
+#include <string>
 
 namespace ignition
 {
@@ -61,6 +62,15 @@ namespace marine
     /// \param[in] _sdf   The SDF Element tree containing the wave parameters.
     public: void SetFromSDF(sdf::Element& _sdf);
 
+    /// \brief The wave algorithm (options are: 'sinusoid', 'trochoid', 'fft').
+    public: std::string Algorithm() const;
+
+    /// \brief The size of the wave tile in metres (L).
+    public: double TileSize() const;
+
+    /// \brief The number of cells in the wave tile in each direction (N). 
+    public: size_t CellCount() const;
+
     /// \brief The number of wave components (3 max if visualisation required).
     public: size_t Number() const;
 
@@ -96,6 +106,24 @@ namespace marine
 
     /// \brief A two component vector specifiying the direction of the mean wave.
     public: math::Vector2d Direction() const;
+
+    /// \brief A two component vector specifiying the horizontal wind velocity.
+    public: math::Vector2d WindVelocity() const;
+
+    /// \brief Set the wave algorithm (options are: 'sinusoid', 'trochoid', 'fft').
+    ///
+    /// \param[in] _algorithm    The wave algorithm.
+    public: void SetAlgorithm(const std::string &_algorithm);
+
+    /// \brief Set the size of the wave tile in metres (L).
+    ///
+    /// \param[in] _L    The size of the wave tile.
+    public: void SetTileSize(double _L);
+
+    /// \brief Set the number of cells in the wave tile in each direction (N). 
+    ///
+    /// \param[in] _N    The number of cells.
+    public: void SetCellCount(size_t _N);
 
     /// \brief Set the number of wave components (3 max).
     ///
@@ -139,6 +167,11 @@ namespace marine
     ///
     /// \param[in] _direction The direction parameter, a two component vector.
     public: void SetDirection(const math::Vector2d& _direction);
+
+    /// \brief Set the horizontal wind velocity.
+    ///
+    /// \param[in] _windVelocity The wind velocity, a two component vector.
+    public: void SetWindVelocity(const math::Vector2d& _windVelocity);
 
     /// \brief Access the component angular frequencies.
     public: const std::vector<double>& AngularFrequency_V() const;

--- a/ign-marine/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/ign-marine/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -630,9 +630,19 @@ void Hydrodynamics::Configure(const Entity &_entity,
   // // Wave Model
   // this->data->waveModelName = Utilities::SdfParamString(*_sdf, "wave_model", "");
 
+  // Empty sdf element used as a placeholder for missing elements 
+  auto sdfEmpty = std::make_shared<sdf::Element>();
+
   // Hydrodynamics parameters
   this->dataPtr->hydroParams.reset(new marine::HydrodynamicsParameters());
-  this->dataPtr->hydroParams->SetFromSDF(*this->dataPtr->sdf);
+
+  auto sdfHydro = sdfEmpty;
+  if (this->dataPtr->sdf->HasElement("hydrodynamics"))
+  {
+    sdfHydro = _sdf->GetElementImpl("hydrodynamics");
+  }
+  this->dataPtr->hydroParams->SetFromSDF(*sdfHydro);
+
 
   // // Markers
   // if (_sdf->HasElement("markers"))

--- a/ign-marine/src/systems/hydrodynamics/Hydrodynamics.hh
+++ b/ign-marine/src/systems/hydrodynamics/Hydrodynamics.hh
@@ -31,7 +31,40 @@ namespace systems
   // Forward declaration
   class HydrodynamicsPrivate;
 
-  /// \brief A plugin for surface hydrodynamics
+  /// \brief A plugin to manage buoyancy and hydrodynamic force calculations
+  ///
+  /// # Usage
+  /// 
+  /// Add the SDF for the plugin to the <model> element of your model. 
+  /// 
+  /// /code
+  /// <plugin name="ignition::gazebo::systems::Hydrodynamics"
+  ///         filename="ignition-marine1-hydrodynamics-system">
+  ///
+  ///   <!-- Hydrodynamics -->
+  ///   <hydrodynamics>
+  ///     <damping_on>1</damping_on>
+  ///     <viscous_drag_on>1</viscous_drag_on>
+  ///     <pressure_drag_on>1</pressure_drag_on>
+  ///
+  ///     <!-- Linear and Angular Damping -->
+  ///     <cDampL1>1.0E-6</cDampL1>
+  ///     <cDampL2>1.0E-6</cDampL2>
+  ///     <cDampR1>1.0E-6</cDampR1>
+  ///     <cDampR2>1.0E-6</cDampR2>
+  ///
+  ///     <!-- 'Pressure' Drag -->
+  ///     <cPDrag1>1.0E+2</cPDrag1>
+  ///     <cPDrag2>1.0E+2</cPDrag2>
+  ///     <fPDrag>0.4</fPDrag>
+  ///     <cSDrag1>1.0E+2</cSDrag1>
+  ///     <cSDrag2>1.0E+2</cSDrag2>
+  ///     <fSDrag>0.4</fSDrag>
+  ///     <vRDrag>1.0</vRDrag>
+  ///   </hydrodynamics>
+  /// </plugin>
+  /// \endcode
+  ///
   class Hydrodynamics
       : public System,
         public ISystemConfigure,


### PR DESCRIPTION
This PR enables the hydrodynamics and wave parameters when using Ignition

There are changes to the parameters for the Hydrodynamics, WaveModel and WaveVisual plugins. This is documented in the README.

The parameter that allows the wave generation algorithm to be set is not enabled in this PR. The `fft` algorithm is set by default, however the parameters for the wave tile size, cell count and wind velocity are operational.

## Example: varying wind velocity 

`<wind_velocity>0.005 0</wind_velocity>`

![v=0 005](https://user-images.githubusercontent.com/24916364/161116558-b266bd58-e43e-4a59-9b8e-01b484b573b4.png)

`<wind_velocity>5 0</wind_velocity>`

![v=10](https://user-images.githubusercontent.com/24916364/161116575-84675f96-8e59-418a-af6a-5c1fe879dcc1.png)

  