### PR TITLE
Update deprecated CGAL type

### DIFF
--- a/gz-waves/src/CGAL_TEST.cc
+++ b/gz-waves/src/CGAL_TEST.cc
@@ -1603,7 +1603,7 @@ TEST(CGAL, CreateConstrainedTrianguation4) {
   typedef CGAL::Triangulation_hierarchy_vertex_base_2<Vbb>    Vb;
   typedef CGAL::Constrained_triangulation_face_base_2<K>      Fb;
   typedef CGAL::Triangulation_data_structure_2<Vb, Fb>        Tds;
-  typedef CGAL::No_intersection_tag                          Itag;
+  typedef CGAL::No_constraint_intersection_tag                Itag;
   typedef CGAL::Constrained_triangulation_2<K, Tds>           TBase;
 
   typedef CGAL::Triangulation_hierarchy_2<TBase>  Triangulation;
@@ -1647,7 +1647,7 @@ TEST(CGAL, CreateCTAlt) {
   typedef CGAL::Triangulation_hierarchy_vertex_base_2<Vbb>    Vb;
   typedef CGAL::Constrained_triangulation_face_base_2<K>      Fb;
   typedef CGAL::Triangulation_data_structure_2<Vb, Fb>        Tds;
-  typedef CGAL::No_intersection_tag                          Itag;
+  typedef CGAL::No_constraint_intersection_tag                Itag;
   typedef CGAL::Constrained_triangulation_2<K, Tds>           TBase;
 
   typedef CGAL::Triangulation_hierarchy_2<TBase>  Triangulation;
@@ -1693,7 +1693,7 @@ TEST(CGAL, CreateCTAltN) {
   typedef CGAL::Triangulation_hierarchy_vertex_base_2<Vbb>    Vb;
   typedef CGAL::Constrained_triangulation_face_base_2<Kp>     Fb;
   typedef CGAL::Triangulation_data_structure_2<Vb, Fb>        Tds;
-  typedef CGAL::No_intersection_tag                           Itag;
+  typedef CGAL::No_constraint_intersection_tag                Itag;
   typedef CGAL::Constrained_Delaunay_triangulation_2<Kp, Tds> TBase;
 
   typedef CGAL::Triangulation_hierarchy_2<TBase>  Triangulation;

--- a/gz-waves/src/TriangulatedGrid.cc
+++ b/gz-waves/src/TriangulatedGrid.cc
@@ -75,8 +75,7 @@ namespace waves
     typedef CGAL::Constrained_triangulation_face_base_2<Gt>               Fbb;
     typedef CGAL::Triangulation_face_base_with_info_2<int64_t, Gt, Fbb>   Fb;
     typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                  Tds;
-    typedef CGAL::No_intersection_tag                                   Itag;
-    // typedef CGAL::No_constraint_intersection_requiring_constructions_tag  Itag;
+    typedef CGAL::No_constraint_intersection_tag                          Itag;
     typedef CGAL::Constrained_Delaunay_triangulation_2<Gt, Tds, Itag>     Tb;
     typedef CGAL::Triangulation_hierarchy_2<Tb>                           Triangulation;
     typedef Triangulation::Vertex_handle                                  Vertex_handle;


### PR DESCRIPTION
This PR updates the deprecated type CGAL::No_intersection_tag.

Eliminate this and similar warnings:

```bash
Starting >>> gz-waves1
[Processing: gz-waves1]                             
--- stderr: gz-waves1                                
/Volumes/MacPro2_DV1/Code/robotics/gz_waves_ws/src/asv_wave_sim/gz-waves/src/TriangulatedGrid.cc:78:19: warning: 'No_intersection_tag' is deprecated [-Wdeprecated-declarations]
    typedef CGAL::No_intersection_tag                                   Itag;
```