### PR TITLE
Update plugin names for ign -> gz migration

### DIFF
--- a/gz-marine-models/models/wam-v/model.sdf
+++ b/gz-marine-models/models/wam-v/model.sdf
@@ -273,14 +273,14 @@
     </joint>
 
     <!-- Joint state and force plugins -->
-    <plugin filename="gz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
-    <plugin filename="gz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>left_engine_joint</joint_name>
     </plugin>
-    <plugin filename="gz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>right_engine_joint</joint_name>
     </plugin>

--- a/gz-marine-models/worlds/buoyancy_test.sdf
+++ b/gz-marine-models/worlds/buoyancy_test.sdf
@@ -15,7 +15,7 @@
     <plugin filename="gz-sim-user-commands-system"
             name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
             name="gz::sim::systems::Imu">
     </plugin>
 

--- a/gz-marine-models/worlds/waves.sdf
+++ b/gz-marine-models/worlds/waves.sdf
@@ -15,7 +15,7 @@
     <plugin filename="gz-sim-user-commands-system"
             name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
             name="gz::sim::systems::Imu">
     </plugin>
 

--- a/gz-marine-models/worlds/waves_wind.sdf
+++ b/gz-marine-models/worlds/waves_wind.sdf
@@ -15,7 +15,7 @@
     <plugin filename="gz-sim-user-commands-system"
             name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
             name="gz::sim::systems::Imu">
     </plugin>
     <plugin filename="gz-sim-wind-effects-system"


### PR DESCRIPTION
Further updates as part of the ign -> gz migration that were missed in a previous commit.

Remove `lib` prefix and trailing `.so` from plugin names otherwise they are not resolved.

