### PR TITLE
Initial optimisation of FFT wave model and correct normal orientation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This package contains plugins that support the simulation of waves and surface vessels in Ignition Gazebo.  
 
-![Ignition Marine](https://github.com/srmainwaring/asv_wave_sim/wiki/images/ign-marine-v3.jpg)
+![Ignition Marine](https://github.com/srmainwaring/asv_wave_sim/wiki/images/ign-marine-v4b.jpg)
 
 ## Notes
 

--- a/ign-marine-models/worlds/waves.sdf
+++ b/ign-marine-models/worlds/waves.sdf
@@ -43,6 +43,7 @@
       <static>1</static>
       <link name="link">
         <visual name="r">
+          <cast_shadows>0</cast_shadows>
           <pose>5 0 0.1 0 0 0</pose>
           <geometry>
             <box>
@@ -57,6 +58,7 @@
           </material>
         </visual>
         <visual name="g">
+          <cast_shadows>0</cast_shadows>
           <pose>0 5 0.1 0 0 0</pose>
           <geometry>
             <box>
@@ -71,6 +73,7 @@
           </material>
         </visual>
         <visual name="b">
+          <cast_shadows>0</cast_shadows>
           <pose>0 0 5.1 0 0 0</pose>
           <geometry>
             <box>

--- a/ign-marine/src/OceanTile.cc
+++ b/ign-marine/src/OceanTile.cc
@@ -401,13 +401,11 @@ void OceanTilePrivate<Vector3>::Create()
   mBitangents.assign(mVertices.size(), vector::Zero<Vector3>);
   mNormals.assign(mVertices.size(), vector::Zero<Vector3>);
 
-  // \todo(srmainwaring): remove - this to test static model
-  UpdateVertices(5.0);
-
   if (mHasVisuals) 
   {
-    ComputeNormals();
-    ComputeTangentSpace();
+    /// \note: uncomment to calculate normals and tangents by finited difference
+    // ComputeNormals();
+    // ComputeTangentSpace();
 #if 0
     CreateMesh(this->mAboveOceanMeshName, 0.0, false);
     CreateMesh(this->mBelowOceanMeshName, -0.05, true);
@@ -626,8 +624,8 @@ void OceanTilePrivate<Vector3>::Update(double _time)
 
   if (mHasVisuals)
   {
-    // Uncomment to calculate the tangent space using finite differences
-    ComputeTangentSpace();
+    /// \note: Uncomment to calculate the tangent space using finite differences
+    // ComputeTangentSpace();
     // UpdateMesh(mAboveOceanSubMesh, 0.0, false);
     // UpdateMesh(mBelowOceanSubMesh, -0.05, false);
   }
@@ -694,11 +692,24 @@ void OceanTilePrivate<math::Vector3d>::UpdateVertexAndTangents(
   t.X() = dsxdx + 1.0;
   t.Y() = dsxdy;
   t.Z() = dhdx;
-  
+
   auto&& b = mBitangents[idx0];
   b.X() = dsxdy;
   b.Y() = dsydy + 1.0;
   b.Z() = dhdy;
+
+  auto&& n = mNormals[idx0];
+  auto normal =  t.Cross(b);
+  n.X() = normal.X();
+  n.Y() = normal.Y();
+  n.Z() = normal.Z();
+
+  /// \todo add check if this is required for non-FFT models
+  // 3. Normal must be reversed when using FTT waves. This is because
+  // the coordinate change from matrix indexing to cartesian indexing
+  // reflects the surface in the line x=y which flips the
+  // surface orientation.
+  n *= -1.0;
 }
 
 //////////////////////////////////////////////////

--- a/ign-marine/src/WaveSimulationFFT2.cc
+++ b/ign-marine/src/WaveSimulationFFT2.cc
@@ -13,6 +13,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
+// The non-vectorised time-dependent update step labelled 'non-vectorised reference version'
+// in WaveSimulationFFT2Impl.ComputeCurrentAmplitudes is based on the Curtis Mobley's
+// IDL code cgAnimate_2D_SeaSurface.py
+
+//***************************************************************************************************
+//* This code is copyright (c) 2016 by Curtis D. Mobley.                                            *
+//* Permission is hereby given to reproduce and use this code for non-commercial academic research, *
+//* provided that the user suitably acknowledges Curtis D. Mobley in any presentations, reports,    *
+//* publications, or other works that make use of the code or its output.  Depending on the extent  *
+//* of use of the code or its outputs, suitable acknowledgement can range from a footnote to offer  *
+//* of coauthorship.  Further questions can be directed to curtis.mobley@sequoiasci.com.            *
+//***************************************************************************************************
+
 #include "ignition/marine/WaveSimulationFFT2.hh"
 #include "ignition/marine/WaveSpectrum.hh"
 
@@ -549,6 +563,7 @@ namespace marine
       }
     }
 
+    // non-vectorised reference version
     std::vector<std::vector<complex>> zhat(Nx, std::vector<complex>(Ny, complex(0.0, 0.0)));
     for (int ikx = 1; ikx < Nx; ++ikx)
     {

--- a/ign-marine/src/WaveSimulationFFT2.cc
+++ b/ign-marine/src/WaveSimulationFFT2.cc
@@ -345,6 +345,9 @@ namespace marine
   /////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeBaseAmplitudes()
   {
+    // gravity acceleration [m/s^2] 
+    const double g = 9.82;
+
     // storage for Fourier coefficients
     mH.resize(mN2, complex(0.0, 0.0));
     mHikx.resize(mN2, complex(0.0, 0.0));
@@ -430,13 +433,6 @@ namespace marine
     double delta_ky = this->ky_f;
     // double c1 = cap_psi_norm * sqrt(delta_kx * delta_ky);
 
-    for (int i = 0; i < mN2; ++i)
-    {
-      // this->cap_psi_2s_root[i] = c1 * sqrt(cap_psi_2s_fft[i]);
-      this->cap_psi_2s_root[i] =
-          cap_psi_norm * sqrt(cap_psi_2s_fft[i] * delta_kx * delta_ky);
-    }
-
     // iid random normals for real and imaginary parts of the amplitudes
     auto seed = std::default_random_engine::default_seed;
     std::default_random_engine generator(seed);
@@ -444,12 +440,14 @@ namespace marine
 
     for (int i = 0; i < mN2; ++i)
     {
+      // this->cap_psi_2s_root[i] = c1 * sqrt(cap_psi_2s_fft[i]);
+      this->cap_psi_2s_root[i] =
+          cap_psi_norm * sqrt(cap_psi_2s_fft[i] * delta_kx * delta_ky);
+
       this->rho[i] = distribution(generator);
       this->sigma[i] = distribution(generator);
     }
 
-    // gravity acceleration [m/s^2] 
-    double g = 9.82;
 
     // angular temporal frequency for time-dependent (from dispersion)
     for (int ikx = 0; ikx < this->Nx; ++ikx)

--- a/ign-marine/src/WaveSimulationFFT2.cc
+++ b/ign-marine/src/WaveSimulationFFT2.cc
@@ -345,7 +345,7 @@ namespace marine
   /////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeBaseAmplitudes()
   {
-    // storage for Fourier coefficients 
+    // storage for Fourier coefficients
     mH.resize(mN2, complex(0.0, 0.0));
     mHikx.resize(mN2, complex(0.0, 0.0));
     mHiky.resize(mN2, complex(0.0, 0.0));
@@ -632,9 +632,7 @@ namespace marine
   /////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeBaseAmplitudesReference()
   {
-    // 1D axes
-
-    // 2D grids
+    // storage for Fourier coefficients
     mH.resize(mN2, complex(0.0, 0.0));
     mHikx.resize(mN2, complex(0.0, 0.0));
     mHiky.resize(mN2, complex(0.0, 0.0));
@@ -643,6 +641,21 @@ namespace marine
     mHkxkx.resize(mN2, complex(0.0, 0.0));
     mHkyky.resize(mN2, complex(0.0, 0.0));
     mHkxky.resize(mN2, complex(0.0, 0.0));
+
+    // arrays for reference version
+    if (cap_psi_2s_root_ref.empty() || 
+        this->cap_psi_2s_root_ref.size() != this->Nx ||
+        this->cap_psi_2s_root_ref[0].size() != this->Ny)
+    {
+      this->cap_psi_2s_root_ref = std::vector<std::vector<double>>(
+          this->Nx, std::vector<double>(this->Ny, 0.0));
+      this->rho_ref = std::vector<std::vector<double>>(
+          this->Nx, std::vector<double>(this->Ny, 0.0));
+      this->sigma_ref = std::vector<std::vector<double>>(
+          this->Nx, std::vector<double>(this->Ny, 0.0));
+      this->omega_k_ref = std::vector<std::vector<double>>(
+          this->Nx, std::vector<double>(this->Ny, 0.0));
+    }
 
     // Guide to indexing conventions:  1. index, 2. math-order, 3. fft-order
     // 

--- a/ign-marine/src/WaveSimulationFFT2.cc
+++ b/ign-marine/src/WaveSimulationFFT2.cc
@@ -345,6 +345,18 @@ namespace marine
   /////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeBaseAmplitudes()
   {
+    this->ComputeBaseAmplitudesRef();
+  }
+
+  /////////////////////////////////////////////////
+  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudes(double _time)
+  {
+    this->ComputeCurrentAmplitudes(_time);
+  }
+
+  /////////////////////////////////////////////////
+  void WaveSimulationFFT2Impl::ComputeBaseAmplitudesRef()
+  {
     // 1D axes
 
     // 2D grids
@@ -540,7 +552,7 @@ namespace marine
   }
 
   /////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudes(double _time)
+  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesRef(double _time)
   {
     // alias
     auto& Nx = this->Nx;

--- a/ign-marine/src/WaveSimulationFFT2Impl.hh
+++ b/ign-marine/src/WaveSimulationFFT2Impl.hh
@@ -79,10 +79,10 @@ namespace marine
     void ComputeCurrentAmplitudes(double _time);
     
     /// \brief Reference implementation of base amplitude calculation
-    void ComputeBaseAmplitudesRef();
+    void ComputeBaseAmplitudesReference();
 
     /// \brief Reference implementation of time-dependent amplitude calculation
-    void ComputeCurrentAmplitudesRef(double _time);
+    void ComputeCurrentAmplitudesReference(double _time);
 
     /// \brief Number of samples in each direction. Must be a multiple of 2
     int mN;
@@ -181,18 +181,39 @@ namespace marine
     // set to 1 to use a symmetric spreading function (=> standing waves)
     bool use_symmetric_spreading_fn = false;
 
+    //////////////////////////////////////////////////
+    /// \note: use flattened array storage for optimised version
+
     // square-root of two-sided discrete elevation variance spectrum
-    std::vector<std::vector<double>> cap_psi_2s_root = std::vector<std::vector<double>>(
-        this->Nx, std::vector<double>(this->Ny, 0.0));
+    std::vector<double> cap_psi_2s_root =
+        std::vector<double>(this->Nx * this->Ny, 0.0);
 
     // iid random normals for real and imaginary parts of the amplitudes
-    std::vector<std::vector<double>> rho = std::vector<std::vector<double>>(
+    std::vector<double> rho =
+        std::vector<double>(this->Nx * this->Ny, 0.0);
+    std::vector<double> sigma =
+        std::vector<double>(this->Nx * this->Ny, 0.0);
+
+    // angular temporal frequency
+    std::vector<double> omega_k =
+        std::vector<double>(this->Nx * this->Ny, 0.0);
+
+    //////////////////////////////////////////////////
+    /// \note: use 2d array storage for reference version
+
+    // square-root of two-sided discrete elevation variance spectrum
+    std::vector<std::vector<double>> cap_psi_2s_root_ref =
+        std::vector<std::vector<double>>(
+            this->Nx, std::vector<double>(this->Ny, 0.0));
+
+    // iid random normals for real and imaginary parts of the amplitudes
+    std::vector<std::vector<double>> rho_ref = std::vector<std::vector<double>>(
         this->Nx, std::vector<double>(this->Ny, 0.0));
-    std::vector<std::vector<double>> sigma = std::vector<std::vector<double>>(
+    std::vector<std::vector<double>> sigma_ref = std::vector<std::vector<double>>(
         this->Nx, std::vector<double>(this->Ny, 0.0));
 
     // angular temporal frequency
-    std::vector<std::vector<double>> omega_k = std::vector<std::vector<double>>(
+    std::vector<std::vector<double>> omega_k_ref = std::vector<std::vector<double>>(
         this->Nx, std::vector<double>(this->Ny, 0.0));
 
     double ECKVOmniDirectionalSpectrum(double k, double u10, double cap_omega_c=0.84);

--- a/ign-marine/src/WaveSimulationFFT2Impl.hh
+++ b/ign-marine/src/WaveSimulationFFT2Impl.hh
@@ -199,22 +199,17 @@ namespace marine
         std::vector<double>(this->Nx * this->Ny, 0.0);
 
     //////////////////////////////////////////////////
-    /// \note: use 2d array storage for reference version
+    /// \note: use 2d array storage for reference version, resized if required
 
     // square-root of two-sided discrete elevation variance spectrum
-    std::vector<std::vector<double>> cap_psi_2s_root_ref =
-        std::vector<std::vector<double>>(
-            this->Nx, std::vector<double>(this->Ny, 0.0));
+    std::vector<std::vector<double>> cap_psi_2s_root_ref;
 
     // iid random normals for real and imaginary parts of the amplitudes
-    std::vector<std::vector<double>> rho_ref = std::vector<std::vector<double>>(
-        this->Nx, std::vector<double>(this->Ny, 0.0));
-    std::vector<std::vector<double>> sigma_ref = std::vector<std::vector<double>>(
-        this->Nx, std::vector<double>(this->Ny, 0.0));
+    std::vector<std::vector<double>> rho_ref;
+    std::vector<std::vector<double>> sigma_ref;
 
     // angular temporal frequency
-    std::vector<std::vector<double>> omega_k_ref = std::vector<std::vector<double>>(
-        this->Nx, std::vector<double>(this->Ny, 0.0));
+    std::vector<std::vector<double>> omega_k_ref;
 
     double ECKVOmniDirectionalSpectrum(double k, double u10, double cap_omega_c=0.84);
     double ECKVSpreadingFunction(double k, double phi, double u10, double cap_omega_c=0.84);

--- a/ign-marine/src/WaveSimulationFFT2Impl.hh
+++ b/ign-marine/src/WaveSimulationFFT2Impl.hh
@@ -33,42 +33,65 @@ namespace marine
   typedef double fftw_data_type;
   typedef std::complex<fftw_data_type> complex;
 
+  /// \brief Implementation of a FFT based wave simulation model
   class WaveSimulationFFT2Impl
   {
   public:
+    /// \brief Destructor 
     ~WaveSimulationFFT2Impl();
 
+    /// \brief Construct a wave simulation model
     WaveSimulationFFT2Impl(int _N, double _L);
 
+    /// \brief Set the components of the wind velocity (U10) in [m/s]
     void SetWindVelocity(double _ux, double _uy);
 
+    /// \brief Set the current time in seconds
     void SetTime(double _time);
 
+    /// \brief Set the horizontal displacement scaling factor
     void SetLambda(double _lambda);
 
+    /// \brief Calculate the sea surface elevation
     void ComputeHeights(
       std::vector<double>& _heights);
 
+    /// \brief Calculate the derivative of the elevation wrt x and y
     void ComputeHeightDerivatives(
       std::vector<double>& _dhdx,
       std::vector<double>& _dhdy);
 
+    /// \brief Calculate the sea surface horizontal displacements
     void ComputeDisplacements(
       std::vector<double>& _sx,
       std::vector<double>& _sy);
 
+    /// \brief Calculate the derivative of the horizontal displacements wrt x and y
     void ComputeDisplacementDerivatives(
       std::vector<double>& _dsxdx,
       std::vector<double>& _dsydy,
       std::vector<double>& _dsxdy);
 
+    /// \brief Calculate the base (time-independent) Fourier amplitudes
     void ComputeBaseAmplitudes();
 
+    /// \brief Calculate the time-independent Fourier amplitudes
     void ComputeCurrentAmplitudes(double _time);
     
+    /// \brief Reference implementation of base amplitude calculation
+    void ComputeBaseAmplitudesRef();
+
+    /// \brief Reference implementation of time-dependent amplitude calculation
+    void ComputeCurrentAmplitudesRef(double _time);
+
+    /// \brief Number of samples in each direction. Must be a multiple of 2
     int mN;
     int mN2;
+
+    /// \brief Size of the sample region [m]
     double mL;
+
+    /// \brief Horizontal displacement scaling factor. Zero for no displacement
     double mLambda;
 
     std::vector<complex> mH;      // FFT0 - height
@@ -106,9 +129,17 @@ namespace marine
     double  Ly = this->mL;
     int     Nx = this->mN;
     int     Ny = this->mN;
+
+    /// \brief Wind speed at 10m above mean sea level [m]
     double  u10 = 5.0;
+
+    /// \brief Direction of u10. Counter clockwise angle from x-axis [rad]
     double  phi10 = 0.0;
+
+    /// \brief Spreading parameter for the cosine-2S model
     double  s_param = 5.0;
+
+    /// \brief Parameter controlling the maturity of the sea state.
     double  cap_omega_c = 0.84;
 
     // derived quantities

--- a/ign-marine/src/WaveSimulationFFT2_TEST.cc
+++ b/ign-marine/src/WaveSimulationFFT2_TEST.cc
@@ -26,8 +26,8 @@
 using namespace ignition;
 using namespace marine;
 
-///////////////////////////////////////////////////////////////////////////////
-// Define tests
+/////////////////////////////////////////////////
+// Define fixture
 
 class TestFixtureWaveSimulationFFT2: public ::testing::Test
 { 
@@ -58,7 +58,7 @@ public:
   int    N = 8;
 };
 
-///////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////
 // Define tests
  
 TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
@@ -92,6 +92,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
     ASSERT_DOUBLE_EQ(model.ky_fft[i] / model.ky_f, iky_fft[i]);
   }
 }
+
+/////////////////////////////////////////////////
+// Reference version checks
 
 TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
 {
@@ -241,7 +244,308 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference
   }
 }
 
+/////////////////////////////////////////////////
+// Optimised version checks
 
+TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
+{
+  WaveSimulationFFT2Impl model(this->N, this->L);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(0.0);
+
+  for (int ikx=0; ikx<this->N; ++ikx)
+  {
+    for (int iky=0; iky<this->N; ++iky)
+    {
+      // index for flattened array
+      int idx = ikx * this->N + iky;
+
+      // index for conjugate
+      int cdx = 0;
+      if (ikx == 0)
+        cdx += ikx * this->N;
+      else
+        cdx += (this->N - ikx) * this->N;
+
+      if (iky == 0)
+        cdx += iky;
+      else
+        cdx += (this->N - iky);
+
+      // look up amplitude and conjugate
+      complex h  = model.mH[idx];
+      complex hc = model.mH[cdx];
+
+      // real part symmetric
+      ASSERT_DOUBLE_EQ(h.real(), hc.real());
+      
+      // imaginary part anti-symmetric
+      ASSERT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
+    }
+  }
+}
+
+TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
+{
+  WaveSimulationFFT2Impl model(this->N, this->L);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(11.2);
+
+  for (int ikx=0; ikx<this->N; ++ikx)
+  {
+    for (int iky=0; iky<this->N; ++iky)
+    {
+      // index for flattened array
+      int idx = ikx * this->N + iky;
+
+      // index for conjugate
+      int cdx = 0;
+      if (ikx == 0)
+        cdx += ikx * this->N;
+      else
+        cdx += (this->N - ikx) * this->N;
+
+      if (iky == 0)
+        cdx += iky;
+      else
+        cdx += (this->N - iky);
+
+      // look up amplitude and conjugate
+      complex h  = model.mH[idx];
+      complex hc = model.mH[cdx];
+
+      // real part symmetric
+      ASSERT_DOUBLE_EQ(h.real(), hc.real());
+      
+      // imaginary part anti-symmetric
+      ASSERT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
+    }
+  }
+}
+
+TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
+{
+  int N2 = this->N * this->N;
+
+  WaveSimulationFFT2Impl model(this->N, this->L);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(0.0);
+
+  std::vector<double> z;
+  model.ComputeHeights(z);
+
+  EXPECT_EQ(z.size(), N2);
+
+  double sum_z2 = 0.0;
+  double sum_h2 = 0.0;
+  for (int i=0; i<N2; ++i)
+  {
+    sum_z2 += z[i]*z[i];
+    sum_h2 += norm(model.mH[i]);
+  }
+
+  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * N2);
+}
+
+TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
+{
+  int N2 = this->N * this->N;
+
+  WaveSimulationFFT2Impl model(this->N, this->L);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(25.3);
+
+  std::vector<double> z;
+  model.ComputeHeights(z);
+
+  EXPECT_EQ(z.size(), N2);
+
+  double sum_z2 = 0.0;
+  double sum_h2 = 0.0;
+  for (int i=0; i<N2; ++i)
+  {
+    sum_z2 += z[i]*z[i];
+    sum_h2 += norm(model.mH[i]);
+  }
+
+  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * N2);
+}
+
+TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
+{
+  int N2 = this->N * this->N;
+
+  WaveSimulationFFT2Impl model(this->N, this->L);
+
+  // displacements should be zero when lamda = 0
+  model.SetLambda(0.0);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(10.0);
+
+  std::vector<double> sx, sy;
+  model.ComputeDisplacements(sx, sy);
+
+  EXPECT_EQ(sx.size(), N2);
+  EXPECT_EQ(sy.size(), N2);
+
+  for (int i=0; i<N2; ++i)
+  {
+    ASSERT_DOUBLE_EQ(sx[i], 0.0);
+    ASSERT_DOUBLE_EQ(sy[i], 0.0);
+  }
+}
+
+/////////////////////////////////////////////////
+// Cross-check optimised version against reference 
+
+TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeZero)
+{
+  int N2 = this->N * this->N;
+
+  WaveSimulationFFT2Impl ref_model(this->N, this->L);
+  ref_model.ComputeBaseAmplitudesReference();
+  ref_model.ComputeCurrentAmplitudesReference(0.0);
+
+  std::vector<double> ref_z;
+  ref_model.ComputeHeights(ref_z);
+
+  WaveSimulationFFT2Impl model(this->N, this->L);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(0.0);
+
+  std::vector<double> z;
+  model.ComputeHeights(z);
+
+  EXPECT_EQ(ref_z.size(), N2);
+  EXPECT_EQ(z.size(), N2);
+
+  for (int i=0; i<N2; ++i)
+  {
+    ASSERT_DOUBLE_EQ(z[i], ref_z[i]);
+  }
+}
+
+TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeNonZero)
+{
+  int N2 = this->N * this->N;
+
+  WaveSimulationFFT2Impl ref_model(this->N, this->L);
+  ref_model.ComputeBaseAmplitudesReference();
+  ref_model.ComputeCurrentAmplitudesReference(31.7);
+
+  std::vector<double> ref_z;
+  ref_model.ComputeHeights(ref_z);
+
+  WaveSimulationFFT2Impl model(this->N, this->L);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(31.7);
+
+  std::vector<double> z;
+  model.ComputeHeights(z);
+
+  EXPECT_EQ(ref_z.size(), N2);
+  EXPECT_EQ(z.size(), N2);
+
+  for (int i=0; i<N2; ++i)
+  {
+    ASSERT_DOUBLE_EQ(z[i], ref_z[i]);
+  }
+}
+
+TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
+{
+  int N2 = this->N * this->N;
+
+  WaveSimulationFFT2Impl ref_model(this->N, this->L);
+  ref_model.ComputeBaseAmplitudesReference();
+  ref_model.ComputeCurrentAmplitudesReference(12.2);
+
+  std::vector<double> ref_sx, ref_sy;
+  ref_model.ComputeDisplacements(ref_sx, ref_sy);
+
+  WaveSimulationFFT2Impl model(this->N, this->L);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(12.2);
+
+  std::vector<double> sx, sy;
+  model.ComputeDisplacements(sx, sy);
+
+  EXPECT_EQ(ref_sx.size(), N2);
+  EXPECT_EQ(ref_sy.size(), N2);
+  EXPECT_EQ(sx.size(), N2);
+  EXPECT_EQ(sy.size(), N2);
+
+  for (int i=0; i<N2; ++i)
+  {
+    ASSERT_DOUBLE_EQ(sx[i], ref_sx[i]);
+    ASSERT_DOUBLE_EQ(sy[i], ref_sy[i]);
+  }
+}
+
+TEST_F(TestFixtureWaveSimulationFFT2, HeightDerivatives)
+{
+  int N2 = this->N * this->N;
+
+  WaveSimulationFFT2Impl ref_model(this->N, this->L);
+  ref_model.ComputeBaseAmplitudesReference();
+  ref_model.ComputeCurrentAmplitudesReference(12.2);
+
+  std::vector<double> ref_dhdx, ref_dhdy;
+  ref_model.ComputeHeightDerivatives(ref_dhdx, ref_dhdy);
+
+  WaveSimulationFFT2Impl model(this->N, this->L);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(12.2);
+
+  std::vector<double> dhdx, dhdy;
+  ref_model.ComputeHeightDerivatives(dhdx, dhdy);
+
+  EXPECT_EQ(ref_dhdx.size(), N2);
+  EXPECT_EQ(ref_dhdy.size(), N2);
+  EXPECT_EQ(dhdx.size(), N2);
+  EXPECT_EQ(dhdy.size(), N2);
+
+  for (int i=0; i<N2; ++i)
+  {
+    ASSERT_DOUBLE_EQ(dhdx[i], ref_dhdx[i]);
+    ASSERT_DOUBLE_EQ(dhdy[i], ref_dhdy[i]);
+  }
+}
+
+TEST_F(TestFixtureWaveSimulationFFT2, DisplacementDerivatives)
+{
+  int N2 = this->N * this->N;
+
+  WaveSimulationFFT2Impl ref_model(this->N, this->L);
+  ref_model.ComputeBaseAmplitudesReference();
+  ref_model.ComputeCurrentAmplitudesReference(12.2);
+
+  std::vector<double> ref_dsxdx, ref_dsydy, ref_dsxdy;
+  ref_model.ComputeDisplacementDerivatives(ref_dsxdx, ref_dsydy, ref_dsxdy);
+
+  WaveSimulationFFT2Impl model(this->N, this->L);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(12.2);
+
+  std::vector<double> dsxdx, dsydy, dsxdy;
+  ref_model.ComputeDisplacementDerivatives(dsxdx, dsydy, dsxdy);
+
+  EXPECT_EQ(ref_dsxdx.size(), N2);
+  EXPECT_EQ(ref_dsydy.size(), N2);
+  EXPECT_EQ(ref_dsxdy.size(), N2);
+  EXPECT_EQ(dsxdx.size(), N2);
+  EXPECT_EQ(dsydy.size(), N2);
+  EXPECT_EQ(dsxdy.size(), N2);
+
+  for (int i=0; i<N2; ++i)
+  {
+    ASSERT_DOUBLE_EQ(dsxdx[i], ref_dsxdx[i]);
+    ASSERT_DOUBLE_EQ(dsydy[i], ref_dsydy[i]);
+    ASSERT_DOUBLE_EQ(dsxdy[i], ref_dsxdy[i]);
+  }
+}
+
+/////////////////////////////////////////////////
 // check we're the indexing / stride rules used in the FFT routines
 TEST_F(TestFixtureWaveSimulationFFT2, Indexing)
 {
@@ -288,7 +592,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, Indexing)
 
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////
 // Run tests
 
 int main(int argc, char **argv)

--- a/ign-marine/src/WaveSimulationFFT2_TEST.cc
+++ b/ign-marine/src/WaveSimulationFFT2_TEST.cc
@@ -93,17 +93,17 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
   }
 }
 
-TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
 {
   WaveSimulationFFT2Impl model(this->N, this->L);
-  model.ComputeBaseAmplitudes();
-  model.ComputeCurrentAmplitudes(0.0);
+  model.ComputeBaseAmplitudesReference();
+  model.ComputeCurrentAmplitudesReference(0.0);
 
   for (int ikx=0; ikx<this->N; ++ikx)
   {
     for (int iky=0; iky<this->N; ++iky)
     {
-      // indexing for flattened array
+      // index for flattened array
       int idx = ikx * this->N + iky;
 
       // index for conjugate
@@ -131,17 +131,17 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
   }
 }
 
-TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
 {
   WaveSimulationFFT2Impl model(this->N, this->L);
-  model.ComputeBaseAmplitudes();
-  model.ComputeCurrentAmplitudes(11.2);
+  model.ComputeBaseAmplitudesReference();
+  model.ComputeCurrentAmplitudesReference(11.2);
 
   for (int ikx=0; ikx<this->N; ++ikx)
   {
     for (int iky=0; iky<this->N; ++iky)
     {
-      // indexing for flattened array
+      // index for flattened array
       int idx = ikx * this->N + iky;
 
       // index for conjugate
@@ -169,13 +169,13 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
   }
 }
 
-TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
 {
   int N2 = this->N * this->N;
 
   WaveSimulationFFT2Impl model(this->N, this->L);
-  model.ComputeBaseAmplitudes();
-  model.ComputeCurrentAmplitudes(0.0);
+  model.ComputeBaseAmplitudesReference();
+  model.ComputeCurrentAmplitudesReference(0.0);
 
   std::vector<double> z;
   model.ComputeHeights(z);
@@ -193,13 +193,13 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
   ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * N2);
 }
 
-TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
 {
   int N2 = this->N * this->N;
 
   WaveSimulationFFT2Impl model(this->N, this->L);
-  model.ComputeBaseAmplitudes();
-  model.ComputeCurrentAmplitudes(25.3);
+  model.ComputeBaseAmplitudesReference();
+  model.ComputeCurrentAmplitudesReference(25.3);
 
   std::vector<double> z;
   model.ComputeHeights(z);
@@ -217,7 +217,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
   ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * N2);
 }
 
-TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
+TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference)
 {
   int N2 = this->N * this->N;
 
@@ -225,8 +225,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
 
   // displacements should be zero when lamda = 0
   model.SetLambda(0.0);
-  model.ComputeBaseAmplitudes();
-  model.ComputeCurrentAmplitudes(10.0);
+  model.ComputeBaseAmplitudesReference();
+  model.ComputeCurrentAmplitudesReference(10.0);
 
   std::vector<double> sx, sy;
   model.ComputeDisplacements(sx, sy);
@@ -239,6 +239,53 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
     ASSERT_DOUBLE_EQ(sx[i], 0.0);
     ASSERT_DOUBLE_EQ(sy[i], 0.0);
   }
+}
+
+
+// check we're the indexing / stride rules used in the FFT routines
+TEST_F(TestFixtureWaveSimulationFFT2, Indexing)
+{
+  int Nx = 3;
+  int Ny = 4;
+
+  std::vector<std::vector<double>> a1(Nx, std::vector<double>(Ny, 0.0));
+  
+  for (int ikx = 0, idx = 0; ikx < Nx; ++ikx)
+  {
+    for (int iky = 0; iky < Ny; ++iky, ++idx)
+    {
+      a1[ikx][iky] = idx;
+    }
+  }
+
+  std::vector<std::vector<double>> a2 = {
+    { 0, 1, 2, 3},
+    { 4, 5, 6, 7},
+    { 8, 9, 10, 11}
+  };
+
+  std::vector<double> a3 = {
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+  };
+
+  EXPECT_EQ(a1.size(), Nx);
+  EXPECT_EQ(a1[0].size(), Ny);
+
+  EXPECT_EQ(a2.size(), Nx);
+  EXPECT_EQ(a2[0].size(), Ny);
+
+  EXPECT_EQ(a3.size(), Nx * Ny);
+
+  for (int ikx = 0; ikx < Nx; ++ikx)
+  {
+    for (int iky = 0; iky < Ny; ++iky)
+    {
+      int idx = ikx * Ny + iky;
+      EXPECT_EQ(a1[ikx][iky], a2[ikx][iky]);
+      EXPECT_EQ(a3[idx], a2[ikx][iky]);
+    }
+  }
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR has an initial round of optimisation of the FFT wave model and corrects the orientation of the vertex normals.


https://user-images.githubusercontent.com/24916364/167673521-6b61ae95-d18f-4c68-8e93-4695771fdb33.mov

## Details

- A number of redundant loops are removed
- The tangent space is calculated using the derivatives computed using FFT rather than finite difference
- The orientation of the normal vector is corrected (reversed in sign)
- Remove shadow casting from the world axes
- Add a test environment map for checking surface normals and tangent vectors
- Keep original unoptimised version as reference implementation
- Add tests that cross check optimised functions against the reference versions