### PR TITLE
Add steepness field to GUI plugin

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,7 +1,7 @@
 
-# Ignition Migration
+# Gazebo Garden Migration
 
-Notes concerning the migration to Ignition
+Notes concerning the migration from Gazebo Classic to Gazebo Garden
 
 System:
 - macOS Big Sur 11.6.2
@@ -9,19 +9,21 @@ System:
 
 ## Branches
 
-| feature | base | description |
+| branch | base | description |
 | --- | --- | --- |
-| fft_waves | master| Legacy Gazebo11 version. Includes FFT wave generator, tiling, dynamic reconfigure (ROS). Shader uses InverseTransposeModel matrix to map TBNs |
-| gazebo11 | master | legacy Gazebo11 version. Includes early version of FFT wave generator |
-| havyard-842 | feature/ign-garden-wip | Add ship model (Havyard 842 tug) |
-| ign-garden-dyn-geom | master | Replicate Ogre dynamic geometry sample in Ignition |
-| ign-garden-wip | master | Main port to Ignition |
-| ign-garden-wip | ign-garden-wip-shaders | Experiments with custom shaders |
+| demo/ship-landing | ign-marine | ArduPilot ship landing demo |
+| demo/ship-landing-v2 | ign-marine | ArduPilot ship landing demo version 2 |
+| feature/fft_waves | master| Legacy Gazebo11 version. Includes FFT wave generator, tiling, dynamic reconfigure (ROS) |
+| feature/gazebo11 | master | legacy Gazebo11 version. Includes early version of FFT wave generator |
+| feature/ign-garden-dyn-geom | master | Replicate Ogre dynamic geometry sample in Ignition |
+| feature/ign-marine-shaders-wip | master | Experiments with custom shaders |
+| gz-marine | master | Main port from Gazebo Classic to Gazebo Garden |
+| ign-marine | master | Main port from Gazebo Classic to Ignition Garden (to deprecate) |
+
 
 ## Legacy TBB version (Gazebo11)
 
-The legacy version of plugin and Gazebo depend on an old version of TBB. Set the following environment
-variables before running the build.
+The legacy version of plugin and Gazebo depend on an old version of TBB. Set the following environment variables before running the build.
 
 ```bash
 export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/tbb@2020_u3
@@ -40,18 +42,16 @@ colcon build --merge-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCM
 
 ## Ignition environment variables
 
-Supposing that the colcon workspace directory containing the `src` folder is `$HOME/wave_sim_ws`,
-then the following environment variables should be set to enable Gazebo to locate the plugins
-and models:
+Supposing that the colcon workspace directory containing the `src` folder is `$HOME/wave_sim_ws`, then the following environment variables should be set to enable Gazebo to locate the plugins and models:
 
 ```bash
 export IGN_GAZEBO_RESOURCE_PATH=${IGN_GAZEBO_RESOURCE_PATH}:\
-$HOME/wave_sim_ws/src/asv_wave_sim/asv_wave_sim_gazebo/models:\
-$HOME/wave_sim_ws/src/asv_wave_sim/asv_wave_sim_gazebo/world_models:\
-$HOME/wave_sim_ws/src/asv_wave_sim/asv_wave_sim_gazebo/worlds
+$HOME/wave_sim_ws/src/asv_wave_sim/gz-marine-models/models:\
+$HOME/wave_sim_ws/src/asv_wave_sim/gz-marine-models/world_models:\
+$HOME/wave_sim_ws/src/asv_wave_sim/gz-marine-models/worlds
 
 export IGN_GAZEBO_SYSTEM_PLUGIN_PATH=${IGN_GAZEBO_SYSTEM_PLUGIN_PATH}:\
-$HOME/wave_sim_ws/src/asv_wave_sim/ign-marine/build/lib
+$HOME/wave_sim_ws/install/lib
 ```
 
 ## CGAL library usage

--- a/gz-marine/include/gz/marine/WaveParameters.hh
+++ b/gz-marine/include/gz/marine/WaveParameters.hh
@@ -65,7 +65,7 @@ namespace marine
     /// \brief The wave algorithm (options are: 'sinusoid', 'trochoid', 'fft').
     public: std::string Algorithm() const;
 
-    /// \brief The size of the wave tile in metres (L).
+    /// \brief The size of the wave tile (m).
     public: double TileSize() const;
 
     /// \brief The number of cells in the wave tile in each direction (N). 
@@ -86,47 +86,52 @@ namespace marine
     ///        with 1 being steepest.
     public: double Steepness() const;
 
-    /// \brief The angular frequency 
+    /// \brief The angular frequency (rad/s) 
     public: double AngularFrequency() const;
 
-    /// \brief The amplitude of the mean wave in [m].
+    /// \brief The amplitude of the mean wave (m).
     public: double Amplitude() const;
 
-    /// \brief The period of the mean wave in [s].
+    /// \brief The period of the mean wave (s).
     public: double Period() const;
 
     /// \brief The phase of the mean wave.
     public: double Phase() const;
 
-    /// \brief The mean wavelength.
+    /// \brief The mean wavelength (m).
     public: double Wavelength() const;
 
-    /// \brief The mean wavenumber.
+    /// \brief The mean angular wavenumber (rad/m).
     public: double Wavenumber() const;
 
-    /// \brief A two component vector specifiying the direction of the mean wave.
+    /// \brief A two component vector specifiying the direction
+    ///        of the mean wave.
     public: math::Vector2d Direction() const;
 
-    /// \brief A two component vector specifiying the horizontal wind velocity.
+    /// \brief A two component vector specifiying the horizontal
+    ///        wind velocity (m/s).
     public: math::Vector2d WindVelocity() const;
 
-    /// \brief The scalar wind speed [m/s].
+    /// \brief The scalar wind speed (m/s).
     public: double WindSpeed() const;
 
-    /// \brief The wind angle (counter clockwise from positive x-axis) [rad].
+    /// \brief The wind angle (counter clockwise from
+    ///        positive x-axis) (rad).
     public: double WindAngleRad() const;
 
-    /// \brief Set the wave algorithm (options are: 'sinusoid', 'trochoid', 'fft').
+    /// \brief Set the wave algorithm (options are: 'sinusoid',
+    ///        'trochoid', 'fft').
     ///
     /// \param[in] _algorithm    The wave algorithm.
     public: void SetAlgorithm(const std::string &_algorithm);
 
-    /// \brief Set the size of the wave tile in metres (L).
+    /// \brief Set the size of the wave tile (m).
     ///
-    /// \param[in] _L    The size of the wave tile.
+    /// \param[in] _L    The size of the wave tile (m).
     public: void SetTileSize(double _L);
 
-    /// \brief Set the number of cells in the wave tile in each direction (N). 
+    /// \brief Set the number of cells in the wave tile
+    ///        in each direction. 
     ///
     /// \param[in] _N    The number of cells.
     public: void SetCellCount(size_t _N);
@@ -154,14 +159,14 @@ namespace marine
     /// \param[in] _steepness The steepness parameter.
     public: void SetSteepness(double _steepness);
 
-    /// \brief Set the mean wave amplitude. Must be positive.
+    /// \brief Set the mean wave amplitude (m). Must be positive.
     ///
-    /// \param[in] _amplitude The amplitude parameter.
+    /// \param[in] _amplitude The amplitude parameter (m).
     public: void SetAmplitude(double _amplitude);
 
-    /// \brief Set the mean wave period. Must be positive.
+    /// \brief Set the mean wave period (s). Must be positive.
     ///
-    /// \param[in] _period The period parameter.
+    /// \param[in] _period The period parameter (s).
     public: void SetPeriod(double _period);
 
     /// \brief Set the mean wave phase.
@@ -171,7 +176,8 @@ namespace marine
 
     /// \brief Set the mean wave direction.
     ///
-    /// \param[in] _direction The direction parameter, a two component vector.
+    /// \param[in] _direction The direction parameter,
+    ///            a two component vector.
     public: void SetDirection(const math::Vector2d& _direction);
 
     /// \brief Set the horizontal wind velocity.
@@ -179,10 +185,17 @@ namespace marine
     /// \param[in] _windVelocity The wind velocity, a two component vector.
     public: void SetWindVelocity(const math::Vector2d& _windVelocity);
 
-    /// \brief Access the component angular frequencies.
+    /// \brief Set the scalar wind speed and downwind angle
+    ///        at 10m above MSL (m/s).
+    ///
+    /// \param[in] _windSpeed    The wind speed (m/s).
+    /// \param[in] _windAngleRad The downwind angle (rad).
+    public: void SetWindSpeedAndAngle(double _windSpeed, double _windAngleRad);
+
+    /// \brief Access the component angular frequencies (rad/s).
     public: const std::vector<double>& AngularFrequency_V() const;
 
-    /// \brief Access the component amplitudes.
+    /// \brief Access the component amplitudes (m).
     public: const std::vector<double>& Amplitude_V() const;
 
     /// \brief Access the component phases.
@@ -191,7 +204,7 @@ namespace marine
     /// \brief Access the steepness components.
     public: const std::vector<double>& Steepness_V() const;
 
-    /// \brief Access the component wavenumbers.
+    /// \brief Access the component wavenumbers (rad/m).
     public: const std::vector<double>& Wavenumber_V() const;
 
     /// \brief Access the component directions.
@@ -202,7 +215,7 @@ namespace marine
 
     /// \internal
     /// \brief Pointer to the class private data.
-    private: std::shared_ptr<WaveParametersPrivate> data;
+    private: std::shared_ptr<WaveParametersPrivate> dataPtr;
   };
 
   typedef std::shared_ptr<WaveParameters> WaveParametersPtr; 

--- a/gz-marine/src/Wavefield.cc
+++ b/gz-marine/src/Wavefield.cc
@@ -158,9 +158,16 @@ namespace marine
 
     // ignmsg << _msg.DebugString();
 
+    // // Get parameters from message
+    // double wind_angle = 0.0;
+    // double wind_speed = 0.0;
+    // wind_angle = Utilities::MsgParamDouble(*_msg, "wind_angle", wind_angle);
+    // wind_speed = Utilities::MsgParamDouble(*_msg, "wind_speed", wind_speed);
+
     // current wind speed and angle
     double windSpeed = this->params->WindSpeed();
     double windAngleRad = this->params->WindAngleRad();
+    double steepness = this->params->Steepness();
 
     // extract parameters
     {
@@ -185,43 +192,26 @@ namespace marine
         windAngleRad = M_PI/180.0*value;
       }
     }
+    {
+      auto it = _msg.params().find("steepness");
+      if (it != _msg.params().end())
+      {
+        /// \todo: assert the type is double
+        auto param = it->second;
+        auto type = param.type();
+        auto value = param.double_value();
+        steepness = value;
+      }
+    }
 
-    /// \todo: update params correctly - put logic in one place
-    // update wind velocity
-    double ux = windSpeed * cos(windAngleRad);
-    double uy = windSpeed * sin(windAngleRad);
-    
     // update parameters and wavefield
-    this->params->SetWindVelocity(math::Vector2d(ux, uy));
-    this->oceanTile->SetWindVelocity(ux, uy);
+    this->params->SetWindSpeedAndAngle(windSpeed, windAngleRad);
+    this->params->SetSteepness(steepness);
+
+    this->oceanTile->SetWindVelocity(
+        this->params->WindVelocity().X(),
+        this->params->WindVelocity().Y());
   }
-
-  /////////////////////////////////////////////////
-  // void Wavefield::OnWaveWindMsg(ConstParam_VPtr &_msg)
-  // {
-  //   std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
-
-  //   // Get parameters from message
-  //   double wind_angle = 0.0;
-  //   double wind_speed = 0.0;
-  //   wind_angle = Utilities::MsgParamDouble(*_msg, "wind_angle", wind_angle);
-  //   wind_speed = Utilities::MsgParamDouble(*_msg, "wind_speed", wind_speed);
-
-  //   // Convert from polar to cartesian
-  //   double wind_vel_x = wind_speed * std::cos(wind_angle);
-  //   double wind_vel_y = wind_speed * std::sin(wind_angle);
-
-  //   // @DEBUG_INFO
-  //   gzmsg << "Wavefield received message on topic ["
-  //     << this->dataPtr->waveWindSub->GetTopic() << "]" << std::endl;
-  //   gzmsg << "wind_angle: " << wind_angle << std::endl;
-  //   gzmsg << "wind_speed: " << wind_speed << std::endl;
-  //   gzmsg << "wind_vel_x: " << wind_vel_x << std::endl;
-  //   gzmsg << "wind_vel_y: " << wind_vel_y << std::endl;
-
-  //   // Update simulation
-  //   this->dataPtr->oceanTile->SetWindVelocity(wind_vel_x, wind_vel_y);
-  // }
 
   /////////////////////////////////////////////////
 

--- a/gz-marine/src/gui/plugins/waves_control/README.md
+++ b/gz-marine/src/gui/plugins/waves_control/README.md
@@ -1,41 +1,36 @@
-# GUI system plugin
+# Waves Control GUI system plugin
 
-This example shows how to create a GUI system plugin.
-
-Gazebo Sim supports any kind of Gazebo GUI plugin
-(`ignition::gui::Plugin`). Gazebo GUI plugins are a special type of 
-GUI plugin which also have access to entity and component updates coming from
-the server.
+This is a GUI system plugin for controlling the waves environment. It is based on the Gazebo Sim example `gz-sim/examples/plugin/gui_system_plugin` which demonstrates how these plugins can access entity and component updates coming from the server.
 
 See `WavesControl.hh` for more information.
 
 ## Build
 
-From the root of the `gz-marine` repository, do the following to build the example:
+From the root of the `asv_wave_sim` repository, do the following to build the example:
 
-~~~
-cd examples/plugin/waves_control
-mkdir build
-cd build
-cmake ..
-make
-~~~
+```bash
+$ cd gz-marine/src/gui/plugin/waves_control
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
+```
 
 This will generate the `WavesControl` library under `build`.
 
 ## Run
 
-Add the library to the path:
+Add the library to the `IGN_GUI_PLUGIN_PATH`:
 
-~~~
-cd src/asv_wave_sim/gz-marine/src/gui/plugin/waves_control
-export IGN_GUI_PLUGIN_PATH=`pwd`/build
-~~~
+```bash
+$ cd gz-marine/src/gui/plugin/waves_control
+$ export IGN_GUI_PLUGIN_PATH=$(pwd)/build
+```
 
 Then run a world, for example:
 
-    ign gazebo -v4 waves.sdf
+```
+$ ign gazebo -v4 waves.sdf
+```
 
 From the GUI plugin menu on the top-right, choose "Waves Control".
-
-You'll see your plugin, displaying the world name `waves`.

--- a/gz-marine/src/gui/plugins/waves_control/WavesControl.cc
+++ b/gz-marine/src/gui/plugins/waves_control/WavesControl.cc
@@ -71,7 +71,10 @@ inline namespace GZ_MARINE_VERSION_NAMESPACE
     public: double windSpeed{5.0};
 
     /// \brief Wind angle
-    public: double windAngle{0.0};
+    public: double windAngle{135.0};
+
+    /// \brief Wave steepness
+    public: double steepness{2.0};
 
     /// \brief Mutex for variable mutated by the checkbox and spinboxes
     /// callbacks.
@@ -110,6 +113,13 @@ void WavesControlPrivate::PublishWaveParams()
     value.set_type(ignition::msgs::Any::DOUBLE);
     value.set_double_value(this->windAngle);
     (*msg.mutable_params())["wind_angle"] = value;
+  }
+  // steepness
+  {
+    ignition::msgs::Any value;
+    value.set_type(ignition::msgs::Any::DOUBLE);
+    value.set_double_value(this->steepness);
+    (*msg.mutable_params())["steepness"] = value;
   }
 
   // publish message
@@ -240,6 +250,17 @@ void WavesControl::UpdateWindAngle(double _windAngle)
   this->dataPtr->windAngle = _windAngle;
 
   ignmsg << "Wind Angle: " << _windAngle << "\n";
+
+  this->dataPtr->PublishWaveParams();
+}
+
+//////////////////////////////////////////////////
+void WavesControl::UpdateSteepness(double _steepness)
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->serviceMutex);
+  this->dataPtr->steepness = _steepness;
+
+  ignmsg << "Steepness: " << _steepness << "\n";
 
   this->dataPtr->PublishWaveParams();
 }

--- a/gz-marine/src/gui/plugins/waves_control/WavesControl.hh
+++ b/gz-marine/src/gui/plugins/waves_control/WavesControl.hh
@@ -69,6 +69,10 @@ inline namespace GZ_MARINE_VERSION_NAMESPACE
     /// \param[in] _windAngle new wind angle
     public slots: void UpdateWindAngle(double _windAngle);
 
+    /// \brief Update the wave steepness
+    /// \param[in] _steepness new steepness
+    public slots: void UpdateSteepness(double _steepness);
+
     /// \internal
     /// \brief Pointer to private data
     private: std::unique_ptr<WavesControlPrivate> dataPtr;

--- a/gz-marine/src/gui/plugins/waves_control/WavesControl.qml
+++ b/gz-marine/src/gui/plugins/waves_control/WavesControl.qml
@@ -114,6 +114,26 @@ GridLayout {
     onEditingFinished: WavesControl.UpdateWindAngle(windAngle.value)
   }
 
+  // steepness
+  Text {
+    Layout.columnSpan: 2
+    id: steepnessText
+    color: "dimgrey"
+    text: "Steepness"
+  }
+
+  IgnSpinBox {
+    Layout.columnSpan: 2
+    Layout.fillWidth: true
+    id: steepness
+    maximumValue: 10
+    minimumValue: 0
+    value: 2
+    decimals: 1
+    stepSize: 0.1
+    onEditingFinished: WavesControl.UpdateSteepness(steepness.value)
+  }
+
   // Bottom spacer
   Item {
     Layout.columnSpan: 4


### PR DESCRIPTION
This PR adds an extra field to control the steepness to the GUI plugin.

The parameter is published by the GUI plugin, and extracted by the WaveVisual and Wavefield, however the interface to update the steepness in the OceanTile is not included in this PR (so it is preparatory work for the full change).

## Other changes

- Update migration notes using new Gazebo Sim naming.
- Update documentation and naming conventions in WaveParameters
- Consolidate calculation to convert from wind speed and down wind angle to wind velocity.