### PR TITLE
Add GUI plugin to control wave environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ign-marine/build
+ign-marine/src/gui/plugins/waves_control/build

--- a/ign-marine/include/ignition/marine/Wavefield.hh
+++ b/ign-marine/include/ignition/marine/Wavefield.hh
@@ -61,12 +61,6 @@ namespace marine
     /// \internal
     /// \brief Pointer to the class private data.
     private: std::shared_ptr<WavefieldPrivate> dataPtr;
-
-    // @TODO: relocate
-  #if 0
-    /// \todo(srmainwaring): port to ignition
-    void OnWaveWindMsg(ConstParam_VPtr &_msg);
-  #endif
   };
 
   typedef std::shared_ptr<Wavefield> WavefieldPtr;

--- a/ign-marine/include/ignition/marine/Wavefield.hh
+++ b/ign-marine/include/ignition/marine/Wavefield.hh
@@ -25,6 +25,7 @@
 #include <ignition/math.hh>
 
 #include <memory>
+#include <string>
 
 namespace ignition
 {
@@ -40,23 +41,23 @@ namespace marine
     public: virtual ~Wavefield();
 
     /// Constructor.
-    public: Wavefield();
+    public: Wavefield(const std::string &_worldName);
 
     // Compute the height at a point.
-    public: virtual bool Height(const cgal::Point3& point, double& height) const;
+    public: bool Height(const cgal::Point3& point, double& height) const;
 
     /// \brief Get the wave parameters.
-    public: virtual std::shared_ptr<const WaveParameters> GetParameters() const;
+    public: std::shared_ptr<const WaveParameters> GetParameters() const;
 
     /// \brief Set the wave parameters.
     ///
     /// \param[in] _params    The new wave parameters.
-    public: virtual void SetParameters(std::shared_ptr<WaveParameters> _params) const;
+    public: void SetParameters(std::shared_ptr<WaveParameters> _params);
 
     /// \brief Update (recalculate) the wave field for the given time.
     ///
     /// \param[in] _time    The time parameter for the wave evolution.
-    public: virtual void Update(double _time);
+    public: void Update(double _time);
 
     /// \internal
     /// \brief Pointer to the class private data.

--- a/ign-marine/include/ignition/marine/Wavefield.hh
+++ b/ign-marine/include/ignition/marine/Wavefield.hh
@@ -60,7 +60,7 @@ namespace marine
 
     /// \internal
     /// \brief Pointer to the class private data.
-    private: std::shared_ptr<WavefieldPrivate> data;
+    private: std::shared_ptr<WavefieldPrivate> dataPtr;
 
     // @TODO: relocate
   #if 0

--- a/ign-marine/src/CGAL_TEST.cc
+++ b/ign-marine/src/CGAL_TEST.cc
@@ -484,7 +484,7 @@ TEST(CGAL, SurfaceMeshWavefield) {
   params->SetPhase(0.0);
 
   // Wavefield
-  marine::Wavefield wavefield; 
+  marine::Wavefield wavefield("waves"); 
   wavefield.SetParameters(params);
 
   // Evolve to t=10 with 1000 updates

--- a/ign-marine/src/CMakeLists.txt
+++ b/ign-marine/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(gui)
 add_subdirectory(systems)
 
 # Collect source files into the "sources" variable and unit test files into the

--- a/ign-marine/src/Physics_TEST.cc
+++ b/ign-marine/src/Physics_TEST.cc
@@ -157,7 +157,7 @@ TEST(Hydrodynamics, BuoyancyUnitBox)
     *linkMesh);
 
   // Wavefield and water patch 2x2  
-  std::shared_ptr<const Wavefield> wavefield(new  Wavefield());
+  std::shared_ptr<const Wavefield> wavefield(new  Wavefield("waves"));
   std::shared_ptr<Grid> patch(
     new  Grid({ 2, 2 }, { 2, 2 }));
   std::shared_ptr<const WavefieldSampler> wavefieldSampler(
@@ -194,7 +194,7 @@ TEST(Hydrodynamics, Buoyancy10x4x2Box)
     *linkMesh);
 
   // Wavefield and water patch 4x4
-  std::shared_ptr<const Wavefield> wavefield(new  Wavefield());
+  std::shared_ptr<const Wavefield> wavefield(new  Wavefield("waves"));
   std::shared_ptr<Grid> patch(
     new  Grid({ 20, 20 }, { 4, 4 }));
   std::shared_ptr<const WavefieldSampler> wavefieldSampler(

--- a/ign-marine/src/WaveSimulationFFT2.cc
+++ b/ign-marine/src/WaveSimulationFFT2.cc
@@ -276,8 +276,8 @@ namespace marine
       {
         int ij = ikx * this->Ny + iky;
         int xy = iky * this->Nx + ikx;
-        _sy[xy] = mOut3[ij][0] * mLambda;
-        _sx[xy] = mOut4[ij][0] * mLambda;
+        _sy[xy] = mOut3[ij][0] * mLambda * -1.0;
+        _sx[xy] = mOut4[ij][0] * mLambda * -1.0;
       }
     }
   }
@@ -335,9 +335,9 @@ namespace marine
       {
         int ij = ikx * this->Ny + iky;
         int xy = iky * this->Nx + ikx;
-        _dsydy[xy] = mOut5[ij][0] * mLambda;
-        _dsxdx[xy] = mOut6[ij][0] * mLambda;
-        _dsxdy[xy] = mOut7[ij][0] * mLambda;
+        _dsydy[xy] = mOut5[ij][0] * mLambda * -1.0;
+        _dsxdx[xy] = mOut6[ij][0] * mLambda * -1.0;
+        _dsxdy[xy] = mOut7[ij][0] * mLambda *  1.0;
       }
     }
   }

--- a/ign-marine/src/Wavefield.cc
+++ b/ign-marine/src/Wavefield.cc
@@ -156,7 +156,7 @@ namespace marine
   {
     std::lock_guard<std::recursive_mutex> lock(this->mutex);
 
-    ignmsg << _msg.DebugString();
+    // ignmsg << _msg.DebugString();
 
     // current wind speed and angle
     double windSpeed = this->params->WindSpeed();

--- a/ign-marine/src/Wavefield.cc
+++ b/ign-marine/src/Wavefield.cc
@@ -39,7 +39,7 @@ namespace marine
   /// \brief Private data for the Wavefield.
   class WavefieldPrivate
   {
-    /// \brief Callback for topic "/model/<model>/waves".
+    /// \brief Callback for topic "/world/<world>/waves".
     ///
     /// \param[in] _msg Wave parameters message.
     public: void OnWaveMsg(const ignition::msgs::Param &_msg);
@@ -53,7 +53,7 @@ namespace marine
     /// \brief The current position of the wave field.
     public: std::unique_ptr<TriangulatedGrid> triangulatedGrid;
 
-  /// \brief Mutex to protect parameter updates.
+    /// \brief Mutex to protect parameter updates.
     public: std::recursive_mutex mutex;
 
     /// \brief Transport node
@@ -66,16 +66,13 @@ namespace marine
   }
 
   /////////////////////////////////////////////////
-  Wavefield::Wavefield() :
+  Wavefield::Wavefield(const std::string &_worldName) :
     dataPtr(new WavefieldPrivate())
   {
     ignmsg << "Constructing Wavefield..." <<  std::endl;
 
-    /// \todo: get the modelName
-    std::string modelName("waves");
-
     // Subscribe to wave parameter updates
-    std::string topic("/model/" + modelName + "/waves");
+    std::string topic("/world/" + _worldName + "/waves");
     this->dataPtr->node.Subscribe(
         topic, &WavefieldPrivate::OnWaveMsg, this->dataPtr.get());
 
@@ -118,7 +115,7 @@ namespace marine
   }
 
   /////////////////////////////////////////////////
-  void Wavefield::SetParameters(std::shared_ptr<WaveParameters> _params) const
+  void Wavefield::SetParameters(std::shared_ptr<WaveParameters> _params)
   {
     this->dataPtr->params = _params;
 

--- a/ign-marine/src/Wavefield.cc
+++ b/ign-marine/src/Wavefield.cc
@@ -48,30 +48,31 @@ namespace marine
     /// \brief The current position of the wave field.
     public: std::unique_ptr<TriangulatedGrid> triangulatedGrid;
 
-    /// \todo(srmainwaring): port to ignition
+  /// \brief Mutex to protect parameter updates.
     public: std::recursive_mutex mutex;
-    // public: ignition::transport::Node node;
-    // public: ignition::transport::SubscriberPtr waveWindSub;
+
+    /// \brief Transport node
+    public: transport::Node node;
   };
 
   /////////////////////////////////////////////////
   Wavefield::~Wavefield()
   {
-    /// \todo(srmainwaring): port to ignition
-    // this->data->waveWindSub.reset();
-    // this->data->node.reset();
   }
 
   /////////////////////////////////////////////////
   Wavefield::Wavefield() :
-    data(new WavefieldPrivate())
+    dataPtr(new WavefieldPrivate())
   {
     ignmsg << "Constructing Wavefield..." <<  std::endl;
 
-    /// \todo(srmainwaring): port to ignition
-    // this->data->node;
-    // this->data->waveWindSub = this->data->node.Subscribe(
-    //   "~/wave/wind", &Wavefield::OnWaveWindMsg, this);
+    /// \todo: get the modelName
+    std::string modelName("waves");
+
+    // Subscribe to wave parameter updates
+    std::string topic("/model/" + modelName + "/waves");
+    this->dataPtr->node.Subscribe(
+        topic, &WavesModelPrivate::OnWaveMsg, this->dataPtr.get());
 
     // Wave parameters
     ignmsg << "Creating WaveParameters." <<  std::endl;
@@ -88,7 +89,7 @@ namespace marine
   bool Wavefield::Height(const cgal::Point3& point, double& height) const
   {
     /// \todo(srmainwaring) the calculation assumes that the tile origin is at its center.
-    const double L = this->data->oceanTile->TileSize();
+    const double L = this->dataPtr->oceanTile->TileSize();
     const double LOver2 = L/2.0;
 
     auto pmod = [&](double x)
@@ -102,79 +103,123 @@ namespace marine
     // Obtain the point modulo the tile dimensions
     cgal::Point3 moduloPoint(pmod(point.x()), pmod(point.y()), point.z());
 
-    return this->data->triangulatedGrid->Height(moduloPoint, height);
+    return this->dataPtr->triangulatedGrid->Height(moduloPoint, height);
   }
 
   /////////////////////////////////////////////////
   std::shared_ptr<const WaveParameters> Wavefield::GetParameters() const
   {
-    return this->data->params;
+    return this->dataPtr->params;
   }
 
   /////////////////////////////////////////////////
   void Wavefield::SetParameters(std::shared_ptr<WaveParameters> _params) const
   {
-    this->data->params = _params;
+    this->dataPtr->params = _params;
 
     // Force an update of the ocean tile and point locator
-    size_t N = this->data->params->CellCount();
-    double L = this->data->params->TileSize();
-    double u = this->data->params->WindVelocity().X();
-    double v = this->data->params->WindVelocity().Y();
+    size_t N = this->dataPtr->params->CellCount();
+    double L = this->dataPtr->params->TileSize();
+    double u = this->dataPtr->params->WindVelocity().X();
+    double v = this->dataPtr->params->WindVelocity().Y();
 
     // OceanTile
     ignmsg << "Creating OceanTile." <<  std::endl;
-    this->data->oceanTile.reset(new physics::OceanTile(
-        this->data->params, false));
-    this->data->oceanTile->SetWindVelocity(u, v);
-    this->data->oceanTile->Create();
+    this->dataPtr->oceanTile.reset(new physics::OceanTile(
+        this->dataPtr->params, false));
+    this->dataPtr->oceanTile->SetWindVelocity(u, v);
+    this->dataPtr->oceanTile->Create();
 
     // Point Locator
     ignmsg << "Creating triangulated grid." <<  std::endl;
-    this->data->triangulatedGrid = std::move(TriangulatedGrid::Create(N, L));
+    this->dataPtr->triangulatedGrid = std::move(TriangulatedGrid::Create(N, L));
   }
 
   /////////////////////////////////////////////////
   void Wavefield::Update(double _time)
   {
-    std::lock_guard<std::recursive_mutex> lock(this->data->mutex);
+    std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
 
     // Update the tile.
-    this->data->oceanTile->Update(_time);
+    this->dataPtr->oceanTile->Update(_time);
 
     // Update the point locator.
-    auto& vertices = this->data->oceanTile->Vertices();
-    this->data->triangulatedGrid->UpdatePoints(vertices);
+    auto& vertices = this->dataPtr->oceanTile->Vertices();
+    this->dataPtr->triangulatedGrid->UpdatePoints(vertices);
   }
 
-#if 0
-  /// \todo(srmainwaring): port to ignition
-  void Wavefield::OnWaveWindMsg(ConstParam_VPtr &_msg)
+  //////////////////////////////////////////////////
+  void Wavefield::OnWaveMsg(const ignition::msgs::Param &_msg)
   {
-    std::lock_guard<std::recursive_mutex> lock(this->data->mutex);
+    std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
 
-    // Get parameters from message
-    double wind_angle = 0.0;
-    double wind_speed = 0.0;
-    wind_angle = Utilities::MsgParamDouble(*_msg, "wind_angle", wind_angle);
-    wind_speed = Utilities::MsgParamDouble(*_msg, "wind_speed", wind_speed);
+    ignmsg << _msg.DebugString();
 
-    // Convert from polar to cartesian
-    double wind_vel_x = wind_speed * std::cos(wind_angle);
-    double wind_vel_y = wind_speed * std::sin(wind_angle);
+    // current wind speed and angle
+    double windSpeed = this->waveParams->WindSpeed();
+    double windAngleRad = this->waveParams->WindAngleRad();
 
-    // @DEBUG_INFO
-    gzmsg << "Wavefield received message on topic ["
-      << this->data->waveWindSub->GetTopic() << "]" << std::endl;
-    gzmsg << "wind_angle: " << wind_angle << std::endl;
-    gzmsg << "wind_speed: " << wind_speed << std::endl;
-    gzmsg << "wind_vel_x: " << wind_vel_x << std::endl;
-    gzmsg << "wind_vel_y: " << wind_vel_y << std::endl;
+    // extract parameters
+    {
+      auto it = _msg.params().find("wind_speed");
+      if (it != _msg.params().end())
+      {
+        /// \todo: assert the type is double
+        auto param = it->second;
+        auto type = param.type();
+        auto value = param.double_value();
+        windSpeed = value;
+      }
+    }
+    {
+      auto it = _msg.params().find("wind_angle");
+      if (it != _msg.params().end())
+      {
+        /// \todo: assert the type is double
+        auto param = it->second;
+        auto type = param.type();
+        auto value = param.double_value();
+        windAngleRad = M_PI/180.0*value;
+      }
+    }
 
-    // Update simulation
-    this->data->oceanTile->SetWindVelocity(wind_vel_x, wind_vel_y);
+    /// \todo: update params correctly - put logic in one place
+    // update wind velocity
+    double ux = windSpeed * cos(windAngleRad);
+    double uy = windSpeed * sin(windAngleRad);
+    
+    // update parameters and wavefield
+    this->dataPtr->params->SetWindVelocity(math::Vector2d(ux, uy));
+    this->dataPtr->oceanTile->SetWindVelocity(wind_vel_x, wind_vel_y);
   }
-#endif
+
+  /////////////////////////////////////////////////
+  // void Wavefield::OnWaveWindMsg(ConstParam_VPtr &_msg)
+  // {
+  //   std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
+
+  //   // Get parameters from message
+  //   double wind_angle = 0.0;
+  //   double wind_speed = 0.0;
+  //   wind_angle = Utilities::MsgParamDouble(*_msg, "wind_angle", wind_angle);
+  //   wind_speed = Utilities::MsgParamDouble(*_msg, "wind_speed", wind_speed);
+
+  //   // Convert from polar to cartesian
+  //   double wind_vel_x = wind_speed * std::cos(wind_angle);
+  //   double wind_vel_y = wind_speed * std::sin(wind_angle);
+
+  //   // @DEBUG_INFO
+  //   gzmsg << "Wavefield received message on topic ["
+  //     << this->dataPtr->waveWindSub->GetTopic() << "]" << std::endl;
+  //   gzmsg << "wind_angle: " << wind_angle << std::endl;
+  //   gzmsg << "wind_speed: " << wind_speed << std::endl;
+  //   gzmsg << "wind_vel_x: " << wind_vel_x << std::endl;
+  //   gzmsg << "wind_vel_y: " << wind_vel_y << std::endl;
+
+  //   // Update simulation
+  //   this->dataPtr->oceanTile->SetWindVelocity(wind_vel_x, wind_vel_y);
+  // }
+
   /////////////////////////////////////////////////
 
 }

--- a/ign-marine/src/gui/CMakeLists.txt
+++ b/ign-marine/src/gui/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(plugins)

--- a/ign-marine/src/gui/plugins/CMakeLists.txt
+++ b/ign-marine/src/gui/plugins/CMakeLists.txt
@@ -1,0 +1,1 @@
+# add_subdirectory(waves_control)

--- a/ign-marine/src/gui/plugins/waves_control/CMakeLists.txt
+++ b/ign-marine/src/gui/plugins/waves_control/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+
+if(POLICY CMP0100)
+  cmake_policy(SET CMP0100 NEW)
+endif()
+
+project(WavesControl)
+
+set(CMAKE_AUTOMOC ON)
+
+find_package(ignition-gazebo7 REQUIRED COMPONENTS gui)
+
+QT5_ADD_RESOURCES(resources_RCC ${PROJECT_NAME}.qrc)
+
+add_library(${PROJECT_NAME} SHARED
+  ${PROJECT_NAME}.cc
+  ${resources_RCC}
+)
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE ignition-gazebo7::gui
+)

--- a/ign-marine/src/gui/plugins/waves_control/README.md
+++ b/ign-marine/src/gui/plugins/waves_control/README.md
@@ -1,0 +1,41 @@
+# GUI system plugin
+
+This example shows how to create a GUI system plugin.
+
+Ignition Gazebo supports any kind of Ignition GUI plugin
+(`ignition::gui::Plugin`). Gazebo GUI plugins are a special type of Ignition
+GUI plugin which also have access to entity and component updates coming from
+the server.
+
+See `WavesControl.hh` for more information.
+
+## Build
+
+From the root of the `ign-gazebo` repository, do the following to build the example:
+
+~~~
+cd examples/plugin/waves_control
+mkdir build
+cd build
+cmake ..
+make
+~~~
+
+This will generate the `WavesControl` library under `build`.
+
+## Run
+
+Add the library to the path:
+
+~~~
+cd src/asv_wave_sim/ign-marine/src/gui/plugin/waves_control
+export IGN_GUI_PLUGIN_PATH=`pwd`/build
+~~~
+
+Then run a world, for example:
+
+    ign gazebo -v4 waves.sdf
+
+From the GUI plugin menu on the top-right, choose "Waves Control".
+
+You'll see your plugin, displaying the world name `waves`.

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.cc
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.cc
@@ -31,6 +31,24 @@ inline namespace IGNITION_MARINE_VERSION_NAMESPACE
   /// \brief Private data class for WavesControl
   class WavesControlPrivate
   {
+    /// \brief Current state of the water patch checkbox
+    public: bool waterPatchCheckboxState{false};
+
+    /// \brief Previous state of the water patch checkbox
+    public: bool waterPatchCheckboxPrevState{false};
+
+    /// \brief Current state of the waterline checkbox
+    public: bool waterlineCheckboxState{false};
+
+    /// \brief Previous state of the waterline checkbox
+    public: bool waterlineCheckboxPrevState{false};
+
+    /// \brief Current state of the submerged triangle checkbox
+    public: bool submergedTriangleCheckboxState{false};
+
+    /// \brief Previous state of the submerged triangle checkbox
+    public: bool submergedTriangleCheckboxPrevState{false};
+
     /// \brief Wind speed
     public: double windSpeed{5.0};
 
@@ -71,6 +89,74 @@ void WavesControl::LoadConfig(const tinyxml2::XMLElement * /*_pluginElem*/)
 void WavesControl::Update(const ignition::gazebo::UpdateInfo & /*_info*/,
     ignition::gazebo::EntityComponentManager &_ecm)
 {
+
+  {
+    std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+
+    // water patch markers
+    if (this->dataPtr->waterPatchCheckboxPrevState &&
+        !this->dataPtr->waterPatchCheckboxState)
+    {
+      // Remove the markers
+      // this->dataPtr->positionMarkerMsg.set_action(
+      //   ignition::msgs::Marker::DELETE_ALL);
+
+      ignmsg << "Removing water patch markers...\n";
+      // this->dataPtr->node.Request(
+      //   "/marker", this->dataPtr->positionMarkerMsg);
+
+      // Change action in case checkbox is checked again
+      // this->dataPtr->positionMarkerMsg.set_action(
+      //   ignition::msgs::Marker::ADD_MODIFY);
+    }
+
+    this->dataPtr->waterPatchCheckboxPrevState =
+        this->dataPtr->waterPatchCheckboxState;
+    
+    // if (!this->dataPtr->waterPatchCheckboxState)
+    //   return;
+
+    // waterline markers
+    if (this->dataPtr->waterlineCheckboxPrevState &&
+        !this->dataPtr->waterlineCheckboxState)
+    {
+      ignmsg << "Removing waterline markers...\n";
+    }
+
+    this->dataPtr->waterlineCheckboxPrevState =
+        this->dataPtr->waterlineCheckboxState;
+
+    // submerged triangle markers
+    if (this->dataPtr->submergedTriangleCheckboxPrevState &&
+        !this->dataPtr->submergedTriangleCheckboxState)
+    {
+      ignmsg << "Removing submerged triangle markers...\n";
+    }
+
+    this->dataPtr->submergedTriangleCheckboxPrevState =
+        this->dataPtr->submergedTriangleCheckboxState;
+  }
+}
+
+//////////////////////////////////////////////////
+void WavesControl::OnShowWaterPatchMarkers(bool _checked)
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+  this->dataPtr->waterPatchCheckboxState = _checked;
+}
+
+//////////////////////////////////////////////////
+void WavesControl::OnShowWaterlineMarkers(bool _checked)
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+  this->dataPtr->waterlineCheckboxState = _checked;
+}
+
+//////////////////////////////////////////////////
+void WavesControl::OnShowSubmergedTriangleMarkers(bool _checked)
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+  this->dataPtr->submergedTriangleCheckboxState = _checked;
 }
 
 //////////////////////////////////////////////////

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.cc
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.cc
@@ -28,6 +28,7 @@
 #include <ignition/gazebo/EntityComponentManager.hh>
 #include <ignition/gazebo/gui/GuiEvents.hh>
 
+#include <string>
 
 namespace ignition
 {
@@ -130,8 +131,11 @@ void WavesControl::LoadConfig(const tinyxml2::XMLElement * /*_pluginElem*/)
     this->title = "Waves Control";
   }
 
+  /// \todo: lookup model name
+  std::string modelName("waves");
+
   // Initialise the publisher
-  std::string topic("/model/waves");
+  std::string topic("/model/" + modelName + "/waves");
   this->dataPtr->pub = this->dataPtr->node.Advertise<ignition::msgs::Param>(topic);
   if (!this->dataPtr->pub)
   {

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.cc
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.cc
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <ignition/plugin/Register.hh>
+#include <ignition/gazebo/components/Name.hh>
+#include <ignition/gazebo/components/World.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/gui/GuiEvents.hh>
+
+#include "WavesControl.hh"
+
+/////////////////////////////////////////////////
+WavesControl::WavesControl() = default;
+
+/////////////////////////////////////////////////
+WavesControl::~WavesControl() = default;
+
+/////////////////////////////////////////////////
+void WavesControl::LoadConfig(const tinyxml2::XMLElement * /*_pluginElem*/)
+{
+  if (this->title.empty())
+    this->title = "Waves Control";
+
+  // Here you can read configuration from _pluginElem, if it's not null.
+}
+
+//////////////////////////////////////////////////
+void WavesControl::Update(const ignition::gazebo::UpdateInfo & /*_info*/,
+    ignition::gazebo::EntityComponentManager &_ecm)
+{
+  // In the update loop, you can for example get the name of the world and set
+  // it as a property that can be read from the QML.
+  _ecm.Each<ignition::gazebo::components::Name,
+            ignition::gazebo::components::World>(
+    [&](const ignition::gazebo::Entity &_entity,
+        const ignition::gazebo::components::Name *_name,
+        const ignition::gazebo::components::World *)->bool
+  {
+    this->SetCustomProperty(QString::fromStdString(_name->Data()));
+    return true;
+  });
+}
+
+/////////////////////////////////////////////////
+QString WavesControl::CustomProperty() const
+{
+  return this->customProperty;
+}
+
+/////////////////////////////////////////////////
+void WavesControl::SetCustomProperty(const QString &_customProperty)
+{
+  this->customProperty = _customProperty;
+  this->CustomPropertyChanged();
+}
+
+// Register this plugin
+IGNITION_ADD_PLUGIN(WavesControl,
+                    ignition::gui::Plugin)

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.hh
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.hh
@@ -49,6 +49,18 @@ inline namespace IGNITION_MARINE_VERSION_NAMESPACE
     public: void Update(const ignition::gazebo::UpdateInfo &_info,
         ignition::gazebo::EntityComponentManager &_ecm) override;
 
+    /// \brief Callback when water patch marker checkbox state is changed
+    /// \param[in] _checked indicates show or hide contacts
+    public slots: void OnShowWaterPatchMarkers(bool _checked);
+
+    /// \brief Callback when waterline marker checkbox state is changed
+    /// \param[in] _checked indicates show or hide contacts
+    public slots: void OnShowWaterlineMarkers(bool _checked);
+
+    /// \brief Callback when submerged triangle marker checkbox state is changed
+    /// \param[in] _checked indicates show or hide contacts
+    public slots: void OnShowSubmergedTriangleMarkers(bool _checked);
+
     /// \brief Update the wind speed
     /// \param[in] _windSpeed new wind speed
     public slots: void UpdateWindSpeed(double _windSpeed);

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.hh
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.hh
@@ -1,80 +1,69 @@
-/*
- * Copyright (C) 2020 Open Source Robotics Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
-*/
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef IGNITION_GAZEBO_WAVESCONTROL_HH_
-#define IGNITION_GAZEBO_WAVESCONTROL_HH_
+#ifndef IGNITION_MARINE_WAVESCONTROL_HH_
+#define IGNITION_MARINE_WAVESCONTROL_HH_
 
+#include <ignition/gui/qt.h>
 #include <ignition/gazebo/gui/GuiSystem.hh>
 
-/// \brief Example of a GUI plugin that has access to entities and components.
-class WavesControl : public ignition::gazebo::GuiSystem
+#include <memory>
+
+namespace ignition
 {
-  Q_OBJECT
+namespace gazebo
+{
 
-    /// \brief Custom property. Use this to create properties that can be read
-    /// from the QML file. See the declarations below.
-    Q_PROPERTY(
-      QString customProperty
-      READ CustomProperty
-      WRITE SetCustomProperty
-      NOTIFY CustomPropertyChanged
-    )
+// Inline bracket to help doxygen filtering.
+inline namespace IGNITION_MARINE_VERSION_NAMESPACE
+{
+  class WavesControlPrivate;
 
-  /// \brief Constructor
-  public: WavesControl();
+  /// \brief Edit parameters controlling the waves systems plugins.
+  class WavesControl : public ignition::gazebo::GuiSystem
+  {
+    Q_OBJECT
 
-  /// \brief Destructor
-  public: ~WavesControl() override;
+    /// \brief Constructor
+    public: WavesControl();
 
-  /// \brief `ignition::gui::Plugin`s can overload this function to
-  /// receive custom configuration from an XML file. Here, it comes from the
-  /// SDF.
-  ///
-  /// <gui>
-  ///   <plugin ...> <!-- this is the plugin element -->
-  ///     ...
-  ///   </plugin>
-  /// </gui>
-  ///
-  /// \param[in] _pluginElem SDF <plugin> element. Will be null if the plugin
-  /// is loaded without any XML configuration.
-  public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
+    /// \brief Destructor
+    public: ~WavesControl() override;
 
-  /// \brief GUI systems can overload this function to receive updated simulation
-  /// state. This is called whenever the server sends state updates to the GUI.
-  /// \param[in] _info Simulation information such as time.
-  /// \param[in] _ecm Entity component manager, which can be used to get the
-  /// latest information about entities and components.
-  public: void Update(const ignition::gazebo::UpdateInfo &_info,
-      ignition::gazebo::EntityComponentManager &_ecm) override;
+    // Documentation inherited
+    public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
-  /// \brief Get the custom property as a string.
-  /// \return Custom property
-  public: Q_INVOKABLE QString CustomProperty() const;
+    // Documentation inherited
+    public: void Update(const ignition::gazebo::UpdateInfo &_info,
+        ignition::gazebo::EntityComponentManager &_ecm) override;
 
-  /// \brief Set the custom property from a string.
-  /// \param[in] _customProperty Custom property
-  public: Q_INVOKABLE void SetCustomProperty(const QString &_customProperty);
+    /// \brief Update the wind speed
+    /// \param[in] _windSpeed new wind speed
+    public slots: void UpdateWindSpeed(double _windSpeed);
 
-  /// \brief Notify that custom property has changed
-  signals: void CustomPropertyChanged();
+    /// \brief Update the wind angle
+    /// \param[in] _windAngle new wind angle
+    public slots: void UpdateWindAngle(double _windAngle);
 
-  /// \brief Custom property
-  private: QString customProperty;
-};
+    /// \internal
+    /// \brief Pointer to private data
+    private: std::unique_ptr<WavesControlPrivate> dataPtr;
+  };
+
+}
+}
+}
 
 #endif

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.hh
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.hh
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef IGNITION_GAZEBO_WAVESCONTROL_HH_
+#define IGNITION_GAZEBO_WAVESCONTROL_HH_
+
+#include <ignition/gazebo/gui/GuiSystem.hh>
+
+/// \brief Example of a GUI plugin that has access to entities and components.
+class WavesControl : public ignition::gazebo::GuiSystem
+{
+  Q_OBJECT
+
+    /// \brief Custom property. Use this to create properties that can be read
+    /// from the QML file. See the declarations below.
+    Q_PROPERTY(
+      QString customProperty
+      READ CustomProperty
+      WRITE SetCustomProperty
+      NOTIFY CustomPropertyChanged
+    )
+
+  /// \brief Constructor
+  public: WavesControl();
+
+  /// \brief Destructor
+  public: ~WavesControl() override;
+
+  /// \brief `ignition::gui::Plugin`s can overload this function to
+  /// receive custom configuration from an XML file. Here, it comes from the
+  /// SDF.
+  ///
+  /// <gui>
+  ///   <plugin ...> <!-- this is the plugin element -->
+  ///     ...
+  ///   </plugin>
+  /// </gui>
+  ///
+  /// \param[in] _pluginElem SDF <plugin> element. Will be null if the plugin
+  /// is loaded without any XML configuration.
+  public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
+
+  /// \brief GUI systems can overload this function to receive updated simulation
+  /// state. This is called whenever the server sends state updates to the GUI.
+  /// \param[in] _info Simulation information such as time.
+  /// \param[in] _ecm Entity component manager, which can be used to get the
+  /// latest information about entities and components.
+  public: void Update(const ignition::gazebo::UpdateInfo &_info,
+      ignition::gazebo::EntityComponentManager &_ecm) override;
+
+  /// \brief Get the custom property as a string.
+  /// \return Custom property
+  public: Q_INVOKABLE QString CustomProperty() const;
+
+  /// \brief Set the custom property from a string.
+  /// \param[in] _customProperty Custom property
+  public: Q_INVOKABLE void SetCustomProperty(const QString &_customProperty);
+
+  /// \brief Notify that custom property has changed
+  signals: void CustomPropertyChanged();
+
+  /// \brief Custom property
+  private: QString customProperty;
+};
+
+#endif

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
@@ -40,9 +40,9 @@ GridLayout {
     Layout.columnSpan: 4
     text: qsTr("Show water patch markers")
     checked: false
-    // onClicked: {
-    //   WavesControl.OnShowWaterPatchMarkers(checked)
-    // }
+    onClicked: {
+      WavesControl.OnShowWaterPatchMarkers(checked)
+    }
   }
 
   // Right spacer
@@ -58,9 +58,9 @@ GridLayout {
     Layout.columnSpan: 4
     text: qsTr("Show waterline markers")
     checked: false
-    // onClicked: {
-    //   WavesControl.OnShowWaterlineMarkers(checked)
-    // }
+    onClicked: {
+      WavesControl.OnShowWaterlineMarkers(checked)
+    }
   }
 
   CheckBox {
@@ -69,9 +69,9 @@ GridLayout {
     Layout.columnSpan: 4
     text: qsTr("Show submerged triangle markers")
     checked: false
-    // onClicked: {
-    //   WavesControl.OnShowSubmergedTriangleMarkers(checked)
-    // }
+    onClicked: {
+      WavesControl.OnShowSubmergedTriangleMarkers(checked)
+    }
   }
 
   // wind speed

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
@@ -21,8 +21,8 @@ import "qrc:/qml"
 GridLayout {
   columns: 6
   columnSpacing: 10
-  Layout.minimumWidth: 250
-  Layout.minimumHeight: 400
+  Layout.minimumWidth: 300
+  Layout.minimumHeight: 350
   anchors.fill: parent
   anchors.leftMargin: 10
   anchors.rightMargin: 10

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
@@ -108,7 +108,7 @@ GridLayout {
     id: windAngle
     maximumValue: 180
     minimumValue: -180
-    value: 0
+    value: 135
     decimals: 0
     stepSize: 10
     onEditingFinished: WavesControl.UpdateWindAngle(windAngle.value)

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
@@ -1,24 +1,122 @@
-/*
- * Copyright (C) 2020 Open Source Robotics Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
-*/
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+import "qrc:/qml"
 
-// Display custom property text
-Text {
-  width: 300
-  text: WavesControl.customProperty
+GridLayout {
+  columns: 6
+  columnSpacing: 10
+  Layout.minimumWidth: 250
+  Layout.minimumHeight: 400
+  anchors.fill: parent
+  anchors.leftMargin: 10
+  anchors.rightMargin: 10
+
+  // Left spacer
+  Item {
+    Layout.columnSpan: 1
+    Layout.rowSpan: 15
+    Layout.fillWidth: true
+  }
+
+  CheckBox {
+    Layout.alignment: Qt.AlignLeft
+    id: showWaterPatchMarkers
+    Layout.columnSpan: 4
+    text: qsTr("Show water patch markers")
+    checked: false
+    // onClicked: {
+    //   WavesControl.OnShowWaterPatchMarkers(checked)
+    // }
+  }
+
+  // Right spacer
+  Item {
+    Layout.columnSpan: 1
+    Layout.rowSpan: 15
+    Layout.fillWidth: true
+  }
+
+  CheckBox {
+    Layout.alignment: Qt.AlignLeft
+    id: showWaterlineMarkers
+    Layout.columnSpan: 4
+    text: qsTr("Show waterline markers")
+    checked: false
+    // onClicked: {
+    //   WavesControl.OnShowWaterlineMarkers(checked)
+    // }
+  }
+
+  CheckBox {
+    Layout.alignment: Qt.AlignLeft
+    id: showSubmergedTriangleMarkers
+    Layout.columnSpan: 4
+    text: qsTr("Show submerged triangle markers")
+    checked: false
+    // onClicked: {
+    //   WavesControl.OnShowSubmergedTriangleMarkers(checked)
+    // }
+  }
+
+  // wind speed
+  Text {
+    Layout.columnSpan: 2
+    id: windSpeedText
+    color: "dimgrey"
+    text: "Wind speed (m/s)"
+  }
+
+  IgnSpinBox {
+    Layout.columnSpan: 2
+    Layout.fillWidth: true
+    id: windSpeed
+    maximumValue: 100.0
+    minimumValue: 0.5
+    value: 5.0
+    decimals: 1
+    stepSize: 0.5
+    onEditingFinished: WavesControl.UpdateWindSpeed(windSpeed.value)
+  }
+
+  // wind angle
+  Text {
+    Layout.columnSpan: 2
+    id: windAngleText
+    color: "dimgrey"
+    text: "Wind angle (deg)"
+  }
+
+  IgnSpinBox {
+    Layout.columnSpan: 2
+    Layout.fillWidth: true
+    id: windAngle
+    maximumValue: 180
+    minimumValue: -180
+    value: 0
+    decimals: 0
+    stepSize: 10
+    onEditingFinished: WavesControl.UpdateWindAngle(windAngle.value)
+  }
+
+  // Bottom spacer
+  Item {
+    Layout.columnSpan: 4
+    Layout.fillHeight: true
+  }
 }

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.qml
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+
+// Display custom property text
+Text {
+  width: 300
+  text: WavesControl.customProperty
+}

--- a/ign-marine/src/gui/plugins/waves_control/WavesControl.qrc
+++ b/ign-marine/src/gui/plugins/waves_control/WavesControl.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="WavesControl/">
+  <file>WavesControl.qml</file>
+</qresource>
+</RCC>

--- a/ign-marine/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/ign-marine/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -713,7 +713,7 @@ void HydrodynamicsPrivate::Init(EntityComponentManager &_ecm)
 bool HydrodynamicsPrivate::InitWavefield(EntityComponentManager &_ecm)
 {
   /// \todo - remove hardcoded name
-  // Retrieve the wavefield entiry using the Name component
+  // Retrieve the wavefield entity using the Name component
   std::string entityName = "wavefield";
   this->wavefieldEntity = _ecm.EntityByComponents(components::Name(entityName));
   // this->wavefieldEntity = _ecm.EntityByComponents(marine::components::Wavefield());

--- a/ign-marine/src/systems/waves/WavesModel.cc
+++ b/ign-marine/src/systems/waves/WavesModel.cc
@@ -25,6 +25,7 @@
 #include <ignition/plugin/Register.hh>
 
 #include <ignition/gazebo/components/Name.hh>
+#include <ignition/gazebo/components/World.hh>
 
 #include <ignition/gazebo/Model.hh>
 #include <ignition/gazebo/Util.hh>
@@ -167,6 +168,18 @@ WavesModelPrivate::~WavesModelPrivate()
 /////////////////////////////////////////////////
 void WavesModelPrivate::Load(EntityComponentManager &_ecm)
 {
+  // World name
+  std::string worldName;
+  _ecm.Each<components::World, components::Name>(
+    [&](const Entity &,
+        const components::World *,
+        const components::Name *_name) -> bool
+    {
+      // Assume there's only one world
+      worldName = _name->Data();
+      return false;
+    });
+
   // Update parameters
   this->isStatic = marine::Utilities::SdfParamBool(
       *this->sdf,  "static", this->isStatic);
@@ -185,7 +198,7 @@ void WavesModelPrivate::Load(EntityComponentManager &_ecm)
   // Wavefield
   std::string entityName = "wavefield";
 
-  this->wavefield.reset(new marine::Wavefield());
+  this->wavefield.reset(new marine::Wavefield(worldName));
   this->wavefield->SetParameters(this->waveParams);
 
   // Create a new entity and register a wavefield component with it.

--- a/ign-marine/src/systems/waves/WavesModel.cc
+++ b/ign-marine/src/systems/waves/WavesModel.cc
@@ -22,20 +22,12 @@
 #include "ignition/marine/components/Wavefield.hh"
 
 #include <ignition/common/Profiler.hh>
-
-#include <ignition/msgs/any.pb.h>
-#include <ignition/msgs/param.pb.h>
-#include <ignition/msgs/param_v.pb.h>
-
 #include <ignition/plugin/Register.hh>
-
-#include <ignition/transport/Node.hh>
 
 #include <ignition/gazebo/components/Name.hh>
 
 #include <ignition/gazebo/Model.hh>
 #include <ignition/gazebo/Util.hh>
-
 
 #include <sdf/Element.hh>
 
@@ -68,11 +60,6 @@ class ignition::gazebo::systems::WavesModelPrivate
   public: void UpdateWaves(const UpdateInfo &_info,
                     EntityComponentManager &_ecm);
 
-  /// \brief Callback for topic "/model/<model>/waves".
-  ///
-  /// \param[in] _msg Wave parameters message.
-  public: void OnWaveMsg(const ignition::msgs::Param &_msg);
-
   /// \brief Model interface
   public: Model model{kNullEntity};
 
@@ -103,12 +90,6 @@ class ignition::gazebo::systems::WavesModelPrivate
 
   /// \brief Previous update time.
   public: double lastUpdateTime{0};
-
-  /// \brief Mutex to protect parameter updates.
-  public: std::mutex mutex;
-
-  /// \brief Transport node
-  public: transport::Node node;
 };
 
 /////////////////////////////////////////////////
@@ -140,14 +121,6 @@ void WavesModel::Configure(const Entity &_entity,
     return;
   }
   this->dataPtr->sdf = _sdf->Clone();
-
-  /// \todo: get the modelName
-  std::string modelName("waves");
-
-  // Subscribe to wave parameter updates
-  std::string topic("/model/" + modelName + "/waves");
-  this->dataPtr->node.Subscribe(
-      topic, &WavesModelPrivate::OnWaveMsg, this->dataPtr.get());
 }
 
 //////////////////////////////////////////////////
@@ -156,6 +129,9 @@ void WavesModel::PreUpdate(
   EntityComponentManager &_ecm)
 {
   IGN_PROFILE("WavesModel::PreUpdate");
+
+  // std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+  // this->dataPtr->currentSimTime = _info.simTime;
 
   /// \todo(anyone) support reset / rewind
   if (_info.dt < std::chrono::steady_clock::duration::zero())
@@ -245,8 +221,6 @@ void WavesModelPrivate::Load(EntityComponentManager &_ecm)
 void WavesModelPrivate::UpdateWaves(const UpdateInfo &_info,
     EntityComponentManager &_ecm)
 {
-  std::lock_guard<std::mutex> lock(this->mutex);
-
   if (!this->isStatic)
   {  
     // Throttle update [30 FPS by default]
@@ -258,51 +232,6 @@ void WavesModelPrivate::UpdateWaves(const UpdateInfo &_info,
       this->lastUpdateTime = simTime;
     }
   }
-}
-
-//////////////////////////////////////////////////
-void WavesModelPrivate::OnWaveMsg(const ignition::msgs::Param &_msg)
-{
-  std::lock_guard<std::mutex> lock(this->mutex);
-
-  ignmsg << _msg.DebugString();
-
-  // current wind speed and angle
-  double windSpeed = this->waveParams->WindSpeed();
-  double windAngleRad = this->waveParams->WindAngleRad();
-
-  // extract parameters
-  {
-    auto it = _msg.params().find("wind_speed");
-    if (it != _msg.params().end())
-    {
-      /// \todo: assert the type is double
-      auto param = it->second;
-      auto type = param.type();
-      auto value = param.double_value();
-      windSpeed = value;
-    }
-  }
-  {
-    auto it = _msg.params().find("wind_angle");
-    if (it != _msg.params().end())
-    {
-      /// \todo: assert the type is double
-      auto param = it->second;
-      auto type = param.type();
-      auto value = param.double_value();
-      windAngleRad = M_PI/180.0*value;
-    }
-  }
-
-  /// \todo: update params correctly - put logic in one place
-  // update wind velocity
-  double ux = windSpeed * cos(windAngleRad);
-  double uy = windSpeed * sin(windAngleRad);
-  
-  // update parameters and wavefield
-  this->waveParams->SetWindVelocity(math::Vector2d(ux, uy));
-  this->wavefield->SetParameters(this->waveParams);
 }
 
 //////////////////////////////////////////////////

--- a/ign-marine/src/systems/waves/WavesVisual.cc
+++ b/ign-marine/src/systems/waves/WavesVisual.cc
@@ -711,7 +711,7 @@ void WavesVisualPrivate::OnWaveMsg(const ignition::msgs::Param &_msg)
 {
   std::lock_guard<std::mutex> lock(this->mutex);
 
-  ignmsg << _msg.DebugString();
+  // ignmsg << _msg.DebugString();
 
   // current wind speed and angle
   double windSpeed = this->waveParams->WindSpeed();

--- a/ign-marine/src/systems/waves/WavesVisual.cc
+++ b/ign-marine/src/systems/waves/WavesVisual.cc
@@ -297,7 +297,7 @@ class ignition::gazebo::systems::WavesVisualPrivate
   /// \brief Used in DynamicMesh example
   public: common::MeshPtr oceanTileMesh;
 
-  /// \brief Mutex to protect sim time updates.
+  /// \brief Mutex to protect sim time and parameter updates.
   public: std::mutex mutex;
 
   /// \brief Transport node
@@ -691,7 +691,6 @@ void WavesVisualPrivate::OnUpdate()
     }
   }
 }
-
 
 //////////////////////////////////////////////////
 void WavesVisualPrivate::OnWaveMsg(const ignition::msgs::Param &_msg)


### PR DESCRIPTION
This PR adds a GUI plugin to control the wave environment. This version allows the wind speed and wind angle parameters for the ECKV cosine-2S spectrum to be adjusted at run time.

There are placeholders for toggling the waterline, water patch and submerged triangle marker visuals, but they are not activated in this PR.

Closes #30

## Usage

Build:

```bash
$ cd ~/ign_ws/src/asv_wave_sim/ign-marine/src/gui/plugins/waves_control
$ mkdir build && cd build
$ cmake ..
$ make
```

Configure:

```bash
$ cd ~/ign_ws/src/asv_wave_sim/ign-marine/src/gui/plugins/waves_control/build
$ export IGN_GUI_PLUGIN_PATH=$IGN_GUI_PLUGIN_PATH:$(pwd)
```

Run:

From the sidebar menu select `Waves Control`
