### PR TITLE
Update dependencies for Gazebo Garden

### DIFF
--- a/ign-marine/CMakeLists.txt
+++ b/ign-marine/CMakeLists.txt
@@ -8,8 +8,8 @@ project(ignition-marine1 VERSION 1.0.0)
 #============================================================================
 # Find ignition-cmake
 #============================================================================
-find_package(ignition-cmake2 2.8.0 REQUIRED)
-set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
+find_package(ignition-cmake3 REQUIRED)
+set(IGN_CMAKE_VER ${ignition-cmake3_VERSION_MAJOR})
 
 #============================================================================
 # Configure the project
@@ -44,8 +44,8 @@ set(IGN_TRANSPORT_VER ${ignition-transport12_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-plugin
-ign_find_package(ignition-plugin1 REQUIRED COMPONENTS loader register)
-set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
+ign_find_package(ignition-plugin2 REQUIRED COMPONENTS loader register)
+set(IGN_PLUGIN_VER ${ignition-plugin2_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-rendering

--- a/ign-marine/src/systems/waves/WavesVisual.cc
+++ b/ign-marine/src/systems/waves/WavesVisual.cc
@@ -425,10 +425,9 @@ void WavesVisualPrivate::OnUpdate()
       nodes.pop_front();
       if (n && n->HasUserData("gazebo-entity"))
       {
-        // RenderUtil stores gazebo-entity user data as int
-        // \todo(anyone) Change this to uint64_t in Ignition H?
+        // RenderUtil stores gazebo-entity user data as uint64_t
         auto variant = n->UserData("gazebo-entity");
-        const int *value = std::get_if<int>(&variant);
+        const uint64_t *value = std::get_if<uint64_t>(&variant);
         if (value && *value == static_cast<int>(this->entity))
         {
           this->visual = std::dynamic_pointer_cast<rendering::Visual>(n);


### PR DESCRIPTION
This PR updates the dependencies of Gazebo Marine to use the current requirements for Gazebo Garden

The dependencies for [~Ignition~ Gazebo Garden](https://gazebosim.org/docs/garden)

