### PR TITLE
Remove OpenCL dependency

### DIFF
--- a/gz-marine/src/CMakeLists.txt
+++ b/gz-marine/src/CMakeLists.txt
@@ -25,7 +25,6 @@ set(sources
   WaveSimulation.cc
   WaveSimulationFFT2.cc
   WaveSimulationFFTW.cc
-  WaveSimulationOpenCL.cc
   WaveSimulationSinusoid.cc
   WaveSimulationTrochoid.cc
   WaveSpectrum.cc

--- a/gz-marine/src/OceanTile.cc
+++ b/gz-marine/src/OceanTile.cc
@@ -936,6 +936,16 @@ void OceanTilePrivate<gz::math::Vector3d>::UpdateMesh(
 }
 
 //////////////////////////////////////////////////
+template <>
+void OceanTilePrivate<cgal::Point3>::UpdateMesh(
+    double _time, gz::common::Mesh *_mesh)
+{
+  /// \note This template specialisation is supplied for compilation on
+  ///       macOS M1 (arm64). It should never be called. 
+  GZ_ASSERT(false, "Should never reach here");
+}
+
+//////////////////////////////////////////////////
 // Specialisation for gz::math::Vector3d
 //////////////////////////////////////////////////
 template <>

--- a/gz-marine/src/systems/dynamic/CMakeLists.txt
+++ b/gz-marine/src/systems/dynamic/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 set(GZ-RENDERING_LIBRARY_DIRS
-  ${GZ-RENDERING_INCLUDE_DIRS}/../../../lib/ign-rendering-${GZ_RENDERING_VER}/engine-plugins)
+  ${GZ-RENDERING_INCLUDE_DIRS}/../../../lib/gz-rendering-${GZ_RENDERING_VER}/engine-plugins)
 
 link_directories(${GZ-RENDERING_LIBRARY_DIRS})
 

--- a/gz-marine/src/systems/waves/CMakeLists.txt
+++ b/gz-marine/src/systems/waves/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 set(GZ-RENDERING_LIBRARY_DIRS
-  ${GZ-RENDERING_INCLUDE_DIRS}/../../../lib/ign-rendering-${GZ_RENDERING_VER}/engine-plugins)
+  ${GZ-RENDERING_INCLUDE_DIRS}/../../../lib/gz-rendering-${GZ_RENDERING_VER}/engine-plugins)
 
 link_directories(${GZ-RENDERING_LIBRARY_DIRS})
 


### PR DESCRIPTION
This PR removes the dependency on OpenCL which is not currently used in the plugins. There is also an update to the search path for the rendering libs in the plugin CMakeLists.txt as part of the name migration. Finally there is a template specialisation of OceanTilePrivate::UpdateMesh for cgal::Point which is needed when compiling for arm64.

### Notes

- This PR is required to build against the latest version of `gz-sim` as there are breaking changes to library and directory names
- Testing is broken because of upstream changes such as https://github.com/gazebosim/gz-math/pull/435 where the expected name of the google test directory is different. This will be fixed in a following PR. 
