### PR TITLE
Dynamic Textures: Add GL3+ shaders

### DIFF
--- a/gz-marine-models/world_models/ocean_waves/materials/waves_fs.glsl
+++ b/gz-marine-models/world_models/ocean_waves/materials/waves_fs.glsl
@@ -1,3 +1,5 @@
+#version 330
+
 // Copyright (C) 2022  Rhys Mainwaring
 //
 // This program is free software: you can redistribute it and/or modify
@@ -30,8 +32,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#version 330
 
 in block
 {

--- a/gz-marine-models/world_models/ocean_waves/materials/waves_fs.glsl
+++ b/gz-marine-models/world_models/ocean_waves/materials/waves_fs.glsl
@@ -31,68 +31,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <metal_stdlib>
-using namespace metal;
+#version 330
 
-struct PS_INPUT
+in block
 {
-  float2 uv0;
-  float3 T;
-  float3 B;
-  float3 N;
-  float3 eyeVec;
-  float2 bumpCoord;
-};
+  vec2 uv0;
+  vec3 T;
+  vec3 B;
+  vec3 N;
+  vec3 eyeVec;
+  vec2 bumpCoord;
+} inPs;
 
-struct Params
-{
-  float4 deepColor;
-  float4 shallowColor;
-  float fresnelPower;
-  float hdrMultiplier;
-};
+uniform vec4 deepColor;
+uniform vec4 shallowColor;
+uniform float fresnelPower;
+uniform float hdrMultiplier;
 
-fragment float4 main_metal
-(
-  PS_INPUT inPs [[stage_in]]
-  , texturecube<float>  cubeMap           [[texture(3)]]
-  , texture2d<float>    bumpMap           [[texture(4)]]
-  , sampler             cubeMapSampler    [[sampler(3)]]
-  , sampler             bumpMapSampler    [[sampler(4)]]
-  , constant Params &p [[buffer(PARAMETER_SLOT)]]
-)
+uniform samplerCube cubeMap;
+uniform sampler2D bumpMap;
+
+out vec4 fragColor;
+
+void main()
 {
   // Apply bump mapping to normal vector to make waves look more detailed:
-  float4 bump = bumpMap.sample(bumpMapSampler, inPs.bumpCoord)*2.0 - 1.0;
-  float3x3 rotMatrix(inPs.T, inPs.B, inPs.N);
-  float3 N = normalize(rotMatrix * bump.xyz);
+  vec4 bump = texture(bumpMap, inPs.bumpCoord)*2.0 - 1.0;
+  mat3 rotMatrix = mat3(inPs.T, inPs.B, inPs.N);
+  vec3 N = normalize(rotMatrix * bump.xyz);
 
   // Reflected ray:
-  float3 E = normalize(inPs.eyeVec);
-  float3 R = reflect(E, N);
+  vec3 E = normalize(inPs.eyeVec);
+  vec3 R = reflect(E, N);
 
-  // Negate z for use with the skybox texture that comes with ign-rendering
-  R = float3(R.x, R.y, -R.z);
-
-  // uncomment this line if using other textures that are Y up
-  // Gazebo requires rotated cube map lookup.
-  // R = float3(R.x, R.z, R.y);
+  // Negate z for use with the skybox texture that comes with gz-rendering
+  R = vec3(R.x, R.y, -R.z);
 
   // Get environment color of reflected ray:
-  float4 envColor = cubeMap.sample(cubeMapSampler, R);
+  vec4 envColor = texture(cubeMap, R, 0.0);
 
   // Cheap hdr effect:
-  envColor.rgb *= (envColor.r+envColor.g+envColor.b)*p.hdrMultiplier;
+  envColor.rgb *= (envColor.r+envColor.g+envColor.b)*hdrMultiplier;
 
   // Compute refraction ratio (Fresnel):
   float facing = 1.0 - dot(-E, N);
-  float waterEnvRatio = clamp(pow(facing, p.fresnelPower), 0.0, 1.0);
+  float waterEnvRatio = clamp(pow(facing, fresnelPower), 0.0, 1.0);
 
   // Refracted ray only considers deep and shallow water colors:
-  float4 waterColor = mix(p.shallowColor, p.deepColor, facing);
+  vec4 waterColor = mix(shallowColor, deepColor, facing);
 
   // Perform linear interpolation between reflection and refraction.
-  float4 color = mix(waterColor, envColor, waterEnvRatio);
+  vec4 color = mix(waterColor, envColor, waterEnvRatio);
 
-  return float4(color.xyz, 0.9);
+  fragColor = vec4(color.xyz, 0.9);
+
+  // debug
+  // fragColor = vec4(inPs.T, 1.0);
 }

--- a/gz-marine-models/world_models/ocean_waves/materials/waves_vs.glsl
+++ b/gz-marine-models/world_models/ocean_waves/materials/waves_vs.glsl
@@ -1,3 +1,5 @@
+#version 330
+
 // Copyright (C) 2022  Rhys Mainwaring
 //
 // This program is free software: you can redistribute it and/or modify
@@ -30,8 +32,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.s
-
-#version 330
 
 in vec4 position;
 in vec2 uv0;

--- a/gz-marine-models/world_models/ocean_waves/materials/waves_vs.glsl
+++ b/gz-marine-models/world_models/ocean_waves/materials/waves_vs.glsl
@@ -1,0 +1,120 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Adapted from glsl trochoid wave shaders developed
+// in https://github.com/uuvsimulator/uuv_simulator
+
+// Copyright (c) 2016 The UUV Simulator Authors.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.s
+
+#version 330
+
+in vec4 position;
+in vec2 uv0;
+
+out block
+{
+  vec2 uv0;
+  vec3 T;
+  vec3 B;
+  vec3 N;
+  vec3 eyeVec;
+  vec2 bumpCoord;
+} outVs;
+
+out gl_PerVertex
+{
+  vec4 gl_Position;
+};
+
+uniform mat4 world_matrix;
+uniform mat4 worldviewproj_matrix;
+uniform vec3 camera_position;
+uniform float t;
+uniform float rescale;
+uniform vec2 bumpScale;
+uniform vec2 bumpSpeed;
+
+uniform sampler2D heightMap;
+uniform sampler2D normalMap;
+uniform sampler2D tangentMap;
+
+void main()
+{
+  vec2 resolution = vec2(1.0, 1.0) * 16.0;
+
+  mat4 model = world_matrix;
+
+  // compute normal matrix
+  // vec3 model0 = model[0].xyz;
+  // vec3 model1 = model[1].xyz;
+  // vec3 model2 = model[2].xyz;
+  // mat3 model_inv = inverse(mat3(
+  //     model0.x, model0.y, model0.z,
+  //     model1.x, model1.y, model1.z,
+  //     model2.x, model2.y, model2.z));
+  // mat3 normal_matrix = transpose(model_inv);
+
+  vec4 P = position.xyzw;
+
+  // debug check to establish which vertex quadrant the uv0 maps to
+//  P.z += ((1 - uv0.x) > 0.5 && uv0.y > 0.5) ? 10.0 : 0.0;
+  //P.z += (uv0.x > 0.5 && uv0.y > 0.5) ? 10.0 : 0.0;
+
+  vec2 texcoord = vec2(/*1.0 - */ uv0.x, /*1.0 -*/ uv0.y);
+
+  // Displacement map
+  vec4 displacements = texture(heightMap, texcoord);
+  P.x += displacements.x;
+  P.y += displacements.y;
+  P.z += displacements.z;
+
+  vec4 tangent = texture(tangentMap, texcoord);
+  vec3 T = (model * tangent).xyz;
+  T = normalize(T);
+
+  vec4 normal = texture(normalMap, texcoord);
+  vec3 N = (model * normal).xyz;
+  N = normalize(N);
+
+  vec3 B = cross(N, T);
+  B = normalize(B);
+  
+  gl_Position = worldviewproj_matrix * P.xyzw;
+  outVs.uv0 = uv0.xy;
+
+  // Rescale tangent vectors
+  outVs.T = T * rescale;
+  outVs.B = B * rescale;
+  outVs.N = N;
+
+  // Compute texture coordinates for bump map
+  outVs.bumpCoord = uv0.xy * bumpScale * resolution + t * bumpSpeed;
+
+  // Eye position in world space
+  outVs.eyeVec = (model * P).xyz - camera_position;
+}

--- a/gz-marine-models/world_models/ocean_waves/model.sdf
+++ b/gz-marine-models/world_models/ocean_waves/model.sdf
@@ -46,6 +46,10 @@
           </wave>
 
           <!-- shader program -->
+          <shader language="glsl">
+            <vertex>materials/waves_vs.glsl</vertex>
+            <fragment>materials/waves_fs.glsl</fragment>
+          </shader>
           <shader language="metal">
             <vertex>materials/waves_vs.metal</vertex>
             <fragment>materials/waves_fs.metal</fragment>
@@ -153,6 +157,10 @@
             <wind_angle_deg>135</wind_angle_deg>
             <steepness>2</steepness>
           </wave>
+          <shader language="glsl">
+            <vertex>materials/waves_vs.glsl</vertex>
+            <fragment>materials/waves_fs.glsl</fragment>
+          </shader>
           <shader language="metal">
             <vertex>materials/waves_vs.metal</vertex>
             <fragment>materials/waves_fs.metal</fragment>

--- a/gz-marine/CMakeLists.txt
+++ b/gz-marine/CMakeLists.txt
@@ -79,21 +79,24 @@ gz_find_package(IgnOGRE VERSION 1.9.0
   PRIVATE_FOR ogre)
 
 #--------------------------------------
-# Find OGRE-Next
-find_package(OGRE-Next QUIET)
-if (OGRE-Next_FOUND)
-  set(HAVE_OGRE2 TRUE)
-  set(HAVE_OGRE-Next TRUE)
-else()
-  # Find OGRE2
-  gz_find_package(IgnOGRE2 VERSION 2.2.0
-      COMPONENTS HlmsPbs HlmsUnlit Overlay
-      REQUIRED_BY ogre2
-      PRIVATE_FOR ogre2)
+# Find OGRE2: first try to find OGRE2 built with PlanarReflections support and
+# fallback to look for OGRE2 without it. Both seems to works for gz-rendering.
+# See https://github.com/gazebosim/gz-rendering/issues/597
+gz_find_package(GzOGRE2 VERSION 2.2.0
+    COMPONENTS HlmsPbs HlmsUnlit Overlay PlanarReflections
+    PRIVATE_FOR ogre2
+    QUIET)
 
-  if (OGRE2_FOUND)
-    set(HAVE_OGRE2 TRUE)
-  endif()
+if ("${OGRE2-PlanarReflections}" STREQUAL "OGRE2-PlanarReflections-NOTFOUND")
+  message(STATUS "PlanarReflections component was not found. Try looking without it:")
+  gz_find_package(GzOGRE2 VERSION 2.2.0
+    COMPONENTS HlmsPbs HlmsUnlit Overlay
+    REQUIRED_BY ogre2
+    PRIVATE_FOR ogre2)
+endif()
+
+if (OGRE2_FOUND)
+  set(HAVE_OGRE2 TRUE)
 endif()
 
 #--------------------------------------

--- a/gz-marine/include/gz/marine/MeshTools.hh
+++ b/gz-marine/include/gz/marine/MeshTools.hh
@@ -23,7 +23,7 @@
 #include "gz/marine/CGALTypes.hh"
 
 #include <gz/common.hh>
-#include <gz/common/mesh.hh>
+#include <gz/common/Mesh.hh>
 
 #include <memory>
 

--- a/gz-marine/src/CMakeLists.txt
+++ b/gz-marine/src/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   gz-transport${GZ_TRANSPORT_VER}::gz-transport${GZ_TRANSPORT_VER}
   sdformat${SDF_VER}::sdformat${SDF_VER}
   ${TBB_LIBRARIES}
+  ${FFT_LIBRARIES}
 )
 if (UNIX AND NOT APPLE)
   target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}

--- a/gz-marine/src/Grid.cc
+++ b/gz-marine/src/Grid.cc
@@ -230,7 +230,6 @@ namespace marine
     // Optimised lookup using face indexing
     // Face index
     const size_t nx = this->data->cellCount[0];
-    const size_t ny = this->data->cellCount[1];
     const size_t idx = 2 * (nx * _iy + _ix) + _k;
 
     // Make triangle from face descriptor
@@ -244,7 +243,6 @@ namespace marine
   {
     // Face index
     const size_t nx = this->data->cellCount[0];
-    const size_t ny = this->data->cellCount[1];
     const size_t idx = 2 * (nx * _iy + _ix) + _k;
 
     // Make triangle from face descriptor
@@ -258,7 +256,6 @@ namespace marine
   {
     // Face index
     const size_t nx = this->data->cellCount[0];
-    const size_t ny = this->data->cellCount[1];
     const size_t idx = 2 * (nx * _iy + _ix) + _k;
 
     return this->data->normals[idx];

--- a/gz-marine/src/OceanTile.cc
+++ b/gz-marine/src/OceanTile.cc
@@ -530,15 +530,15 @@ void OceanTilePrivate<gz::math::Vector3d>::ComputeTBN(
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<cgal::Point3>::ComputeTBN(
-    const cgal::Point3& _p0, 
-    const cgal::Point3& _p1, 
-    const cgal::Point3& _p2, 
-    const gz::math::Vector2d& _uv0, 
-    const gz::math::Vector2d& _uv1, 
-    const gz::math::Vector2d& _uv2, 
-    cgal::Point3& _tangent, 
-    cgal::Point3& _bitangent, 
-    cgal::Point3& _normal)
+    const cgal::Point3& /*_p0*/, 
+    const cgal::Point3& /*_p1*/, 
+    const cgal::Point3& /*_p2*/, 
+    const gz::math::Vector2d& /*_uv0*/, 
+    const gz::math::Vector2d& /*_uv1*/, 
+    const gz::math::Vector2d& /*_uv2*/, 
+    cgal::Point3& /*_tangent*/, 
+    cgal::Point3& /*_bitangent*/, 
+    cgal::Point3& /*_normal*/)
 {
   // Not used
   gzerr << "No implementation"
@@ -604,12 +604,12 @@ void OceanTilePrivate<gz::math::Vector3d>::ComputeTBN(
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<cgal::Point3>::ComputeTBN(
-    const std::vector<cgal::Point3>& _vertices,
-    const std::vector<gz::math::Vector2d>& _texCoords,
-    const std::vector<gz::math::Vector3i>& _faces, 
-    std::vector<cgal::Point3>& _tangents,
-    std::vector<cgal::Point3>& _bitangents,
-    std::vector<cgal::Point3>& _normals)
+    const std::vector<cgal::Point3>& /*_vertices*/,
+    const std::vector<gz::math::Vector2d>& /*_texCoords*/,
+    const std::vector<gz::math::Vector3i>& /*_faces*/, 
+    std::vector<cgal::Point3>& /*_tangents*/,
+    std::vector<cgal::Point3>& /*_bitangents*/,
+    std::vector<cgal::Point3>& /*_normals*/)
 {
   // Not used
   gzerr << "No implementation " 
@@ -761,7 +761,6 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
   
     const size_t N = mResolution;
     const size_t NPlus1  = N + 1;
-    const size_t NMinus1 = N - 1;
 
     for (size_t iy=0; iy<N; ++iy)
     {
@@ -803,7 +802,6 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
 
     const size_t N = mResolution;
     const size_t NPlus1  = N + 1;
-    const size_t NMinus1 = N - 1;
 
     for (size_t iy=0; iy<N; ++iy)
     {
@@ -938,7 +936,7 @@ void OceanTilePrivate<gz::math::Vector3d>::UpdateMesh(
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<cgal::Point3>::UpdateMesh(
-    double _time, gz::common::Mesh *_mesh)
+    double /*_time*/, gz::common::Mesh */*_mesh*/)
 {
   /// \note This template specialisation is supplied for compilation on
   ///       macOS M1 (arm64). It should never be called. 

--- a/gz-marine/src/Physics.cc
+++ b/gz-marine/src/Physics.cc
@@ -62,7 +62,8 @@ namespace marine
     const cgal::Point3& _A,
     const cgal::Point3& _B
   )
-  { 
+  {
+    /// \todo provide robust floating point checks
     double div = _fA + _fB;
     if (div != 0)
     {

--- a/gz-marine/src/TriangulatedGrid.cc
+++ b/gz-marine/src/TriangulatedGrid.cc
@@ -182,7 +182,7 @@ namespace marine
     // timer.reset();
     // timer.start();
     Face_handle fh;
-    for (int64_t i=0; i<points_.size(); ++i) {
+    for (uint64_t i=0; i<points_.size(); ++i) {
       auto vh = tri_.insert(points_[i] ,fh);
       if (vh != nullptr) {
         vh->info() = i;
@@ -287,7 +287,7 @@ namespace marine
   bool TriangulatedGrid::Private::Height(const std::vector<cgal::Point3>& queries, std::vector<double>& heights) const {
     bool foundAll = true;
     Face_handle fh = nullptr;
-    for (int64_t i=0; i<heights.size(); ++i)
+    for (uint64_t i=0; i<heights.size(); ++i)
     {
       double height_i = 0.0;
       const cgal::Point3& query = queries[i];


### PR DESCRIPTION
This PR adds GL3+ shaders to the dynamic texture version of the simulation. There are also a number of code cleanup changes to enable compilation on Ubuntu 22.04.

### Testing

Regression is carried out on macOS and support for Ubuntu on an Ubuntu Jammy (22.04) VM using software rendering llvmpipe (LLVM 13.0.1).