### PR TITLE
Remove 'lib' prefix from plugin names

### DIFF
--- a/gz-marine-models/models/wam-v/model.sdf
+++ b/gz-marine-models/models/wam-v/model.sdf
@@ -273,14 +273,14 @@
     </joint>
 
     <!-- Joint state and force plugins -->
-    <plugin filename="libgz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system.so"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system.so"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>left_engine_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system.so"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>right_engine_joint</joint_name>
     </plugin>

--- a/gz-marine/src/Geometry.cc
+++ b/gz-marine/src/Geometry.cc
@@ -14,7 +14,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/marine/Geometry.hh"
-#include "gz/marine/Grid.hh"
 
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 #include <CGAL/AABB_tree.h>

--- a/gz-marine/src/Physics.cc
+++ b/gz-marine/src/Physics.cc
@@ -17,7 +17,6 @@
 #include "gz/marine/Algorithm.hh"
 #include "gz/marine/Convert.hh"
 #include "gz/marine/Geometry.hh"
-#include "gz/marine/Grid.hh"
 #include "gz/marine/PhysicalConstants.hh"
 #include "gz/marine/Utilities.hh"
 #include "gz/marine/Wavefield.hh"

--- a/gz-marine/src/WaveParameters.cc
+++ b/gz-marine/src/WaveParameters.cc
@@ -16,7 +16,6 @@
 #include "gz/marine/WaveParameters.hh"
 #include "gz/marine/Convert.hh"
 #include "gz/marine/Geometry.hh"
-#include "gz/marine/Grid.hh"
 #include "gz/marine/Physics.hh"
 #include "gz/marine/Utilities.hh"
 


### PR DESCRIPTION
This PR removes the `lib` prefix from plugin names and remove unnecessary includes to `Grid.hh`. 
