### PR TITLE
Fix wave direction

### DIFF
--- a/ign-marine-models/world_models/waves/model.sdf
+++ b/ign-marine-models/world_models/waves/model.sdf
@@ -14,7 +14,7 @@
           <tile_size>512</tile_size>
           <cell_count>128</cell_count>
           <wind_speed>5.0</wind_speed>
-          <wind_angle_deg>-45</wind_angle_deg>
+          <wind_angle_deg>135</wind_angle_deg>
           <steepness>2</steepness>
 
         </wave>
@@ -52,7 +52,7 @@
               <tile_size>512</tile_size>
               <cell_count>128</cell_count>
               <wind_speed>5.0</wind_speed>
-              <wind_angle_deg>-45</wind_angle_deg>
+              <wind_angle_deg>135</wind_angle_deg>
               <steepness>2</steepness>
 
             </wave>

--- a/ign-marine-models/worlds/waves.sdf
+++ b/ign-marine-models/worlds/waves.sdf
@@ -38,6 +38,55 @@
       <uri>model://waves</uri>
     </include>
 
+    <!-- ENU axes -->
+    <model name="axes">
+      <static>1</static>
+      <link name="link">
+        <visual name="r">
+          <pose>5 0 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>10 0.01 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <emissive>1 0 0 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+        <visual name="g">
+          <pose>0 5 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 10 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <emissive>0 1 0 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+        <visual name="b">
+          <pose>0 0 5.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 0.01 10</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <emissive>0 0 1 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
     <include>
       <pose>0 0 0 0 0 3.14</pose>
       <uri>model://duck</uri>

--- a/ign-marine/src/OceanTile.cc
+++ b/ign-marine/src/OceanTile.cc
@@ -314,7 +314,7 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
       // FFT2
       std::unique_ptr<WaveSimulationFFT2> waveSim(
           new WaveSimulationFFT2(_N, _L));
-      waveSim->SetLambda(1.0);      // larger lambda => steeper waves.
+      waveSim->SetLambda(_params->Steepness());  // larger lambda => steeper waves.
       mWaveSim = std::move(waveSim);
       break;
     }

--- a/ign-marine/src/WaveSimulationFFT2.cc
+++ b/ign-marine/src/WaveSimulationFFT2.cc
@@ -152,9 +152,20 @@ namespace marine
       _heights.resize(mN2, 0.0);
     }
 
-    for (size_t i=0; i<mN2; ++i)
+    // for (size_t i=0; i<mN2; ++i)
+    // {
+    //   _heights[i] = mOut0[i][0];
+    // }
+    // change from matrix 'ij' to cartesian 'xy' coordinates
+    // z(i,j) => z(x, y): x = j, y = i
+    for (size_t ikx = 0; ikx < this->Nx; ++ikx)
     {
-      _heights[i] = mOut0[i][0];
+      for (size_t iky = 0; iky < this->Ny; ++iky)
+      {
+        int ij = ikx * this->Ny + iky;
+        int xy = iky * this->Nx + ikx;
+        _heights[xy] = mOut0[ij][0];
+      }
     }
   }
 
@@ -187,10 +198,24 @@ namespace marine
       _dhdy.resize(mN2, 0.0);
     }
 
-    for (size_t i=0; i<mN2; ++i)
+    // for (size_t i=0; i<mN2; ++i)
+    // {
+    //   _dhdx[i] = mOut1[i][0];
+    //   _dhdy[i] = mOut2[i][0];
+    // }
+    // change from matrix 'ij' to cartesian 'xy' coordinates
+    // z(i,j) => z(x, y): x = j, y = i
+    // dz(i,j)/di => dz(x, y)/dy: x = j, y = i
+    // dz(i,j)/dj => dz(x, y)/dx: x = j, y = i
+    for (size_t ikx = 0; ikx < this->Nx; ++ikx)
     {
-      _dhdx[i] = mOut1[i][0];
-      _dhdy[i] = mOut2[i][0];
+      for (size_t iky = 0; iky < this->Ny; ++iky)
+      {
+        int ij = ikx * this->Ny + iky;
+        int xy = iky * this->Nx + ikx;
+        _dhdy[xy] = mOut1[ij][0];
+        _dhdx[xy] = mOut2[ij][0];
+      }
     }
   }
 
@@ -223,10 +248,23 @@ namespace marine
       _sy.resize(mN2, 0.0);
     }
 
-    for (size_t i=0; i<mN2; ++i)
+    // for (size_t i=0; i<mN2; ++i)
+    // {
+    //   _sx[i] = mOut3[i][0] * mLambda;
+    //   _sy[i] = mOut4[i][0] * mLambda;
+    // }
+    // change from matrix 'ij' to cartesian 'xy' coordinates
+    // sy(i,j) => si(x, y): x = j, y = i
+    // sx(i,j) => sj(x, y): x = j, y = i
+    for (size_t ikx = 0; ikx < this->Nx; ++ikx)
     {
-      _sx[i] = mOut3[i][0] * mLambda;
-      _sy[i] = mOut4[i][0] * mLambda;
+      for (size_t iky = 0; iky < this->Ny; ++iky)
+      {
+        int ij = ikx * this->Ny + iky;
+        int xy = iky * this->Nx + ikx;
+        _sy[xy] = mOut3[ij][0] * mLambda;
+        _sx[xy] = mOut4[ij][0] * mLambda;
+      }
     }
   }
 
@@ -268,11 +306,25 @@ namespace marine
       _dsxdy.resize(mN2, 0.0);
     }
 
-    for (size_t i=0; i<mN2; ++i)
+    // for (size_t i=0; i<mN2; ++i)
+    // {
+    //   _dsxdx[i] = mOut5[i][0] * mLambda;
+    //   _dsydy[i] = mOut6[i][0] * mLambda;
+    //   _dsxdy[i] = mOut7[i][0] * mLambda;
+    // }
+    // change from matrix 'ij' to cartesian 'xy' coordinates
+    // sy(i,j) => si(x, y): x = j, y = i
+    // sx(i,j) => sj(x, y): x = j, y = i
+    for (size_t ikx = 0; ikx < this->Nx; ++ikx)
     {
-      _dsxdx[i] = mOut5[i][0] * mLambda;
-      _dsydy[i] = mOut6[i][0] * mLambda;
-      _dsxdy[i] = mOut7[i][0] * mLambda;
+      for (size_t iky = 0; iky < this->Ny; ++iky)
+      {
+        int ij = ikx * this->Ny + iky;
+        int xy = iky * this->Nx + ikx;
+        _dsydy[xy] = mOut5[ij][0] * mLambda;
+        _dsxdx[xy] = mOut6[ij][0] * mLambda;
+        _dsxdy[xy] = mOut7[ij][0] * mLambda;
+      }
     }
   }
 
@@ -551,7 +603,7 @@ namespace marine
         double ook = 1.0 / k;
 
         // index for flattened arrays
-        int idx = ikx * Nx + iky;
+        int idx = ikx * Ny + iky;
 
         complex h  = zhat[ikx][iky];
         complex hi = h * iunit;


### PR DESCRIPTION
This PR fixes an issue where the requested wave direction is not set correctly because the FFT2 wave simulation and ocean tile are using different coordinate systems. The FFT uses a matrix coordinate system ('ij') whereas the OceanTile uses a cartesian ('xy') coordinate system - as a result the x and y axes were transposed. 

Other changes:

- Hardcoded steepness parameter is now retrieved from the parameters
- Default downwind direction updated
- Add reference axes to wave model 
