### PR TITLE
Add render engine extension to control load order of render plugins

### DIFF
--- a/gz-waves/CMakeLists.txt
+++ b/gz-waves/CMakeLists.txt
@@ -82,14 +82,14 @@ gz_find_package(GzOGRE VERSION 1.9.0
 # Find OGRE2: first try to find OGRE2 built with PlanarReflections support and
 # fallback to look for OGRE2 without it. Both seems to works for gz-rendering.
 # See https://github.com/gazebosim/gz-rendering/issues/597
-gz_find_package(GzOGRE2 VERSION 2.2.0
+gz_find_package(GzOGRE2 VERSION 2.3.1
     COMPONENTS HlmsPbs HlmsUnlit Overlay PlanarReflections
     PRIVATE_FOR ogre2
     QUIET)
 
 if ("${OGRE2-PlanarReflections}" STREQUAL "OGRE2-PlanarReflections-NOTFOUND")
   message(STATUS "PlanarReflections component was not found. Try looking without it:")
-  gz_find_package(GzOGRE2 VERSION 2.2.0
+  gz_find_package(GzOGRE2 VERSION 2.3.1
     COMPONENTS HlmsPbs HlmsUnlit Overlay
     REQUIRED_BY ogre2
     PRIVATE_FOR ogre2)
@@ -97,6 +97,14 @@ endif()
 
 if (OGRE2_FOUND)
   set(HAVE_OGRE2 TRUE)
+endif()
+
+#####################################
+# Define compile-time default variables
+if(MSVC)
+  set(GZ_RENDERING_PLUGIN_PATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
+else()
+  set(GZ_RENDERING_PLUGIN_PATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
 endif()
 
 #--------------------------------------

--- a/gz-waves/src/systems/dynamic/CMakeLists.txt
+++ b/gz-waves/src/systems/dynamic/CMakeLists.txt
@@ -8,10 +8,9 @@ gz_add_system(dynamic-geometry
   SOURCES
     DynamicGeometry.cc
   PUBLIC_LINK_LIBS
-    ${rendering_target}
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
     gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
     gz-rendering${GZ_RENDERING_VER}-ogre2
     gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
-    IgnOGRE2::IgnOGRE2
+    GzOGRE2::GzOGRE2
 )

--- a/gz-waves/src/systems/waves/BaseOceanGeometry.hh
+++ b/gz-waves/src/systems/waves/BaseOceanGeometry.hh
@@ -1,0 +1,90 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_BASE_BASEOCEANGEOMETRY_HH_
+#define GZ_RENDERING_BASE_BASEOCEANGEOMETRY_HH_
+
+#include "OceanGeometry.hh"
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    /// \brief Base implementation of an Ocean geometry
+    template <class T>
+    class BaseOceanGeometry :
+        public virtual OceanGeometry,
+        public virtual T
+    {
+      /// \brief Constructor
+      public: BaseOceanGeometry();
+
+      /// \brief Destructor
+      public: virtual ~BaseOceanGeometry();
+
+      /// \brief Load from a mesh
+      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
+
+      /// \brief Update from a mesh
+      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
+
+      /// \brief Work-around the protected accessors and methods in Scene
+      public: virtual void InitObject(ScenePtr _scene,
+          unsigned int _id, const std::string &_name) override;
+
+    };
+
+    /////////////////////////////////////////////////
+    // BaseOceanGeometry
+    /////////////////////////////////////////////////
+    template <class T>
+    BaseOceanGeometry<T>::BaseOceanGeometry()
+    {
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    BaseOceanGeometry<T>::~BaseOceanGeometry()
+    {
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanGeometry<T>::LoadMesh(gz::common::MeshPtr _mesh)
+    {
+      // no default implementation
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanGeometry<T>::UpdateMesh(gz::common::MeshPtr _mesh)
+    {
+      // no default implementation
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanGeometry<T>::InitObject(ScenePtr _scene,
+        unsigned int _id, const std::string &_name)
+    {
+      // no default implementation
+    }
+
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/BaseOceanVisual.hh
+++ b/gz-waves/src/systems/waves/BaseOceanVisual.hh
@@ -1,0 +1,178 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_BASE_BASEOCEANVISUAL_HH_
+#define GZ_RENDERING_BASE_BASEOCEANVISUAL_HH_
+
+#include "OceanVisual.hh"
+
+#include <gz/rendering/base/BaseObject.hh>
+#include <gz/rendering/base/BaseRenderTypes.hh>
+#include <gz/rendering/Scene.hh>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    /// \brief Base implementation of an Ocean visual
+    template <class T>
+    class BaseOceanVisual :
+      public virtual OceanVisual,
+      public virtual T
+    {
+      /// \brief Constructor
+      public: BaseOceanVisual();
+
+      /// \brief Destructor
+      public: virtual ~BaseOceanVisual();
+
+      // Documentation inherited.
+      public: virtual void Init() override;
+
+      // Documentation inherited.
+      public: virtual void PreRender() override;
+
+      // Documentation inherited.
+      protected: virtual void Destroy() override;
+
+      // Documentation inherited.
+      public: virtual MaterialPtr Material() const override;
+
+      // Documentation inherited.
+      public: virtual void SetMaterial(
+        MaterialPtr _material, bool _unique) override;
+
+      /// \brief Load a dynamic cube (example)
+      public: virtual void LoadCube() override;
+
+      /// \brief Load from an ocean tile
+      public: virtual void LoadOceanTile(
+          waves::visual::OceanTilePtr _oceanTile) override;
+
+      /// \brief Update from an ocean tile
+      public: virtual void UpdateOceanTile(
+          waves::visual::OceanTilePtr _oceanTile) override;
+
+      /// \brief Load from a mesh
+      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
+
+      /// \brief Update from a mesh
+      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
+
+      /// \brief Work-around the protected accessors and protected methods in Scene
+      public: virtual void InitObject(ScenePtr _scene,
+          unsigned int _id, const std::string &_name) override;
+
+    };
+
+    //////////////////////////////////////////////////
+    template <class T>
+    BaseOceanVisual<T>::BaseOceanVisual()
+    {
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    BaseOceanVisual<T>::~BaseOceanVisual()
+    {
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::PreRender()
+    {
+      T::PreRender();
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::Init()
+    {
+      T::Init();
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::Destroy()
+    {
+      T::Destroy();
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    MaterialPtr BaseOceanVisual<T>::Material() const
+    {
+      return T::Material();
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::SetMaterial(
+      MaterialPtr _material, bool _unique)
+    {
+      T::SetMaterial(_material, _unique);
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::LoadCube( )
+    {
+      // no default implementation
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::LoadOceanTile(
+      waves::visual::OceanTilePtr _oceanTile)
+    {
+      // no default implementation
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::UpdateOceanTile(
+      waves::visual::OceanTilePtr _oceanTile)
+    {
+      // no default implementation
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::LoadMesh(gz::common::MeshPtr _mesh)
+    {
+      // no default implementation
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::UpdateMesh(gz::common::MeshPtr _mesh)
+    {
+      // no default implementation
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseOceanVisual<T>::InitObject(ScenePtr _scene,
+        unsigned int _id, const std::string &_name)
+    {
+      // no default implementation
+    }
+
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/BaseRenderEngineExtension.cc
+++ b/gz-waves/src/systems/waves/BaseRenderEngineExtension.cc
@@ -1,0 +1,77 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "BaseRenderEngineExtension.hh"
+
+#include <gz/common/Console.hh>
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+BaseRenderEngineExtension::BaseRenderEngineExtension()
+{
+}
+
+//////////////////////////////////////////////////
+BaseRenderEngineExtension::~BaseRenderEngineExtension()
+{
+}
+
+//////////////////////////////////////////////////
+bool BaseRenderEngineExtension::Load(
+    const std::map<std::string, std::string> &_params)
+{
+  if (this->loaded)
+  {
+    gzwarn << "Render-engine extension has already been loaded" << std::endl;
+    return true;
+  }
+
+  this->loaded = this->LoadImpl(_params);
+  return this->loaded;
+}
+
+//////////////////////////////////////////////////
+bool BaseRenderEngineExtension::Init()
+{
+  if (!this->loaded)
+  {
+    gzerr << "Render-engine extension must be loaded first"
+        << std::endl;
+    return false;
+  }
+
+  if (this->initialized)
+  {
+    gzwarn << "Render-engine extension has already been initialized"
+        << std::endl;
+    return true;
+  }
+
+  this->initialized = this->InitImpl();
+  return this->initialized;
+}
+
+//////////////////////////////////////////////////
+bool BaseRenderEngineExtension::IsInitialized() const
+{
+  return this->initialized;
+}
+
+//////////////////////////////////////////////////
+void BaseRenderEngineExtension::Destroy()
+{
+}

--- a/gz-waves/src/systems/waves/BaseRenderEngineExtension.hh
+++ b/gz-waves/src/systems/waves/BaseRenderEngineExtension.hh
@@ -1,0 +1,61 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_BASE_RENDERENGINEEXTENSION_HH_
+#define GZ_RENDERING_BASE_RENDERENGINEEXTENSION_HH_
+
+#include "RenderEngineExtension.hh"
+
+#include <map>
+#include <string>
+#include <gz/rendering/config.hh>
+#include <gz/rendering/GraphicsAPI.hh>
+#include <gz/rendering/RenderTypes.hh>
+#include <gz/rendering/Export.hh>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+    class GZ_RENDERING_VISIBLE BaseRenderEngineExtension :
+        public virtual RenderEngineExtension
+    {
+      protected: BaseRenderEngineExtension();
+
+      public: virtual ~BaseRenderEngineExtension();
+
+      public: virtual bool Load(
+          const std::map<std::string, std::string> &_params = {}) override;
+
+      public: virtual bool Init() override;
+
+      public: virtual void Destroy() override;
+
+      public: virtual bool IsInitialized() const override;
+
+      protected: virtual bool LoadImpl(
+          const std::map<std::string, std::string> &_params) = 0;
+
+      protected: virtual bool InitImpl() = 0;
+
+      protected: bool loaded = false;
+
+      protected: bool initialized = false;
+    };
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/CMakeLists.txt
+++ b/gz-waves/src/systems/waves/CMakeLists.txt
@@ -4,29 +4,82 @@ set(GZ-RENDERING_LIBRARY_DIRS
 
 link_directories(${GZ-RENDERING_LIBRARY_DIRS})
 
-gz_add_system(waves-visual
+#################################################
+gz_add_component(rendering
   SOURCES
-    WavesVisual.cc
+    BaseRenderEngineExtension.cc
+    DisplacementMap.cc
+    OceanGeometry.cc
+    OceanVisual.cc
+    RenderEngineExtension.cc
+    RenderEngineExtensionManager.cc
+    RenderEngineExtensionPlugin.cc
+    SceneNodeFactory.cc
+  GET_TARGET_NAME
+    rendering_target
+)
+
+set_property(
+  SOURCE RenderEngineExtensionManager.cc
+  PROPERTY COMPILE_DEFINITIONS
+  GZ_RENDERING_PLUGIN_PATH="${GZ_RENDERING_PLUGIN_PATH}"
+)
+
+target_link_libraries(${rendering_target}
+  PUBLIC
+    gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
+    gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
+  PRIVATE
+    gz-plugin${GZ_PLUGIN_VER}::loader  
+)
+
+#################################################
+# this must be the only component that directly depends on ogre2
+gz_add_component(rendering-ogre2
+  SOURCES
+    Ogre2DisplacementMap.cc
     Ogre2DynamicMesh.cc
     Ogre2OceanGeometry.cc
     Ogre2OceanVisual.cc
-  PUBLIC_LINK_LIBS
+    Ogre2RenderEngineExtension.cc
+    Ogre2SceneNodeFactory.cc
+  GET_TARGET_NAME
+    rendering_ogre2_target
+  DEPENDS_ON_COMPONENTS
+    ${rendering_target}
+)
+
+target_link_directories(${rendering_ogre2_target}
+  PUBLIC
+    ${GZ-RENDERING_LIBRARY_DIRS}
+)
+
+target_link_libraries(${rendering_ogre2_target}
+  PUBLIC
     ${rendering_target}
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
     gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
     gz-rendering${GZ_RENDERING_VER}-ogre2
-    gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
-    IgnOGRE2::IgnOGRE2
-    ${FFT_LIBRARIES}
+    GzOGRE2::GzOGRE2
+  PRIVATE
+    gz-plugin${GZ_PLUGIN_VER}::register
 )
 
-
-gz_add_system(waves-model
+#################################################
+gz_add_system(waves-visual
   SOURCES
-    WavesModel.cc
+    WavesVisual.cc
   PUBLIC_LINK_LIBS
     ${rendering_target}
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
     gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
-    ${FFT_LIBRARIES}
+)
+
+#################################################
+gz_add_system(waves-model
+  SOURCES
+    WavesModel.cc
+  PUBLIC_LINK_LIBS
+    gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
+    gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
 )

--- a/gz-waves/src/systems/waves/DisplacementMap.cc
+++ b/gz-waves/src/systems/waves/DisplacementMap.cc
@@ -1,0 +1,23 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "DisplacementMap.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+DisplacementMap::~DisplacementMap() = default;
+

--- a/gz-waves/src/systems/waves/DisplacementMap.hh
+++ b/gz-waves/src/systems/waves/DisplacementMap.hh
@@ -1,0 +1,53 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_DISPLACEMENTMAP_HH_
+#define GZ_RENDERING_DISPLACEMENTMAP_HH_
+
+#include <gz/rendering/config.hh>
+#include "gz/rendering/Export.hh"
+
+#include <memory>
+#include <vector>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    class GZ_RENDERING_VISIBLE DisplacementMap
+    {
+      public: virtual ~DisplacementMap();
+
+      public: virtual void InitTextures() = 0;
+
+      public: virtual void UpdateTextures(
+        const std::vector<double> &mHeights,
+        const std::vector<double> &mDhdx,
+        const std::vector<double> &mDhdy,
+        const std::vector<double> &mDisplacementsX,
+        const std::vector<double> &mDisplacementsY,
+        const std::vector<double> &mDxdx,
+        const std::vector<double> &mDydy,
+        const std::vector<double> &mDxdy) = 0;
+    };
+
+    typedef std::shared_ptr<DisplacementMap> DisplacementMapPtr;
+
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/OceanGeometry.cc
+++ b/gz-waves/src/systems/waves/OceanGeometry.cc
@@ -1,0 +1,22 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "OceanGeometry.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+OceanGeometry::~OceanGeometry() = default;

--- a/gz-waves/src/systems/waves/OceanGeometry.hh
+++ b/gz-waves/src/systems/waves/OceanGeometry.hh
@@ -1,0 +1,56 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_OCEANGEOMETRY_HH_
+#define GZ_RENDERING_OCEANGEOMETRY_HH_
+
+#include <gz/common/graphics/Types.hh>
+
+#include <gz/rendering/config.hh>
+#include <gz/rendering/Geometry.hh>
+#include <gz/rendering/Object.hh>
+#include <gz/rendering/RenderTypes.hh>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    /// \brief Ocean geometry class based on a dynamic mesh
+    class GZ_RENDERING_VISIBLE OceanGeometry :
+        public virtual Geometry
+    {
+      /// \brief Destructor
+      public: virtual ~OceanGeometry();
+
+      /// \brief Load from a mesh
+      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) = 0;
+
+      /// \brief Update from a mesh
+      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) = 0;
+
+      /// \brief Work-around the protected accessors and methods in Scene
+      public: virtual void InitObject(ScenePtr _scene,
+          unsigned int _id, const std::string &_name) = 0;
+
+    };
+
+    typedef std::shared_ptr<OceanGeometry> OceanGeometryPtr;
+
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/OceanVisual.cc
+++ b/gz-waves/src/systems/waves/OceanVisual.cc
@@ -1,0 +1,22 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "OceanVisual.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+OceanVisual::~OceanVisual() = default;

--- a/gz-waves/src/systems/waves/OceanVisual.hh
+++ b/gz-waves/src/systems/waves/OceanVisual.hh
@@ -1,0 +1,69 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_OCEANVISUAL_HH_
+#define GZ_RENDERING_OCEANVISUAL_HH_
+
+#include "gz/waves/OceanTile.hh"
+
+#include <gz/common/graphics/Types.hh>
+
+#include <gz/rendering/config.hh>
+#include <gz/rendering/Object.hh>
+#include <gz/rendering/RenderTypes.hh>
+#include <gz/rendering/Visual.hh>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    /// \brief Ocean visual using a dynamic mesh
+    class GZ_RENDERING_VISIBLE OceanVisual :
+      public virtual Visual
+    {
+      /// \brief Destructor
+      public: virtual ~OceanVisual();
+
+      /// \brief Load a dynamic cube (example)
+      public: virtual void LoadCube() = 0;
+
+      /// \brief Load from an ocean tile
+      public: virtual void LoadOceanTile(
+          waves::visual::OceanTilePtr _oceanTile) = 0;
+
+      /// \brief Update from an ocean tile
+      public: virtual void UpdateOceanTile(
+          waves::visual::OceanTilePtr _oceanTile) = 0;
+
+      /// \brief Load from a mesh
+      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) = 0;
+
+      /// \brief Update from a mesh
+      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) = 0;
+
+      /// \brief Work-around the protected accessors and methods in Scene
+      public: virtual void InitObject(ScenePtr _scene,
+          unsigned int _id, const std::string &_name) = 0;
+
+    };
+
+    typedef std::shared_ptr<OceanVisual> OceanVisualPtr;
+
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
+++ b/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
@@ -1,0 +1,459 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "Ogre2DisplacementMap.hh"
+
+#include <gz/rendering/RenderingIface.hh>
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+Ogre2DisplacementMap::Ogre2DisplacementMap(
+  ScenePtr _scene,
+  MaterialPtr _material,
+  uint64_t _entity,
+  uint32_t _width,
+  uint32_t _height) :
+  entity(_entity),
+  scene(_scene),
+  material(_material),
+  width(_width),
+  height(_height)
+{
+}
+
+//////////////////////////////////////////////////
+Ogre2DisplacementMap::~Ogre2DisplacementMap()
+{
+  gzmsg << "Ogre2DisplacementMap::Destructor\n";
+
+  // Remove staging textures
+  gz::rendering::Ogre2ScenePtr ogre2Scene =
+    std::dynamic_pointer_cast<gz::rendering::Ogre2Scene>(
+        this->scene);
+
+  if(ogre2Scene != nullptr)
+  {
+    Ogre::SceneManager *ogre2SceneManager = ogre2Scene->OgreSceneManager();
+
+    if (ogre2SceneManager != nullptr)
+    {
+      Ogre::TextureGpuManager *ogre2TextureManager =
+          ogre2SceneManager->getDestinationRenderSystem()->
+              getTextureGpuManager();
+
+      if (ogre2TextureManager != nullptr)
+      {
+        for (uint8_t i=0; i<3; ++i)   {
+          if (mHeightMapStagingTextures[i]) {
+              ogre2TextureManager->removeStagingTexture(
+                  mHeightMapStagingTextures[i]);
+              mHeightMapStagingTextures[i] = nullptr;
+          }
+
+          if (mNormalMapStagingTextures[i]) {
+              ogre2TextureManager->removeStagingTexture(
+                  mNormalMapStagingTextures[i]);
+              mNormalMapStagingTextures[i] = nullptr;
+          }
+
+          if (mTangentMapStagingTextures[i]) {
+              ogre2TextureManager->removeStagingTexture(
+                  mTangentMapStagingTextures[i]);
+              mTangentMapStagingTextures[i] = nullptr;
+          }
+        }
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void Ogre2DisplacementMap::InitTextures()
+{
+  gzmsg << "Ogre2DisplacementMap::InitTextures\n";
+
+  if (!this->material)
+  {
+    gzerr << "Invalid Material\n";
+    return;
+  }
+
+  gz::rendering::Ogre2ScenePtr ogre2Scene =
+    std::dynamic_pointer_cast<gz::rendering::Ogre2Scene>(
+        this->scene);
+
+  gz::rendering::Ogre2MaterialPtr ogre2Material =
+    std::dynamic_pointer_cast<gz::rendering::Ogre2Material>(
+        this->material);
+
+  Ogre::SceneManager *ogre2SceneManager = ogre2Scene->OgreSceneManager();
+
+  Ogre::TextureGpuManager *ogre2TextureManager =
+      ogre2SceneManager->getDestinationRenderSystem()->getTextureGpuManager();
+
+  // Create empty image
+  uint32_t depthOrSlices{1};
+  Ogre::TextureTypes::TextureTypes textureType{
+      Ogre::TextureTypes::TextureTypes::Type2D};
+  Ogre::PixelFormatGpu format{
+      Ogre::PixelFormatGpu::PFG_RGBA32_FLOAT};
+  uint8_t numMipmaps{1u};
+
+  gzmsg << "Create HeightMap image\n";
+  mHeightMapImage = new Ogre::Image2();
+  mHeightMapImage->createEmptyImage(this->width, this->height, depthOrSlices,
+      textureType, format, numMipmaps);
+
+  gzmsg << "Create NormalMap image\n";
+  mNormalMapImage = new Ogre::Image2();
+  mNormalMapImage->createEmptyImage(this->width, this->height, depthOrSlices,
+      textureType, format, numMipmaps);
+
+  gzmsg << "Create TangentMap image\n";
+  mTangentMapImage = new Ogre::Image2();
+  mTangentMapImage->createEmptyImage(this->width, this->height, depthOrSlices,
+      textureType, format, numMipmaps);
+
+  gzmsg << "Initialising images\n";
+  uint32_t bufLen = sizeof(float) * 4 * this->width * this->height;
+  memset(mHeightMapImage->getRawBuffer(), 0, bufLen);
+  memset(mNormalMapImage->getRawBuffer(), 0, bufLen);
+  memset(mTangentMapImage->getRawBuffer(), 0, bufLen);
+
+  // Create displacement texture
+  gzmsg << "Create HeightMap texture\n";
+  mHeightMapTex = ogre2TextureManager->createTexture(
+      "HeightMapTex(" + std::to_string(this->entity) + ")",
+      Ogre::GpuPageOutStrategy::SaveToSystemRam,
+      Ogre::TextureFlags::ManualTexture,
+      Ogre::TextureTypes::Type2D );
+
+  mHeightMapTex->setResolution(mHeightMapImage->getWidth(),
+      mHeightMapImage->getHeight());
+  mHeightMapTex->setPixelFormat(mHeightMapImage->getPixelFormat());
+  mHeightMapTex->setNumMipmaps(Ogre::PixelFormatGpuUtils::getMaxMipmapCount(
+      mHeightMapTex->getWidth(), mHeightMapTex->getHeight()));
+
+  // Create normal texture
+  gzmsg << "Create NormalMap texture\n";
+  mNormalMapTex = ogre2TextureManager->createTexture(
+      "NormalMapTex(" + std::to_string(this->entity) + ")",
+      Ogre::GpuPageOutStrategy::SaveToSystemRam,
+      Ogre::TextureFlags::ManualTexture,
+      Ogre::TextureTypes::Type2D );
+
+  mNormalMapTex->setResolution(mNormalMapImage->getWidth(),
+      mNormalMapImage->getHeight());
+  mNormalMapTex->setPixelFormat(mNormalMapImage->getPixelFormat());
+  mNormalMapTex->setNumMipmaps(Ogre::PixelFormatGpuUtils::getMaxMipmapCount(
+      mNormalMapTex->getWidth(), mNormalMapTex->getHeight()));
+
+  // Create tangent texture
+  gzmsg << "Create TangentMap texture\n";
+  mTangentMapTex = ogre2TextureManager->createTexture(
+      "TangentMapTex(" + std::to_string(this->entity) + ")",
+      Ogre::GpuPageOutStrategy::SaveToSystemRam,
+      Ogre::TextureFlags::ManualTexture,
+      Ogre::TextureTypes::Type2D );
+
+  mTangentMapTex->setResolution(mTangentMapImage->getWidth(),
+      mTangentMapImage->getHeight());
+  mTangentMapTex->setPixelFormat(mTangentMapImage->getPixelFormat());
+  mTangentMapTex->setNumMipmaps(Ogre::PixelFormatGpuUtils::getMaxMipmapCount(
+      mTangentMapTex->getWidth(), mTangentMapTex->getHeight()));
+
+  // Set texture on wave material
+  gzmsg << "Assign dynamic textures to material\n";
+  auto mat = ogre2Material->Material();
+  auto pass = mat->getTechnique(0u)->getPass(0);
+  auto ogreParams = pass->getVertexProgramParameters();
+
+  /// \todo understand why using the render engine instance
+  /// directly gives an incorrect result?
+  // {
+  //   auto engine = rendering::Ogre2RenderEngine::Instance();
+  //   auto graphicsAPI = engine->GraphicsAPI();
+  //   gzdbg << "Using graphicsAPI: "
+  //       << GraphicsAPIUtils::Str(graphicsAPI) << "\n";
+  // }
+
+  auto engine = rendering::engine("ogre2");
+  auto graphicsAPI = engine->GraphicsAPI();
+  gzdbg << "Using graphicsAPI: "
+      << GraphicsAPIUtils::Str(graphicsAPI) << "\n";
+
+  {
+    auto texUnit = pass->getTextureUnitState("heightMap");
+    if (!texUnit)
+    {
+      texUnit = pass->createTextureUnitState();
+      texUnit->setName("heightMap");
+    }
+    texUnit->setTexture(mHeightMapTex);
+    texUnit->setTextureCoordSet(0);
+    int texIndex = static_cast<int>(pass->getTextureUnitStateIndex(texUnit));
+
+    gzmsg << "texNameStr:   " << mHeightMapTex->getNameStr() << "\n";
+    gzmsg << "texCoordSet:  " << 0 << "\n";
+    gzmsg << "texIndex:     " << texIndex << "\n";
+
+    // set to wrap mode otherwise default is clamp mode
+    Ogre::HlmsSamplerblock samplerBlockRef;
+    samplerBlockRef.mU = Ogre::TAM_WRAP;
+    samplerBlockRef.mV = Ogre::TAM_WRAP;
+    samplerBlockRef.mW = Ogre::TAM_WRAP;
+    texUnit->setSamplerblock(samplerBlockRef);
+
+    if (graphicsAPI == rendering::GraphicsAPI::OPENGL)
+    {
+      // set the texture map index
+      ogreParams->setNamedConstant("heightMap", &texIndex, 1, 1);
+    }
+  }
+
+  {
+    auto texUnit = pass->getTextureUnitState("normalMap");
+    if (!texUnit)
+    {
+      texUnit = pass->createTextureUnitState();
+      texUnit->setName("normalMap");
+    }
+    texUnit->setTexture(mNormalMapTex);
+    texUnit->setTextureCoordSet(0);
+    int texIndex = static_cast<int>(pass->getTextureUnitStateIndex(texUnit));
+
+    gzmsg << "texNameStr:   " << mNormalMapTex->getNameStr() << "\n";
+    gzmsg << "texCoordSet:  " << 0 << "\n";
+    gzmsg << "texIndex:     " << texIndex << "\n";
+
+    // set to wrap mode otherwise default is clamp mode
+    Ogre::HlmsSamplerblock samplerBlockRef;
+    samplerBlockRef.mU = Ogre::TAM_WRAP;
+    samplerBlockRef.mV = Ogre::TAM_WRAP;
+    samplerBlockRef.mW = Ogre::TAM_WRAP;
+    texUnit->setSamplerblock(samplerBlockRef);
+
+    if (graphicsAPI == rendering::GraphicsAPI::OPENGL)
+    {
+      // set the texture map index
+      ogreParams->setNamedConstant("normalMap", &texIndex, 1, 1);
+    }
+  }
+
+  {
+    auto texUnit = pass->getTextureUnitState("tangentMap");
+    if (!texUnit)
+    {
+      texUnit = pass->createTextureUnitState();
+      texUnit->setName("tangentMap");
+    }
+    texUnit->setTexture(mTangentMapTex);
+    texUnit->setTextureCoordSet(0);
+    int texIndex = static_cast<int>(pass->getTextureUnitStateIndex(texUnit));
+
+    gzmsg << "texNameStr:   " << mTangentMapTex->getNameStr() << "\n";
+    gzmsg << "texCoordSet:  " << 0 << "\n";
+    gzmsg << "texIndex:     " << texIndex << "\n";
+
+    // set to wrap mode otherwise default is clamp mode
+    Ogre::HlmsSamplerblock samplerBlockRef;
+    samplerBlockRef.mU = Ogre::TAM_WRAP;
+    samplerBlockRef.mV = Ogre::TAM_WRAP;
+    samplerBlockRef.mW = Ogre::TAM_WRAP;
+    texUnit->setSamplerblock(samplerBlockRef);
+
+    if (graphicsAPI == rendering::GraphicsAPI::OPENGL)
+    {
+      // set the texture map index
+      ogreParams->setNamedConstant("tangentMap", &texIndex, 1, 1);
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void Ogre2DisplacementMap::UpdateTextures(
+  const std::vector<double> &mHeights,
+  const std::vector<double> &mDhdx,
+  const std::vector<double> &mDhdy,
+  const std::vector<double> &mDisplacementsX,
+  const std::vector<double> &mDisplacementsY,
+  const std::vector<double> &mDxdx,
+  const std::vector<double> &mDydy,
+  const std::vector<double> &mDxdy
+)
+{
+  gz::rendering::Ogre2ScenePtr ogre2Scene =
+    std::dynamic_pointer_cast<gz::rendering::Ogre2Scene>(
+        this->scene);
+
+  Ogre::SceneManager *ogre2SceneManager = ogre2Scene->OgreSceneManager();
+
+  Ogre::TextureGpuManager *ogre2TextureManager =
+      ogre2SceneManager->getDestinationRenderSystem()->getTextureGpuManager();
+
+  // update the image data
+  uint32_t width  = mHeightMapImage->getWidth();
+  uint32_t height = mHeightMapImage->getHeight();
+
+  Ogre::TextureBox heightBox  = mHeightMapImage->getData(0);
+  Ogre::TextureBox normalBox  = mNormalMapImage->getData(0);
+  Ogre::TextureBox tangentBox = mTangentMapImage->getData(0);
+
+  for (uint32_t iv=0; iv < height; ++iv)
+  {
+      /// \todo: coordinates are flipped in the vertex shader
+      // texture index to vertex index
+      int32_t iy = /*height - 1 - */ iv;
+      for (uint32_t iu=0; iu < width; ++iu)
+      {
+          // texture index to vertex index
+          int32_t ix = /* width - 1 - */ iu;
+
+          float Dx{0.0}, Dy{0.0}, Dz{0.0};
+          float Tx{1.0}, Ty{0.0}, Tz{0.0};
+          float Bx{0.0}, By{1.0}, Bz{0.0};
+          float Nx{0.0}, Ny{0.0}, Nz{1.0};
+
+          int32_t idx = iy * width + ix;
+          double h  = mHeights[idx];
+          double sx = mDisplacementsX[idx];
+          double sy = mDisplacementsY[idx];
+          double dhdx  = mDhdx[idx]; 
+          double dhdy  = mDhdy[idx]; 
+          double dsxdx = mDxdx[idx]; 
+          double dsydy = mDydy[idx]; 
+          double dsxdy = mDxdy[idx]; 
+
+          // vertex displacements
+          Dx += sy;
+          Dy += sx;
+          Dz  = h;
+
+          // tangents
+          Tx = dsydy + 1.0;
+          Ty = dsxdy;
+          Tz = dhdy;
+
+          // bitangents
+          Bx = dsxdy;
+          By = dsxdx + 1.0;
+          Bz = dhdx;
+
+          // normals N = T x B
+          Nx = 1.0 * (Ty*Bz - Tz*Bx);
+          Ny = 1.0 * (Tz*Bx - Tx*Bz);
+          Nz = 1.0 * (Tx*By - Ty*Bx);
+
+          heightBox.setColourAt(Ogre::ColourValue(Dx, Dy, Dz, 0.0), iu, iv, 0,
+              mHeightMapImage->getPixelFormat());
+          normalBox.setColourAt(Ogre::ColourValue(Nx, Ny, Nz, 0.0), iu, iv, 0,
+              mNormalMapImage->getPixelFormat());
+          tangentBox.setColourAt(Ogre::ColourValue(Tx, Ty, Tz, 0.0), iu, iv, 0,
+              mTangentMapImage->getPixelFormat());
+      }
+  }
+
+  // schedule update to GPU
+  mHeightMapTex->scheduleTransitionTo(Ogre::GpuResidency::Resident, nullptr);
+  mNormalMapTex->scheduleTransitionTo(Ogre::GpuResidency::Resident, nullptr);
+  mTangentMapTex->scheduleTransitionTo(Ogre::GpuResidency::Resident, nullptr);
+
+  // Staging texture is required for upload from CPU -> GPU
+  {
+    if (!mHeightMapStagingTextures[mHeightMapFrameIdx]) {
+        mHeightMapStagingTextures[mHeightMapFrameIdx] =
+            ogre2TextureManager->getStagingTexture(
+                mHeightMapImage->getWidth(),
+                mHeightMapImage->getHeight(),
+                1u, 1u,
+                mHeightMapImage->getPixelFormat(),
+                100u);
+    }
+
+    Ogre::StagingTexture *stagingTexture =
+      mHeightMapStagingTextures[mHeightMapFrameIdx];
+    mHeightMapFrameIdx = (mHeightMapFrameIdx + 1) % 3;
+
+    stagingTexture->startMapRegion();
+    Ogre::TextureBox texBox = stagingTexture->mapRegion(
+        mHeightMapImage->getWidth(), mHeightMapImage->getHeight(), 1u, 1u,
+        mHeightMapImage->getPixelFormat());
+
+    texBox.copyFrom(mHeightMapImage->getData(0));
+    stagingTexture->stopMapRegion();
+    stagingTexture->upload(texBox, mHeightMapTex, 0, 0, 0);
+    if (!mHeightMapTex->isDataReady()) {
+        mHeightMapTex->notifyDataIsReady();
+    }
+  }
+
+  {
+    if (!mNormalMapStagingTextures[mNormalMapFrameIdx]) {
+        mNormalMapStagingTextures[mNormalMapFrameIdx] =
+            ogre2TextureManager->getStagingTexture(
+                mNormalMapImage->getWidth(),
+                mNormalMapImage->getHeight(),
+                1u, 1u,
+                mNormalMapImage->getPixelFormat(),
+                100u);
+    }
+
+    Ogre::StagingTexture *stagingTexture =
+      mNormalMapStagingTextures[mNormalMapFrameIdx];
+    mNormalMapFrameIdx = (mNormalMapFrameIdx + 1) % 3;
+    
+    stagingTexture->startMapRegion();
+    Ogre::TextureBox texBox = stagingTexture->mapRegion(
+        mNormalMapImage->getWidth(), mNormalMapImage->getHeight(), 1u, 1u,
+        mNormalMapImage->getPixelFormat());
+
+    texBox.copyFrom(mNormalMapImage->getData(0));
+    stagingTexture->stopMapRegion();
+    stagingTexture->upload(texBox, mNormalMapTex, 0, 0, 0);
+    if (!mNormalMapTex->isDataReady()) {
+        mNormalMapTex->notifyDataIsReady();
+    }
+  }
+
+  {
+    if (!mTangentMapStagingTextures[mTangentMapFrameIdx]) {
+        mTangentMapStagingTextures[mTangentMapFrameIdx] =
+            ogre2TextureManager->getStagingTexture(
+                mTangentMapImage->getWidth(),
+                mTangentMapImage->getHeight(),
+                1u, 1u,
+                mTangentMapImage->getPixelFormat(),
+                100u);
+    }
+
+    Ogre::StagingTexture *stagingTexture =
+      mTangentMapStagingTextures[mTangentMapFrameIdx];
+    mTangentMapFrameIdx = (mTangentMapFrameIdx + 1) % 3;
+
+    stagingTexture->startMapRegion();
+    Ogre::TextureBox texBox = stagingTexture->mapRegion(
+        mTangentMapImage->getWidth(), mTangentMapImage->getHeight(), 1u, 1u,
+        mTangentMapImage->getPixelFormat());
+
+    texBox.copyFrom(mTangentMapImage->getData(0));
+    stagingTexture->stopMapRegion();
+    stagingTexture->upload(texBox, mTangentMapTex, 0, 0, 0);
+    if (!mTangentMapTex->isDataReady()) {
+      mTangentMapTex->notifyDataIsReady();
+    }
+  }
+}

--- a/gz-waves/src/systems/waves/Ogre2DisplacementMap.hh
+++ b/gz-waves/src/systems/waves/Ogre2DisplacementMap.hh
@@ -1,0 +1,96 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_OGRE2_OGRE2DISPLACEMENTMAP_HH_
+#define GZ_RENDERING_OGRE2_OGRE2DISPLACEMENTMAP_HH_
+
+#include "DisplacementMap.hh"
+
+#include <gz/rendering/config.hh>
+#include <gz/rendering/Material.hh>
+#include <gz/rendering/Scene.hh>
+#include "gz/rendering/Export.hh"
+
+#include <gz/rendering/ogre2.hh>
+#include <gz/rendering/ogre2/Export.hh>
+
+#include <memory>
+#include <vector>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    class GZ_RENDERING_OGRE2_VISIBLE Ogre2DisplacementMap :
+        public DisplacementMap
+    {
+      public: Ogre2DisplacementMap(
+        ScenePtr _scene,
+        MaterialPtr _material,
+        uint64_t _entity,
+        uint32_t _width,
+        uint32_t _height);
+
+      public: virtual ~Ogre2DisplacementMap();
+
+      public: virtual void InitTextures() override;
+
+      public: virtual void UpdateTextures(
+        const std::vector<double> &mHeights,
+        const std::vector<double> &mDhdx,
+        const std::vector<double> &mDhdy,
+        const std::vector<double> &mDisplacementsX,
+        const std::vector<double> &mDisplacementsY,
+        const std::vector<double> &mDxdx,
+        const std::vector<double> &mDydy,
+        const std::vector<double> &mDxdy
+      ) override;
+
+      private: ScenePtr scene;
+      private: MaterialPtr material;
+      private: uint64_t entity{0};
+      private: uint32_t width{0};
+      private: uint32_t height{0};
+
+      private:
+      /// \note: new code adapted from ogre ocean materials sample
+      // textures for displacement, normal and tangent maps
+      Ogre::Image2       *mHeightMapImage{nullptr};
+      Ogre::Image2       *mNormalMapImage{nullptr};
+      Ogre::Image2       *mTangentMapImage{nullptr};
+      Ogre::TextureGpu   *mHeightMapTex{nullptr};
+      Ogre::TextureGpu   *mNormalMapTex{nullptr};
+      Ogre::TextureGpu   *mTangentMapTex{nullptr};
+
+      /// \note Triple buffer staging textures
+      Ogre::StagingTexture* mHeightMapStagingTextures[3] =
+          {nullptr, nullptr, nullptr};
+      Ogre::StagingTexture* mNormalMapStagingTextures[3] =
+          {nullptr, nullptr, nullptr};
+      Ogre::StagingTexture* mTangentMapStagingTextures[3] =
+          {nullptr, nullptr, nullptr};
+
+      uint8_t mHeightMapFrameIdx{0};
+      uint8_t mNormalMapFrameIdx{0};
+      uint8_t mTangentMapFrameIdx{0};
+    };
+
+    }
+  }
+}
+
+#endif

--- a/gz-waves/src/systems/waves/Ogre2DynamicMesh.cc
+++ b/gz-waves/src/systems/waves/Ogre2DynamicMesh.cc
@@ -1,7 +1,19 @@
-/*
- * Copyright (C) 2022 Rhys Mainwaring
- *
-*/
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Adapted from gz-rendering DynamicGeometry
 
 /*
  * Copyright (C) 2020 Open Source Robotics Foundation

--- a/gz-waves/src/systems/waves/Ogre2DynamicMesh.hh
+++ b/gz-waves/src/systems/waves/Ogre2DynamicMesh.hh
@@ -1,7 +1,19 @@
-/*
- * Copyright (C) 2022 Rhys Mainwaring
- *
-*/
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Adapted from gz-rendering DynamicGeometry
 
 /*
  * Copyright (C) 2021 Open Source Robotics Foundation
@@ -19,6 +31,7 @@
  * limitations under the License.
  *
 */
+
 #ifndef GZ_RENDERING_OGRE2_OGRE2DYNAMICMESH_HH_
 #define GZ_RENDERING_OGRE2_OGRE2DYNAMICMESH_HH_
 
@@ -32,7 +45,6 @@
 #include <gz/rendering/ogre2/Ogre2Geometry.hh>
 #include <gz/rendering/ogre2/Ogre2RenderTypes.hh>
 #include <gz/rendering/Marker.hh>
-
 
 #ifdef _MSC_VER
   #pragma warning(push, 0)

--- a/gz-waves/src/systems/waves/Ogre2OceanGeometry.cc
+++ b/gz-waves/src/systems/waves/Ogre2OceanGeometry.cc
@@ -1,20 +1,17 @@
-/*
- * Copyright (C) 2022  Rhys Mainwaring
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
-*/
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "Ogre2OceanGeometry.hh"
 #include "Ogre2DynamicMesh.hh"
@@ -23,7 +20,7 @@
 
 #include <gz/common.hh>
 #include <gz/rendering/ogre2/Ogre2Material.hh>
-
+#include <gz/rendering/ogre2/Ogre2Scene.hh>
 
 /// \brief Private implementation
 class gz::rendering::Ogre2OceanGeometryPrivate
@@ -208,12 +205,15 @@ void Ogre2OceanGeometry::UpdateMesh(gz::common::MeshPtr _mesh)
 }
 
 //////////////////////////////////////////////////
-void Ogre2OceanGeometry::InitObject(Ogre2ScenePtr _scene,
+void Ogre2OceanGeometry::InitObject(ScenePtr _scene,
     unsigned int _id, const std::string &_name)
 {
+  rendering::Ogre2ScenePtr ogre2Scene =
+      std::dynamic_pointer_cast<rendering::Ogre2Scene>(_scene);
+
   this->id = _id;
   this->name = _name;
-  this->scene = _scene;
+  this->scene = ogre2Scene;
 
   // initialize object
   this->Load();

--- a/gz-waves/src/systems/waves/Ogre2OceanGeometry.hh
+++ b/gz-waves/src/systems/waves/Ogre2OceanGeometry.hh
@@ -1,51 +1,50 @@
-/*
- * Copyright (C) 2022  Rhys Mainwaring
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
-*/
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #ifndef GZ_RENDERING_OGRE2_OGRE2OCEANGEOMETRY_HH_
 #define GZ_RENDERING_OGRE2_OGRE2OCEANGEOMETRY_HH_
+
+#include "BaseOceanGeometry.hh"
 
 #include <gz/rendering/ogre2/Export.hh>
 #include <gz/rendering/ogre2/Ogre2Geometry.hh>
 #include <gz/rendering/RenderTypes.hh>
-// #include <gz/rendering/Scene.hh>
 
 #include <memory>
+
+namespace Ogre
+{
+  class MovableObject;
+}
 
 namespace gz
 {
   namespace rendering
   {
     inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-    //
-    // forward declarations
+    // Forward declarations
     class Ogre2OceanGeometryPrivate;
 
-    /*  \class Ogre2OceanGeometry Ogre2OceanGeometry.hh \
-     *  gz/rendering/ogre2/Ogre2OceanGeometry.hh
-     */
     /// \brief Ocean geometry class based on a dynamic mesh
     class GZ_RENDERING_OGRE2_VISIBLE Ogre2OceanGeometry :
-        public Ogre2Geometry
+        public BaseOceanGeometry<Ogre2Geometry>
     {
       /// \brief Constructor
-      /// \param[in] _scene Pointer to scene
       public: explicit Ogre2OceanGeometry();
 
-      /// \brief Virtual destructor
+      /// \brief Destructor
       public: virtual ~Ogre2OceanGeometry();
 
       // Documentation inherited.
@@ -68,14 +67,14 @@ namespace gz
         SetMaterial(MaterialPtr _material, bool _unique) override;
 
       /// \brief Load from a mesh
-      public: void LoadMesh(gz::common::MeshPtr _mesh);
+      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
 
       /// \brief Update from a mesh
-      public: void UpdateMesh(gz::common::MeshPtr _mesh);
+      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
 
       /// \brief Work-around the protected accessors and protected methods in Scene
-      public: void InitObject(Ogre2ScenePtr _scene,
-          unsigned int _id, const std::string &_name);
+      public: virtual void InitObject(ScenePtr _scene,
+          unsigned int _id, const std::string &_name) override;
 
       /// \brief OceanGeometry should be created by scene.
       private: friend class Ogre2Scene;

--- a/gz-waves/src/systems/waves/Ogre2OceanVisual.cc
+++ b/gz-waves/src/systems/waves/Ogre2OceanVisual.cc
@@ -21,6 +21,7 @@
 #include <gz/common.hh>
 #include <gz/common/SubMesh.hh>
 #include <gz/rendering/ogre2/Ogre2Material.hh>
+#include <gz/rendering/ogre2/Ogre2Scene.hh>
 
 #ifdef _MSC_VER
   #pragma warning(push, 0)
@@ -346,12 +347,15 @@ void Ogre2OceanVisual::SetMaterialImpl(Ogre2MaterialPtr _material)
 }
 
 //////////////////////////////////////////////////
-void Ogre2OceanVisual::InitObject(Ogre2ScenePtr _scene,
+void Ogre2OceanVisual::InitObject(ScenePtr _scene,
     unsigned int _id, const std::string &_name)
 {
+  rendering::Ogre2ScenePtr ogre2Scene =
+      std::dynamic_pointer_cast<rendering::Ogre2Scene>(_scene);
+
   this->id = _id;
   this->name = _name;
-  this->scene = _scene;
+  this->scene = ogre2Scene;
 
   // initialize object
   this->Load();

--- a/gz-waves/src/systems/waves/Ogre2OceanVisual.hh
+++ b/gz-waves/src/systems/waves/Ogre2OceanVisual.hh
@@ -16,17 +16,13 @@
 #ifndef GZ_RENDERING_OGRE2_OGRE2OCEANVISUAL_HH_
 #define GZ_RENDERING_OGRE2_OGRE2OCEANVISUAL_HH_
 
+#include "BaseOceanVisual.hh"
+
 #include "gz/waves/OceanTile.hh"
 
-#include <gz/rendering/base/BaseVisual.hh>
 #include <gz/rendering/ogre2/Ogre2Visual.hh>
 
 #include <memory>
-
-namespace Ogre
-{
-  class MovableObject;
-}
 
 namespace gz
 {
@@ -39,10 +35,9 @@ namespace gz
 
     /// \brief Ogre2.x implementation of an ocean visual class
     class GZ_RENDERING_OGRE2_VISIBLE Ogre2OceanVisual :
-      public Ogre2Visual
+      public BaseOceanVisual<Ogre2Visual>
     {
       /// \brief Constructor
-      // protected: Ogre2OceanVisual();
       public: Ogre2OceanVisual();
 
       /// \brief Destructor
@@ -64,29 +59,30 @@ namespace gz
       public: virtual void SetMaterial(
         MaterialPtr _material, bool _unique) override;
 
-
       /// \brief Load a dynamic cube (example)
-      public: void LoadCube();
+      public: virtual void LoadCube() override;
 
       /// \brief Load from an ocean tile
-      public: void LoadOceanTile(waves::visual::OceanTilePtr _oceanTile);
+      public: virtual void LoadOceanTile(
+          waves::visual::OceanTilePtr _oceanTile) override;
 
       /// \brief Update from an ocean tile
-      public: void UpdateOceanTile(waves::visual::OceanTilePtr _oceanTile);
+      public: virtual void UpdateOceanTile(
+          waves::visual::OceanTilePtr _oceanTile) override;
 
       /// \brief Load from a mesh
-      public: void LoadMesh(gz::common::MeshPtr _mesh);
+      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
 
       /// \brief Update from a mesh
-      public: void UpdateMesh(gz::common::MeshPtr _mesh);
+      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
 
       /// \brief Set material to geometry.
       /// \param[in] _material Ogre material.
       protected: virtual void SetMaterialImpl(Ogre2MaterialPtr _material);
 
       /// \brief Work-around the protected accessors and protected methods in Scene
-      public: void InitObject(Ogre2ScenePtr _scene,
-          unsigned int _id, const std::string &_name);
+      public: virtual void InitObject(ScenePtr _scene,
+          unsigned int _id, const std::string &_name) override;
 
       private: friend class Ogre2Scene;
 

--- a/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.cc
+++ b/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.cc
@@ -1,0 +1,164 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "Ogre2RenderEngineExtension.hh"
+
+#include "SceneNodeFactory.hh"
+#include "Ogre2SceneNodeFactory.hh"
+
+#include <gz/common/Console.hh>
+#include <gz/plugin/Register.hh>
+
+#include <gz/rendering/RenderEngine.hh>
+#include <gz/rendering/RenderingIface.hh>
+
+
+//////////////////////////////////////////////////
+class GZ_RENDERING_OGRE2_HIDDEN
+    gz::rendering::Ogre2RenderEngineExtensionPrivate
+{
+  public: gz::rendering::SceneNodeFactoryPtr sceneNodeFactory;
+};
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+Ogre2RenderEngineExtensionPlugin::Ogre2RenderEngineExtensionPlugin()
+{
+}
+
+//////////////////////////////////////////////////
+Ogre2RenderEngineExtensionPlugin::~Ogre2RenderEngineExtensionPlugin()
+    = default;
+
+//////////////////////////////////////////////////
+std::string Ogre2RenderEngineExtensionPlugin::Name() const
+{
+  return Ogre2RenderEngineExtension::Instance()->Name();
+}
+
+//////////////////////////////////////////////////
+RenderEngineExtension *Ogre2RenderEngineExtensionPlugin::Extension() const
+{
+  return Ogre2RenderEngineExtension::Instance();
+}
+
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+Ogre2RenderEngineExtension::Ogre2RenderEngineExtension() :
+    dataPtr(std::make_unique<Ogre2RenderEngineExtensionPrivate>())
+{
+}
+
+//////////////////////////////////////////////////
+Ogre2RenderEngineExtension::~Ogre2RenderEngineExtension()
+{
+}
+
+//////////////////////////////////////////////////
+void Ogre2RenderEngineExtension::Destroy()
+{
+  BaseRenderEngineExtension::Destroy();
+}
+
+//////////////////////////////////////////////////
+std::string Ogre2RenderEngineExtension::Name() const
+{
+  return "ogre2";
+}
+
+//////////////////////////////////////////////////
+bool Ogre2RenderEngineExtension::LoadImpl(
+    const std::map<std::string, std::string> &_params)
+{
+  try
+  {
+    this->LoadAttempt();
+    this->loaded = true;
+    return true;
+  }
+  catch(...)
+  {
+    gzerr << "Failed to load render-engine extension" << std::endl;
+    return false;
+  }
+}
+
+//////////////////////////////////////////////////
+bool Ogre2RenderEngineExtension::InitImpl()
+{
+  try
+  {
+    this->InitAttempt();
+    return true;
+  }
+  catch (...)
+  {
+    gzerr << "Failed to initialize render-engine extension" << std::endl;
+    return false;
+  }
+}
+
+//////////////////////////////////////////////////
+void Ogre2RenderEngineExtension::LoadAttempt()
+{
+  gzdbg << "Attempting to load Ogre2RenderEngineExtension" << std::endl;
+}
+
+//////////////////////////////////////////////////
+void Ogre2RenderEngineExtension::InitAttempt()
+{
+  gzdbg << "Attempting to initialise Ogre2RenderEngineExtension" << std::endl;
+
+  std::string engineName("ogre2");
+
+  // Check the render engine is available and loaded
+  if (!rendering::hasEngine(engineName))
+  {
+    gzerr << "Failed to load render-engine extension ["
+        << this->Name() << "] as render-engine [ "
+        << engineName << "] is not available.\n";
+  }
+
+  if (!rendering::isEngineLoaded(engineName))
+  {
+    gzerr << "Failed to load render-engine extension ["
+        << this->Name() << "] as render-engine [ "
+        << engineName << "] is not loaded.\n";
+  }
+
+  // Check which graphics API is being used
+  auto engine = rendering::engine("ogre2");
+  auto graphicsAPI = engine->GraphicsAPI();
+  gzdbg << "Using graphicsAPI: "
+      << GraphicsAPIUtils::Str(graphicsAPI) << "\n";
+
+  // create the scene node factory
+  this->dataPtr->sceneNodeFactory = std::make_shared<Ogre2SceneNodeFactory>();
+}
+
+//////////////////////////////////////////////////
+SceneNodeFactoryPtr Ogre2RenderEngineExtension::SceneNodeFactory() const
+{
+  return this->dataPtr->sceneNodeFactory;
+}
+
+//////////////////////////////////////////////////
+// Register this plugin
+GZ_ADD_PLUGIN(gz::rendering::Ogre2RenderEngineExtensionPlugin,
+              gz::rendering::RenderEngineExtensionPlugin)
+

--- a/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.hh
+++ b/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.hh
@@ -1,0 +1,90 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_OGRE2_RENDERENGINEEXTENSION_HH_
+#define GZ_RENDERING_OGRE2_RENDERENGINEEXTENSION_HH_
+
+#include "BaseRenderEngineExtension.hh"
+#include "RenderEngineExtensionPlugin.hh"
+#include "RenderEngineExtension.hh"
+
+#include <gz/common/SingletonT.hh>
+
+#include <gz/rendering/config.hh>
+#include <gz/rendering/Export.hh>
+
+#include "gz/rendering/ogre2/Ogre2RenderTypes.hh"
+#include <gz/rendering/ogre2/Export.hh>
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+    
+    // Forward declaration
+    class  Ogre2RenderEngineExtensionPrivate;
+
+    class GZ_RENDERING_OGRE2_VISIBLE Ogre2RenderEngineExtensionPlugin :
+      public RenderEngineExtensionPlugin
+    {
+      public: Ogre2RenderEngineExtensionPlugin();
+
+      public: ~Ogre2RenderEngineExtensionPlugin();
+
+      public: std::string Name() const;
+
+      public: RenderEngineExtension *Extension() const;
+    };
+
+    class GZ_RENDERING_OGRE2_VISIBLE Ogre2RenderEngineExtension :
+        public virtual BaseRenderEngineExtension,
+        public common::SingletonT<Ogre2RenderEngineExtension>
+    {
+      private: Ogre2RenderEngineExtension();
+
+      public: virtual ~Ogre2RenderEngineExtension();
+
+      public: virtual void Destroy() override;
+
+      public: virtual std::string Name() const override;
+
+      public: virtual SceneNodeFactoryPtr SceneNodeFactory() const override;
+
+      protected: virtual bool LoadImpl(
+          const std::map<std::string, std::string> &_params) override;
+
+      protected: virtual bool InitImpl() override;
+
+      private: void LoadAttempt();
+
+      private: void InitAttempt();
+
+      /// \brief Pointer to private data
+      private: std::unique_ptr<Ogre2RenderEngineExtensionPrivate> dataPtr;
+
+      /// \brief Singleton setup
+      private: friend class common::SingletonT<Ogre2RenderEngineExtension>;
+    };
+
+    }
+  }
+}
+
+#endif

--- a/gz-waves/src/systems/waves/Ogre2SceneNodeFactory.cc
+++ b/gz-waves/src/systems/waves/Ogre2SceneNodeFactory.cc
@@ -1,0 +1,84 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "Ogre2SceneNodeFactory.hh"
+
+#include "DisplacementMap.hh"
+#include "OceanGeometry.hh"
+#include "OceanVisual.hh"
+
+#include "Ogre2DisplacementMap.hh"
+#include "Ogre2OceanGeometry.hh"
+#include "Ogre2OceanVisual.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+Ogre2SceneNodeFactory::Ogre2SceneNodeFactory()
+{
+}
+
+//////////////////////////////////////////////////
+Ogre2SceneNodeFactory::~Ogre2SceneNodeFactory()
+{
+}
+
+//////////////////////////////////////////////////
+OceanVisualPtr Ogre2SceneNodeFactory::CreateOceanVisual(ScenePtr _scene)
+{
+  // create name and increment the object id
+  std::stringstream ss;
+  ss << "OceanVisual(" << objId++ << ")";
+  std::string objName = ss.str();
+
+  // create visual
+  rendering::OceanVisualPtr visual =
+      std::make_shared<rendering::Ogre2OceanVisual>(); 
+  visual->InitObject(_scene, objId, objName);
+
+  return visual;
+}
+
+//////////////////////////////////////////////////
+OceanGeometryPtr Ogre2SceneNodeFactory::CreateOceanGeometry(ScenePtr _scene)
+{
+  // create name and increment the object id
+  std::stringstream ss;
+  ss << "OceanGeometry(" << objId++ << ")";
+  std::string objName = ss.str();
+
+  // create geometry
+  rendering::OceanGeometryPtr geometry =
+      std::make_shared<rendering::Ogre2OceanGeometry>(); 
+  geometry->InitObject(_scene, objId, objName);
+
+  return geometry;
+}
+
+//////////////////////////////////////////////////
+DisplacementMapPtr Ogre2SceneNodeFactory::CreateDisplacementMap(
+    ScenePtr _scene,
+    MaterialPtr _material,
+    uint64_t _entity,
+    uint32_t _width,
+    uint32_t _height)
+{
+  rendering::DisplacementMapPtr displacementMap =
+      std::make_shared<rendering::Ogre2DisplacementMap>(
+          _scene, _material, _entity, _width, _height); 
+
+  return displacementMap;
+}

--- a/gz-waves/src/systems/waves/Ogre2SceneNodeFactory.hh
+++ b/gz-waves/src/systems/waves/Ogre2SceneNodeFactory.hh
@@ -1,0 +1,64 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_OGRE2_SCENENODEFACTORY_HH_
+#define GZ_RENDERING_OGRE2_SCENENODEFACTORY_HH_
+
+#include "SceneNodeFactory.hh"
+
+#include <gz/rendering/config.hh>
+#include <gz/rendering/Scene.hh>
+#include "gz/rendering/Export.hh"
+
+#include <gz/rendering/ogre2/Export.hh>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    class GZ_RENDERING_OGRE2_VISIBLE Ogre2SceneNodeFactory :
+        public SceneNodeFactory
+    {
+      /// \brief Constructor
+      public: Ogre2SceneNodeFactory();
+
+      /// \brief Destructor
+      public: virtual ~Ogre2SceneNodeFactory();
+
+      /// \brief Create an ocean visual
+      public: virtual OceanVisualPtr CreateOceanVisual(
+          ScenePtr _scene) override;
+    
+      /// \brief Create an ocean geometry
+      public: virtual OceanGeometryPtr CreateOceanGeometry(
+          ScenePtr _scene) override;
+
+      /// \brief Create a displacement map
+      public: virtual DisplacementMapPtr CreateDisplacementMap(
+          ScenePtr _scene,
+          MaterialPtr _material,
+          uint64_t _entity,
+          uint32_t _width,
+          uint32_t _height) override;
+
+      private: unsigned int objId{50000};
+    };
+
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/RenderEngineExtension.cc
+++ b/gz-waves/src/systems/waves/RenderEngineExtension.cc
@@ -1,0 +1,23 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "RenderEngineExtension.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+RenderEngineExtension::~RenderEngineExtension() = default;
+

--- a/gz-waves/src/systems/waves/RenderEngineExtension.hh
+++ b/gz-waves/src/systems/waves/RenderEngineExtension.hh
@@ -1,0 +1,91 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Copied from gz-rendering RenderEngine
+
+/*
+ * Copyright (C) 2015 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef GZ_RENDERING_RENDERENGINEEXTENSION_HH_
+#define GZ_RENDERING_RENDERENGINEEXTENSION_HH_
+
+#include "SceneNodeFactory.hh"
+
+#include <map>
+#include <string>
+#include <gz/rendering/config.hh>
+#include <gz/rendering/GraphicsAPI.hh>
+#include <gz/rendering/RenderTypes.hh>
+#include <gz/rendering/Export.hh>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+    //
+    /// \brief An abstract interface to a concrete render-engine extension.
+    class GZ_RENDERING_VISIBLE RenderEngineExtension
+    {
+      /// \brief Destructor
+      public: virtual ~RenderEngineExtension();
+
+      /// \brief Load any necessary resources to set up the extension. This
+      /// should called before any other function.
+      /// \param[in] _params Parameters to be passed to the underlying
+      /// rendering engine extension.
+      /// \return True if the extension was successfully loaded
+      public: virtual bool Load(
+          const std::map<std::string, std::string> &_params = {}) = 0;
+
+      /// \brief Initialize the extension. This should be called immediately
+      /// after a successful call to Load.
+      /// \return True if the extension was successfully initialized
+      public: virtual bool Init() = 0;
+
+      /// \brief Destroys all scenes created by extension and releases all
+      /// loaded resources. This should be called when the given extension
+      /// will no longer be used during runtime.
+      /// \return True if the extension was successfully destroyed
+      public: virtual void Destroy() = 0;
+
+      /// \brief Determines if the extension has been initialized.
+      /// \return True if the extension is initialized
+      public: virtual bool IsInitialized() const = 0;
+
+      /// \brief Get name of the extension.
+      /// \return The extension name
+      public: virtual std::string Name() const = 0;
+
+      /// \brief Get the SceneNodeFactory.
+      public: virtual SceneNodeFactoryPtr SceneNodeFactory() const = 0;
+    };
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/RenderEngineExtensionManager.cc
+++ b/gz-waves/src/systems/waves/RenderEngineExtensionManager.cc
@@ -1,0 +1,587 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Copied from gz-rendering RenderEngineManager
+
+/*
+ * Copyright (C) 2015 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "RenderEngineExtensionManager.hh"
+#include "RenderEngineExtension.hh"
+#include "RenderEngineExtensionPlugin.hh"
+
+
+#include <gz/common/Console.hh>
+#include <gz/common/SystemPaths.hh>
+#include <gz/plugin/Loader.hh>
+#include <gz/rendering/config.hh>
+
+#include <map>
+#include <mutex>
+
+
+/// \brief Holds information about an extension
+struct ExtensionInfo
+{
+  /// \brief The name of the extension's shared library, default extensions
+  /// can also be specified with their regular name (ogre, optix, etc.).
+  std::string name;
+
+  /// \brief The pointer to the render extension.
+  gz::rendering::RenderEngineExtension *extension;
+};
+
+/// \brief Private implementation of the RenderEngineExtensionManager class.
+class gz::rendering::RenderEngineExtensionManagerPrivate
+{
+  /// \brief ExtensionMap that maps extension name to an extension pointer.
+  typedef std::map<std::string, RenderEngineExtension *> ExtensionMap;
+
+  /// \brief ExtensionMap iterator.
+  typedef ExtensionMap::iterator ExtensionIter;
+
+  /// \brief Get a pointer to the render extension from an ExtensionMap
+  /// iterator.
+  /// \param[in] _iter ExtensionMap iterator
+  /// \param[in] _path Another search path for rendering extension plugin.
+  public: RenderEngineExtension *Extension(ExtensionInfo _info,
+      const std::map<std::string, std::string> &_params,
+      const std::string &_path);
+
+  /// \brief Unload the given render extension from an ExtensionMap iterator.
+  /// The extension will remain registered and can be loaded again later.
+  /// \param[in] _iter ExtensionMap iterator
+  /// \return True if the extension is unloaded
+  public: bool UnloadExtension(ExtensionIter _iter);
+
+  /// \brief Register default extensions supplied by ign-rendering
+  public: void RegisterDefaultExtensions();
+
+  /// \brief Unregister an extension using an ExtensionMap iterator.
+  /// Once an extension is unregistered, it can no longer be loaded. Use
+  /// RenderEngineExtensionManagerPrivate::UnloadExtension to unload the extension
+  /// without unregistering it if you wish to load the extension again
+  /// \param[in] _iter ExtensionMap iterator
+  public: void UnregisterExtension(ExtensionIter _iter);
+
+  /// \brief Load a render extension plugin.
+  /// \param[in] _filename Filename of plugin shared library
+  /// \param[in] _path Another search path for rendering extension plugin.
+  /// \return True if the plugin is loaded successfully
+  public: bool LoadExtensionPlugin(const std::string &_filename,
+              const std::string &_path);
+
+  /// \brief Unload a render extension plugin.
+  /// \param[in] _extensionName Name of extension associated with this plugin
+  /// \return True if the plugin is unloaded successfully
+  public: bool UnloadExtensionPlugin(const std::string &_extensionName);
+
+  /// \brief Extensions that have been registered
+  public: ExtensionMap extensions;
+
+  /// \brief A map of default extension library names to their plugin names.
+  public: std::map<std::string, std::string> defaultExtensions;
+
+  /// \brief A map of loaded extension plugins to its plugin name.
+  public: std::map<std::string, std::string> extensionPlugins;
+
+  /// \brief Plugin loader for managing render extension plugin libraries.
+  public: gz::plugin::Loader pluginLoader;
+
+  /// \brief Environment variable which holds paths to look for plugins
+  public: std::string pluginPathEnv = "GZ_RENDERING_PLUGIN_PATH";
+
+  /// \brief List which holds paths to look for extension plugins.
+  public: std::list<std::string> pluginPaths;
+
+  /// \brief Mutex to protect the extensions map.
+  public: std::recursive_mutex extensionsMutex;
+};
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+// RenderEngineExtensionManager
+//////////////////////////////////////////////////
+RenderEngineExtensionManager::RenderEngineExtensionManager() :
+  dataPtr(new RenderEngineExtensionManagerPrivate)
+{
+  this->dataPtr->RegisterDefaultExtensions();
+}
+
+//////////////////////////////////////////////////
+RenderEngineExtensionManager::~RenderEngineExtensionManager() = default;
+
+//////////////////////////////////////////////////
+unsigned int RenderEngineExtensionManager::ExtensionCount() const
+{
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  return this->dataPtr->extensions.size();
+}
+
+//////////////////////////////////////////////////
+bool RenderEngineExtensionManager::HasExtension(const std::string &_name) const
+{
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  auto iter = this->dataPtr->extensions.find(_name);
+
+  if (iter == this->dataPtr->extensions.end())
+  {
+    // Check if the provided name is a name of a default extension, if so,
+    // translate the name to the shared library name
+    auto defaultIt = this->dataPtr->defaultExtensions.find(_name);
+    if (defaultIt != this->dataPtr->defaultExtensions.end())
+      iter = this->dataPtr->extensions.find(defaultIt->second);
+  }
+
+  return iter != this->dataPtr->extensions.end();
+}
+
+//////////////////////////////////////////////////
+bool RenderEngineExtensionManager::IsExtensionLoaded(
+    const std::string &_name) const
+{
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  auto iter = this->dataPtr->extensions.find(_name);
+
+  if (iter == this->dataPtr->extensions.end())
+  {
+    // Check if the provided name is a name of a default extension, if so,
+    // translate the name to the shared library name
+    auto defaultIt = this->dataPtr->defaultExtensions.find(_name);
+    if (defaultIt != this->dataPtr->defaultExtensions.end())
+    {
+      iter = this->dataPtr->extensions.find(defaultIt->second);
+      if (iter == this->dataPtr->extensions.end())
+        return false;
+    }
+    else
+      return false;
+  }
+
+  return nullptr != iter->second;
+}
+
+//////////////////////////////////////////////////
+std::vector<std::string> RenderEngineExtensionManager::LoadedExtensions() const
+{
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  std::vector<std::string> extensions;
+  for (auto [name, extension] :  // NOLINT(whitespace/braces)
+      this->dataPtr->extensions)
+  {
+    std::string n = name;
+    if (nullptr != extension)
+    {
+      // gz-rendering3 changed loaded extension names to the actual lib name.
+      // For backward compatibility, return extension name if it is one of the
+      // default extensions
+      for (const auto &it : this->dataPtr->defaultExtensions)
+      {
+        if (it.second == name)
+        {
+          n = it.first;
+          break;
+        }
+      }
+      extensions.push_back(n);
+    }
+  }
+  return extensions;
+}
+
+//////////////////////////////////////////////////
+RenderEngineExtension *RenderEngineExtensionManager::Extension(
+    const std::string &_name,
+    const std::map<std::string, std::string> &_params,
+    const std::string &_path)
+{
+  ExtensionInfo info{_name, nullptr};
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  // check in the list of available extensions
+  auto iter = this->dataPtr->extensions.find(_name);
+  if (iter != this->dataPtr->extensions.end())
+  {
+    info.name = iter->first;
+    info.extension = iter->second;
+  }
+
+  return this->dataPtr->Extension(info, _params, _path);
+}
+
+//////////////////////////////////////////////////
+RenderEngineExtension *RenderEngineExtensionManager::ExtensionAt(
+    unsigned int _index,
+    const std::map<std::string, std::string> &_params,
+    const std::string &_path)
+{
+  if (_index >= this->ExtensionCount())
+  {
+    gzerr << "Invalid render-extension index: " << _index << std::endl;
+    return nullptr;
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  auto iter = this->dataPtr->extensions.begin();
+  std::advance(iter, _index);
+  return this->dataPtr->Extension({iter->first, iter->second}, _params, _path);
+}
+
+//////////////////////////////////////////////////
+bool RenderEngineExtensionManager::UnloadExtension(const std::string &_name)
+{
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  // check in the list of available extensions
+  auto iter = this->dataPtr->extensions.find(_name);
+
+  if (iter == this->dataPtr->extensions.end())
+  {
+    // Check if the provided name is a name of a default extension, if so,
+    // translate the name to the shared library name
+    auto defaultIt = this->dataPtr->defaultExtensions.find(_name);
+    if (defaultIt != this->dataPtr->defaultExtensions.end())
+      iter = this->dataPtr->extensions.find(defaultIt->second);
+
+    if (iter == this->dataPtr->extensions.end())
+    {
+      gzerr << "No render-extension registered with name: "
+          << _name << std::endl;
+      return false;
+    }
+  }
+
+  return this->dataPtr->UnloadExtension(iter);
+}
+
+//////////////////////////////////////////////////
+bool RenderEngineExtensionManager::UnloadExtensionAt(unsigned int _index)
+{
+  if (_index >= this->ExtensionCount())
+  {
+    gzerr << "Invalid render-extension index: " << _index << std::endl;
+    return false;
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  auto iter = this->dataPtr->extensions.begin();
+  std::advance(iter, _index);
+  return this->dataPtr->UnloadExtension(iter);
+}
+
+//////////////////////////////////////////////////
+void RenderEngineExtensionManager::RegisterExtension(const std::string &_name,
+    RenderEngineExtension *_extension)
+{
+  if (!_extension)
+  {
+    gzerr << "Render-extension cannot be null" << std::endl;
+    return;
+  }
+
+  if (this->HasExtension(_name))
+  {
+    gzerr << "Render-extension already registered with name: "
+          << _name << std::endl;
+
+    return;
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  this->dataPtr->extensions[_name] = _extension;
+}
+
+//////////////////////////////////////////////////
+void RenderEngineExtensionManager::UnregisterExtension(const std::string &_name)
+{
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  auto iter = this->dataPtr->extensions.find(_name);
+
+  if (iter != this->dataPtr->extensions.end())
+  {
+    this->dataPtr->UnregisterExtension(iter);
+  }
+}
+
+//////////////////////////////////////////////////
+void RenderEngineExtensionManager::UnregisterExtension(
+    RenderEngineExtension *_extension)
+{
+  if (!_extension)
+    return;
+
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  auto begin = this->dataPtr->extensions.begin();
+  auto end = this->dataPtr->extensions.end();
+
+  for (auto iter = begin; iter != end; ++iter)
+  {
+    if (iter->second == _extension)
+    {
+      this->dataPtr->UnregisterExtension(iter);
+      return;
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void RenderEngineExtensionManager::UnregisterExtensionAt(unsigned int _index)
+{
+  if (_index >= this->ExtensionCount())
+  {
+    gzerr << "Invalid render-extension index: " << _index << std::endl;
+    return;
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(this->dataPtr->extensionsMutex);
+  auto iter = this->dataPtr->extensions.begin();
+  std::advance(iter, _index);
+  this->dataPtr->UnregisterExtension(iter);
+}
+
+//////////////////////////////////////////////////
+void RenderEngineExtensionManager::SetPluginPaths(
+    const std::list<std::string> &_paths)
+{
+  this->dataPtr->pluginPaths = _paths;
+}
+
+//////////////////////////////////////////////////
+// RenderEngineExtensionManagerPrivate
+//////////////////////////////////////////////////
+RenderEngineExtension *RenderEngineExtensionManagerPrivate::Extension(
+    ExtensionInfo _info,
+    const std::map<std::string, std::string> &_params,
+    const std::string &_path)
+{
+  RenderEngineExtension *extension = _info.extension;
+
+  if (!extension)
+  {
+    std::string libName = _info.name;
+
+    // Check if the provided name is a name of a default extension, if so,
+    // translate the name to the shared library name
+    auto defaultIt = this->defaultExtensions.find(_info.name);
+    if (defaultIt != this->defaultExtensions.end())
+      libName = defaultIt->second;
+
+    // Load the extension plugin
+    if (this->LoadExtensionPlugin(libName, _path))
+    {
+      std::lock_guard<std::recursive_mutex> lock(this->extensionsMutex);
+      auto extensionIt = this->extensions.find(libName);
+      if (extensionIt != this->extensions.end())
+        extension = extensionIt->second;
+    }
+  }
+
+  if (!extension)
+    return nullptr;
+
+  if (!extension->IsInitialized())
+  {
+    extension->Load(_params);
+    extension->Init();
+  }
+
+  return extension;
+}
+
+//////////////////////////////////////////////////
+bool RenderEngineExtensionManagerPrivate::UnloadExtension(ExtensionIter _iter)
+{
+  RenderEngineExtension *extension = _iter->second;
+
+  if (!extension)
+    return false;
+
+  extension->Destroy();
+
+  return this->UnloadExtensionPlugin(_iter->first);
+}
+
+//////////////////////////////////////////////////
+void RenderEngineExtensionManagerPrivate::RegisterDefaultExtensions()
+{
+  // TODO(anyone): Find a cleaner way to get the default extension library name
+
+  // cppcheck-suppress unreadVariable
+  // std::string libName = "gz-rendering-";
+  std::string libName = "gz-waves1-rendering-";
+
+  // cppcheck-suppress unusedVariable
+  std::string extensionName;
+
+  std::lock_guard<std::recursive_mutex> lock(this->extensionsMutex);
+// #if HAVE_OGRE2
+  extensionName = "ogre2";
+  this->defaultExtensions[extensionName] = libName + extensionName;
+  if (this->extensions.find(libName + extensionName) == this->extensions.end())
+    this->extensions[libName + extensionName] = nullptr;
+// #endif
+}
+
+//////////////////////////////////////////////////
+bool RenderEngineExtensionManagerPrivate::LoadExtensionPlugin(
+    const std::string &_filename, const std::string &_path)
+{
+  gzmsg << "Loading plugin [" << _filename << "]" << std::endl;
+
+  gz::common::SystemPaths systemPaths;
+  systemPaths.SetPluginPathEnv(this->pluginPathEnv);
+
+  // Add default install folder.
+  systemPaths.AddPluginPaths(std::string(GZ_RENDERING_PLUGIN_PATH));
+  systemPaths.AddPluginPaths({GZ_RENDERING_ENGINE_INSTALL_DIR});
+
+  // Add any preset plugin paths.
+  for (const auto &path : this->pluginPaths)
+    systemPaths.AddPluginPaths(path);
+
+  // Add extra search path.
+  systemPaths.AddPluginPaths(_path);
+
+  auto pathToLib = systemPaths.FindSharedLibrary(_filename);
+
+  // Load plugin
+  auto pluginNames = this->pluginLoader.LoadLib(pathToLib);
+  if (pluginNames.empty())
+  {
+    gzerr << "Failed to load plugin [" << _filename <<
+              "] : couldn't load library on path [" << pathToLib <<
+              "]." << std::endl;
+    return false;
+  }
+
+  auto extensionNames = pluginLoader.PluginsImplementing<
+      gz::rendering::RenderEngineExtensionPlugin>();
+
+  if (extensionNames.empty())
+  {
+    std::stringstream error;
+    error << "Found no render extension plugins in ["
+          << _filename << "], available interfaces are:"
+          << std::endl;
+    for (auto pluginName : pluginNames)
+    {
+      error << "- " << pluginName << std::endl;
+    }
+    gzerr << error.str();
+    return false;
+  }
+
+  auto extensionName = *extensionNames.begin();
+  if (extensionNames.size() > 1)
+  {
+    std::stringstream warn;
+    warn << "Found multiple render extension plugins in ["
+          << _filename << "]:"
+          << std::endl;
+    for (auto pluginName : extensionNames)
+    {
+      warn << "- " << pluginName << std::endl;
+    }
+    warn << "Loading [" << extensionName << "]." << std::endl;
+    gzwarn << warn.str();
+  }
+
+  auto plugin = pluginLoader.Instantiate(extensionName);
+  if (!plugin)
+  {
+    gzerr << "Failed to instantiate plugin [" << extensionName << "]"
+           << std::endl;
+    return false;
+  }
+
+  auto renderPlugin =
+      plugin->QueryInterface<gz::rendering::RenderEngineExtensionPlugin>();
+
+  if (!renderPlugin)
+  {
+    gzerr << "Failed to query interface from [" << extensionName << "]"
+           << std::endl;
+    return false;
+  }
+
+  // This triggers the extension to be instantiated
+  {
+    std::lock_guard<std::recursive_mutex> lock(this->extensionsMutex);
+    this->extensions[_filename] = renderPlugin->Extension();
+  }
+
+  // store extension plugin data so plugin can be unloaded later
+  this->extensionPlugins[_filename] = extensionName;
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool RenderEngineExtensionManagerPrivate::UnloadExtensionPlugin(
+    const std::string &_extensionName)
+{
+  auto it = this->extensionPlugins.find(_extensionName);
+  if (it == this->extensionPlugins.end())
+  {
+    gzmsg << "Skip unloading extension plugin. [" << _extensionName << "] "
+           << "not loaded from plugin." << std::endl;
+    return false;
+  }
+
+  std::string pluginName = it->second;
+  this->extensionPlugins.erase(it);
+
+#ifndef _WIN32
+  // Unloading the plugin on windows causes tests to crash on exit
+  // see issue #45
+  if (!this->pluginLoader.ForgetLibraryOfPlugin(pluginName))
+  {
+    gzerr << "Failed to unload plugin: " << pluginName << std::endl;
+  }
+#endif
+
+  std::lock_guard<std::recursive_mutex> lock(this->extensionsMutex);
+  auto extensionIt = this->extensions.find(_extensionName);
+  if (extensionIt == this->extensions.end())
+    return false;
+
+  // set to null - this means extension is still registered but not loaded
+  this->extensions[_extensionName] = nullptr;
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+void RenderEngineExtensionManagerPrivate::UnregisterExtension(ExtensionIter _iter)
+{
+  _iter->second->Destroy();
+
+  std::lock_guard<std::recursive_mutex> lock(this->extensionsMutex);
+  this->extensions.erase(_iter);
+}

--- a/gz-waves/src/systems/waves/RenderEngineExtensionManager.hh
+++ b/gz-waves/src/systems/waves/RenderEngineExtensionManager.hh
@@ -1,0 +1,170 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Copied from gz-rendering RenderEngineManager
+
+/*
+ * Copyright (C) 2015 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GZ_RENDERING_RENDERENGINEEXTENSIONMANAGER_HH_
+#define GZ_RENDERING_RENDERENGINEEXTENSIONMANAGER_HH_
+
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include <gz/common/SingletonT.hh>
+#include <gz/utils/SuppressWarning.hh>
+#include <gz/rendering/config.hh>
+#include <gz/rendering/Export.hh>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+    //
+    // forward declarations.
+    class RenderEngineExtension;
+    class RenderEngineExtensionManagerPrivate;
+
+    /// \class RenderEngineExtensionManager RenderEngineExtensionManager.hh
+    /// gz/rendering/RenderEngineExtensionManager.hh
+    /// \brief Collection of render-engine extensions. This provides access to
+    /// all the extensions available at runtime.
+    /// RenderEngineExtension objects should not be access directly, but instead
+    /// via the RenderEngineExtensionManager to maintain a flexible
+    /// render-engine agnostic design.
+    class GZ_RENDERING_VISIBLE RenderEngineExtensionManager :
+      public virtual common::SingletonT<RenderEngineExtensionManager>
+    {
+      /// \brief Constructor
+      public: RenderEngineExtensionManager();
+
+      /// \brief Destructor
+      public: ~RenderEngineExtensionManager();
+
+      /// \brief Get the number of available extensions
+      /// \return the number of available extensions
+      public: unsigned int ExtensionCount() const;
+
+      /// \brief Determine if an extension with the given name is avaiable.
+      /// It also checks the list of default extensions supplied by
+      /// gz-rendering.
+      /// \param[in] _name Name of the desired extension
+      /// \return True if the specified extension is available
+      public: bool HasExtension(const std::string &_name) const;
+
+      /// \brief Determine if an extension with the given name is already
+      /// loaded.
+      /// \param[in] _name Name of the desired extension
+      /// \return True if the specified extension is loaded.
+      public: bool IsExtensionLoaded(const std::string &_name) const;
+
+      /// \brief Get the list of all extensions already loaded.
+      /// \return Names of all loaded extensions.
+      public: std::vector<std::string> LoadedExtensions() const;
+
+      /// \brief Get the extension with the given name. If the no
+      /// extension is registered under the given name, NULL will be
+      /// returned.
+      /// \param[in] _name Name of the desired extension
+      /// \param[in] _params Parameters to be passed to the extension.
+      /// \param[in] _path Another search path for extension plugin.
+      /// \return The specified extension
+      public: RenderEngineExtension *Extension(const std::string &_name,
+                  const std::map<std::string, std::string> &_params = {},
+                  const std::string &_path = "");
+
+      /// \brief Get the extension at the given index. If no
+      /// extension is exists at the given index, NULL will be returned.
+      /// \param[in] _index Index of the desired extension
+      /// \param[in] _params Parameters to be passed to the render engine.
+      /// \param[in] _path Another search path for rendering engine plugin.
+      /// \return The specified extension
+      public: RenderEngineExtension *ExtensionAt(unsigned int _index,
+                  const std::map<std::string, std::string> &_params = {},
+                  const std::string &_path = "");
+
+      /// \brief Unload the extension with the given name. If the no
+      /// extension is registered under the given name, false will be
+      /// returned.
+      /// \param[in] _name Name of the desired extension
+      /// \return  True if the engine is unloaded
+      public: bool UnloadExtension(const std::string &_name);
+
+      /// \brief Unload the extension at the given index. If the no
+      /// extension is registered under the given name, false will be
+      /// returned.
+      /// \param[in] _index Index of the desired extension
+      /// \return  True if the engine is unloaded
+      public: bool UnloadExtensionAt(unsigned int _index);
+
+      /// \brief Register a new extension under the given name. If the
+      /// given name is already in use, the extension will not be
+      /// registered.
+      /// \param[in] _name Name the extension will be registered under
+      /// \param[in] _engine Render-engine to be registered
+      public: void RegisterExtension(const std::string &_name,
+                  RenderEngineExtension *_engine);
+
+      /// \brief Unregister an extension registered under the given name.
+      /// If no extension is registered under the given name no work
+      /// will be done.
+      /// \param[in] _name Name of the extension to unregister
+      public: void UnregisterExtension(const std::string &_name);
+
+      /// \brief Unregister the given extension. If the given extension
+      /// is not currently registered, no work will be done.
+      /// \param[in] _engine Render-engine to unregister
+      public: void UnregisterExtension(RenderEngineExtension *_engine);
+
+      /// \brief Unregister an extension at the given index. If the no
+      /// extension is registered at the given index, no work will be done.
+      /// \param[in] _index Index of the extension to unregister
+      public: void UnregisterExtensionAt(unsigned int _index);
+
+      /// \brief Set the plugin paths from which render engines can be loaded.
+      /// \param[in] _paths The list of the plugin paths
+      public: void SetPluginPaths(const std::list<std::string> &_paths);
+
+      GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
+      /// \brief private implementation details
+      private: std::unique_ptr<RenderEngineExtensionManagerPrivate> dataPtr;
+      GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
+
+      /// \brief required SingletonT friendship
+      private: friend class
+          gz::common::SingletonT<RenderEngineExtensionManager>;
+    };
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/RenderEngineExtensionPlugin.cc
+++ b/gz-waves/src/systems/waves/RenderEngineExtensionPlugin.cc
@@ -1,0 +1,52 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Copied from gz-rendering RenderEnginePlugin.hh
+
+/*
+ * Copyright (C) 2018 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "RenderEngineExtensionPlugin.hh"
+
+class gz::rendering::RenderEngineExtensionPluginPrivate
+{
+};
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+RenderEngineExtensionPlugin::RenderEngineExtensionPlugin()
+    : dataPtr(new RenderEngineExtensionPluginPrivate)
+{
+}
+
+//////////////////////////////////////////////////
+RenderEngineExtensionPlugin::~RenderEngineExtensionPlugin() = default;
+

--- a/gz-waves/src/systems/waves/RenderEngineExtensionPlugin.hh
+++ b/gz-waves/src/systems/waves/RenderEngineExtensionPlugin.hh
@@ -1,0 +1,80 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Copied from gz-rendering RenderEnginePlugin.hh
+
+/*
+ * Copyright (C) 2018 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GZ_RENDERING_RENDERENGINEEXTENSIONPLUGIN_HH_
+#define GZ_RENDERING_RENDERENGINEEXTENSIONPLUGIN_HH_
+
+#include <memory>
+#include <string>
+
+#include <gz/utils/SuppressWarning.hh>
+#include <gz/rendering/config.hh>
+#include <gz/rendering/Export.hh>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+    //
+    // Forward declarations
+    class RenderEngineExtension;
+    class RenderEngineExtensionPluginPrivate;
+
+    /// \brief Base plugin class for render engine extensions
+    class GZ_RENDERING_VISIBLE RenderEngineExtensionPlugin
+    {
+      /// \brief Constructor
+      public: RenderEngineExtensionPlugin();
+
+      /// \brief Destructor
+      public: virtual ~RenderEngineExtensionPlugin();
+
+      /// \brief Get the name of extension
+      /// \return Name of render engine extension
+      public: virtual std::string Name() const = 0;
+
+      /// \brief Get a pointer to the extension
+      /// \return Render engine extension instance
+      public: virtual RenderEngineExtension *Extension() const = 0;
+
+      /// \brief Pointer to private data class
+      GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
+      public: std::unique_ptr<RenderEngineExtensionPluginPrivate> dataPtr;
+      GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
+    };
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/SceneNodeFactory.cc
+++ b/gz-waves/src/systems/waves/SceneNodeFactory.cc
@@ -1,0 +1,23 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "SceneNodeFactory.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+SceneNodeFactory::~SceneNodeFactory() = default;
+

--- a/gz-waves/src/systems/waves/SceneNodeFactory.hh
+++ b/gz-waves/src/systems/waves/SceneNodeFactory.hh
@@ -1,0 +1,60 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_RENDERING_SCENENODEFACTORY_HH_
+#define GZ_RENDERING_SCENENODEFACTORY_HH_
+
+#include "DisplacementMap.hh"
+#include "OceanGeometry.hh"
+#include "OceanVisual.hh"
+
+#include <gz/rendering/config.hh>
+#include <gz/rendering/Scene.hh>
+#include "gz/rendering/Export.hh"
+
+#include <memory>
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    class GZ_RENDERING_VISIBLE SceneNodeFactory
+    {
+      /// \brief Destructor
+      public: virtual ~SceneNodeFactory();
+
+      /// \brief Create an ocean visual
+      public: virtual OceanVisualPtr CreateOceanVisual(ScenePtr _scene) = 0;
+    
+      /// \brief Create an ocean geometry
+      public: virtual OceanGeometryPtr CreateOceanGeometry(ScenePtr _scene) = 0;
+
+      /// \brief Create a displacement map
+      public: virtual DisplacementMapPtr CreateDisplacementMap(
+          ScenePtr _scene,
+          MaterialPtr _material,
+          uint64_t _entity,
+          uint32_t _width,
+          uint32_t _height) = 0;
+    };
+
+    typedef std::shared_ptr<SceneNodeFactory> SceneNodeFactoryPtr;
+
+    }
+  }
+}
+#endif

--- a/gz-waves/src/systems/waves/WavesVisual.cc
+++ b/gz-waves/src/systems/waves/WavesVisual.cc
@@ -14,7 +14,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-// Code for retrieving shader params from gz-sim/src/systems/shader_param
+// Code for retrieving shader params copied from
+// gz-sim/src/systems/shader_param
 
 /*
  * Copyright (C) 2022 Open Source Robotics Foundation
@@ -35,8 +36,14 @@
 
 #include "WavesVisual.hh"
 
-#include "Ogre2OceanVisual.hh"
-#include "Ogre2OceanGeometry.hh"
+#include "DisplacementMap.hh"
+
+#include "OceanGeometry.hh"
+#include "OceanVisual.hh"
+#include "SceneNodeFactory.hh"
+
+#include "RenderEngineExtension.hh"
+#include "RenderEngineExtensionManager.hh"
 
 #include "gz/waves/OceanTile.hh"
 #include "gz/waves/Utilities.hh"
@@ -60,10 +67,6 @@
 
 #include <gz/rendering/Grid.hh>
 
-#include <gz/rendering/ogre2.hh>
-#include <gz/rendering/ogre2/Ogre2MeshFactory.hh>
-#include <gz/rendering/ogre2/Ogre2Scene.hh>
-
 #include <gz/transport/Node.hh>
 
 #include <gz/sim/components/Name.hh>
@@ -81,188 +84,8 @@
 #include <vector>
 #include <string>
 
-namespace gz
-{
-namespace rendering
-{
-inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-
-  // Subclass from Ogre2Mesh and Ogre2MeshFactory to get
-  // indirect access to protected members and override any
-  // behaviour that tries to load a gz::common::Mesh which we
-  // are not using.
-
-  //////////////////////////////////////////////////
-  class GZ_RENDERING_OGRE2_VISIBLE Ogre2MeshExt :
-      public Ogre2Mesh
-  {
-    /// \brief Destructor
-    public: virtual ~Ogre2MeshExt() {}
-
-    /// \brief Constructor
-    protected: explicit Ogre2MeshExt() : Ogre2Mesh() {}
-
-    /// \brief Allow intercept of pre-render call for this mesh
-    public: virtual void PreRender() override
-    {
-      Ogre2Mesh::PreRender();
-    }
-
-    /// \brief Work-around the protected accessors and protected methods in Scene
-    public: void InitObject(Ogre2ScenePtr _scene, unsigned int _id, const std::string &_name)
-    {
-      this->id = _id;
-      this->name = _name;
-      this->scene = _scene;
-
-      // initialize object
-      this->Load();
-      this->Init();
-    }
-
-    /// \brief Used by friend class (Ogre2MeshFactoryExt)
-    protected: void SetOgreItem(Ogre::Item *_ogreItem)
-    {
-      this->ogreItem = _ogreItem;
-    }
-
-    private: friend class Ogre2MeshFactoryExt;
-  };
-
-  typedef std::shared_ptr<Ogre2MeshExt> Ogre2MeshExtPtr;
-
-  //////////////////////////////////////////////////
-  class GZ_RENDERING_OGRE2_VISIBLE Ogre2MeshFactoryExt :
-      public Ogre2MeshFactory
-  {
-    /// \brief Destructor
-    public: virtual ~Ogre2MeshFactoryExt() {}
-
-    /// \brief Constructor - construct from an Ogre2ScenePtr
-    public: explicit Ogre2MeshFactoryExt(Ogre2ScenePtr _scene) :
-        Ogre2MeshFactory(_scene), ogre2Scene(_scene) {}
-
-    /// \brief Override - use an extension of Ogre2Mesh
-    public: virtual Ogre2MeshPtr Create(const MeshDescriptor &_desc) override
-    {
-      // create ogre entity
-      Ogre2MeshExtPtr mesh(new Ogre2MeshExt);
-      MeshDescriptor normDesc = _desc;
-      // \todo do this? override MeshDescriptor behaviour as we're not using gz::common::Mesh
-      normDesc.Load();
-      mesh->SetOgreItem(this->OgreItem(normDesc));
-
-      // check if invalid mesh
-      if (!mesh->ogreItem)
-      {
-        gzerr << "Failed to get Ogre item for [" << _desc.meshName << "]"
-                << std::endl;
-        return nullptr;
-      }
-
-      // create sub-mesh store
-      Ogre2SubMeshStoreFactory subMeshFactory(this->scene, mesh->ogreItem);
-      mesh->subMeshes = subMeshFactory.Create();
-      for (unsigned int i = 0; i < mesh->subMeshes->Size(); i++)
-      {
-        Ogre2SubMeshPtr submesh =
-            std::dynamic_pointer_cast<Ogre2SubMesh>(mesh->subMeshes->GetById(i));
-        submesh->SetMeshName(this->MeshName(_desc));
-      }
-      return mesh;
-    }
-
-    /// \brief Override \todo: may be able to use base class implementation...
-    protected: virtual Ogre::Item * OgreItem(const MeshDescriptor &_desc) override
-    {
-      if (!this->Load(_desc))
-      {
-        return nullptr;
-      }
-
-      std::string name = this->MeshName(_desc);
-      gzmsg << "Get Ogre::SceneManager\n";
-      Ogre::SceneManager *sceneManager = this->scene->OgreSceneManager();
-
-      gzmsg << "Check for v2 mesh\n";
-      // check if a v2 mesh already exists
-      Ogre::MeshPtr mesh =
-          Ogre::MeshManager::getSingleton().getByName(name);
-
-      // if not, it probably has not been imported from v1 yet
-      if (!mesh)
-      {
-        gzmsg << "Check for v1 mesh\n";
-        Ogre::v1::MeshPtr v1Mesh =
-            Ogre::v1::MeshManager::getSingleton().getByName(name);
-        if (!v1Mesh)
-        {
-          gzerr << "Did not find v1 mesh [" << name << "]\n";
-          return nullptr;
-        }
-
-        // examine v1 mesh properties
-        v1Mesh->load();
-        gzmsg << "v1 mesh: isLoaded: " << v1Mesh->isLoaded() << "\n";
-
-        gzmsg << "Creating v2 mesh\n";
-        // create v2 mesh from v1
-        mesh = Ogre::MeshManager::getSingleton().createManual(
-            name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-
-        gzmsg << "Importing v2 mesh\n";
-        mesh->importV1(v1Mesh.get(), false, true, true);
-        this->ogreMeshes.push_back(name);
-      }
-
-      return sceneManager->createItem(mesh, Ogre::SCENE_DYNAMIC);
-    }
-
-    /// \brief Override
-    protected: virtual bool LoadImpl(const MeshDescriptor &_desc) override
-    {
-      /// \todo: currently assume we've already loaded from the tile
-      /// but should handle better
-      return true;
-    }
-
-    /// \brief Override \todo: may be able to use base class implementation...
-    public: virtual bool Validate(const MeshDescriptor &_desc) override
-    {
-      if (!_desc.mesh && _desc.meshName.empty())
-      {
-        gzerr << "Invalid mesh-descriptor, no mesh specified" << std::endl;
-        return false;
-      }
-
-      if (!_desc.mesh)
-      {
-        gzerr << "Cannot load null mesh [" << _desc.meshName << "]" << std::endl;
-        return false;
-        // Override MeshDescriptor behaviour as we're not using gz::common::Mesh
-        // return true;
-      }
-
-      if (_desc.mesh->SubMeshCount() == 0)
-      {
-        gzerr << "Cannot load mesh with zero sub-meshes" << std::endl;
-        return false;
-      }
-
-      return true;
-    }
-
-    /// \brief Pointer to the derived Ogre2Scene
-    private: rendering::Ogre2ScenePtr ogre2Scene;
-
-  };
-
-  typedef std::shared_ptr<Ogre2MeshFactoryExt> Ogre2MeshFactoryExtPtr;
-}
-}
-}
-
 using namespace gz;
+using namespace rendering;
 using namespace sim;
 using namespace systems;
 
@@ -375,32 +198,16 @@ class gz::sim::systems::WavesVisualPrivate
   public: rendering::MaterialPtr oceanMaterial;
 
   /// \brief Pointer to ocean visual
-  public: std::vector<rendering::Ogre2OceanVisualPtr> oceanOgreVisuals;
-  public: std::vector<rendering::VisualPtr> oceanVisuals;
-  public: std::vector<rendering::Ogre2OceanGeometryPtr> oceanGeometries;
+  public: std::vector<rendering::OceanVisualPtr> oceanVisuals;
+  public: std::vector<rendering::VisualPtr> oceanVisuals2;
+  public: std::vector<rendering::OceanGeometryPtr> oceanGeometries;
 
   public: MeshDeformationMethod meshDeformationMethod{
       MeshDeformationMethod::DYNAMIC_GEOMETRY};
 
   /////////////////
   // DYNAMIC_TEXTURE
-
-  /// \note: new code adapted from ogre ocean materials sample
-  // textures for displacement, normal and tangent maps
-  Ogre::Image2       *mHeightMapImage;
-  Ogre::Image2       *mNormalMapImage;
-  Ogre::Image2       *mTangentMapImage;
-  Ogre::TextureGpu   *mHeightMapTex;
-  Ogre::TextureGpu   *mNormalMapTex;
-  Ogre::TextureGpu   *mTangentMapTex;
-
-  /// \note Triple buffer staging textures
-  Ogre::StagingTexture* mHeightMapStagingTextures[3];
-  Ogre::StagingTexture* mNormalMapStagingTextures[3];
-  Ogre::StagingTexture* mTangentMapStagingTextures[3];
-  uint8_t mHeightMapFrameIdx{0};
-  uint8_t mNormalMapFrameIdx{0};
-  uint8_t mTangentMapFrameIdx{0};
+  public: DisplacementMapPtr displacementMap;
 
   std::unique_ptr<gz::waves::WaveSimulation> mWaveSim;
   std::vector<double> mHeights;
@@ -464,17 +271,23 @@ class gz::sim::systems::WavesVisualPrivate
 
   /// \brief Connection to pre-render event callback
   public: gz::common::ConnectionPtr connection{nullptr};
+
+  /// \brief RenderEngineExtension
+  public: rendering::RenderEngineExtension *extension{nullptr};
+
 };
 
 /////////////////////////////////////////////////
 WavesVisual::WavesVisual()
     : System(), dataPtr(std::make_unique<WavesVisualPrivate>())
 {
+  gzmsg << "WavesVisual: constructing\n";
 }
 
 /////////////////////////////////////////////////
 WavesVisual::~WavesVisual()
 {
+  gzmsg << "WavesVisual: destructing\n";
 }
 
 /////////////////////////////////////////////////
@@ -687,49 +500,9 @@ WavesVisualPrivate::SetMeshDeformationMethod(const std::string &_str)
 //////////////////////////////////////////////////
 WavesVisualPrivate::~WavesVisualPrivate()
 {
-  // Remove staging textures
-  gz::rendering::Ogre2ScenePtr ogre2Scene =
-    std::dynamic_pointer_cast<gz::rendering::Ogre2Scene>(
-        this->scene);
-
-  if(ogre2Scene != nullptr)
-  {
-    Ogre::SceneManager *ogre2SceneManager = ogre2Scene->OgreSceneManager();
-
-    if (ogre2SceneManager != nullptr)
-    {
-      Ogre::TextureGpuManager *ogre2TextureManager =
-          ogre2SceneManager->getDestinationRenderSystem()->getTextureGpuManager();
-
-      if (ogre2TextureManager != nullptr)
-      {
-        for (uint8_t i=0; i<3; ++i)   {
-          if (mHeightMapStagingTextures[i]) {
-              ogre2TextureManager->removeStagingTexture(
-                  mHeightMapStagingTextures[i]);
-              mHeightMapStagingTextures[i] = nullptr;
-          }
-
-          if (mNormalMapStagingTextures[i]) {
-              ogre2TextureManager->removeStagingTexture(
-                  mNormalMapStagingTextures[i]);
-              mNormalMapStagingTextures[i] = nullptr;
-          }
-
-          if (mTangentMapStagingTextures[i]) {
-              ogre2TextureManager->removeStagingTexture(
-                  mTangentMapStagingTextures[i]);
-              mTangentMapStagingTextures[i] = nullptr;
-          }
-        }
-      }
-    }
-  }
-
   // Remove visuals
-  for (auto& ogreVisual : this->oceanVisuals)
+  for (auto& vis : this->oceanVisuals2)
   {
-    auto vis = ogreVisual;
     if (vis != nullptr)
     {
       vis->Destroy();
@@ -752,6 +525,16 @@ void WavesVisualPrivate::OnUpdate()
   }
 
   if (!this->scene)
+    return;
+
+  // load extensions
+  if (!this->extension)
+  {
+    extension = rendering::RenderEngineExtensionManager::Instance()->
+        Extension("ogre2");
+  }
+
+  if (!this->extension)
     return;
 
   if (!this->visual)
@@ -812,7 +595,7 @@ void WavesVisualPrivate::OnUpdate()
     case MeshDeformationMethod::DYNAMIC_GEOMETRY:
     {
       // Test attaching another visual to the entity
-      if (this->oceanVisuals.empty() && oceanOgreVisuals.empty())
+      if (this->oceanVisuals2.empty() && oceanVisuals.empty())
       {
         gzmsg << "WavesVisual: creating dynamic geometry ocean visual\n";
 
@@ -834,10 +617,6 @@ void WavesVisualPrivate::OnUpdate()
         // create mesh - do not store in MeshManager as it will be modified
         this->oceanTileMesh.reset(this->oceanTile->CreateMesh());
 
-        // scene: use in object initialisation work-around
-        rendering::Ogre2ScenePtr ogre2Scene =
-            std::dynamic_pointer_cast<rendering::Ogre2Scene>(this->scene);
-
         // Hide the primary visual
         this->visual->SetVisible(false);
 
@@ -845,6 +624,9 @@ void WavesVisualPrivate::OnUpdate()
         // rather than multiple visuals referencing one mesh and instancing?
 
         // Water tiles: tiles_x[0], tiles_x[0] + 1, ..., tiles_x[1], etc.
+        rendering::SceneNodeFactoryPtr sceneNodeFactory =
+            this->extension->SceneNodeFactory();
+
         unsigned int objId = 50000;
         auto position = this->visual->LocalPosition();
         for (int iy=this->tiles_y[0]; iy<=this->tiles_y[1]; ++iy)
@@ -866,22 +648,18 @@ void WavesVisualPrivate::OnUpdate()
             std::string objName = ss.str();
 
             // create visual
-            // gzmsg << "Creating visual: tile: ["
-            //     << ix << ", " << iy << "]"
-            //     << ", name: " << objName << "\n";
-            rendering::Ogre2OceanVisualPtr ogreVisual =
-                std::make_shared<rendering::Ogre2OceanVisual>(); 
-            ogreVisual->InitObject(ogre2Scene, objId, objName);
-            ogreVisual->LoadMesh(this->oceanTileMesh);
+            rendering::OceanVisualPtr oceanVisual =
+                sceneNodeFactory->CreateOceanVisual(this->scene);
 
-            ogreVisual->SetLocalPosition(tilePosition);
-            ogreVisual->SetMaterial(this->oceanMaterial, false);
-            ogreVisual->SetVisible(true);
+            oceanVisual->LoadMesh(this->oceanTileMesh);
+            oceanVisual->SetLocalPosition(tilePosition);
+            oceanVisual->SetMaterial(this->oceanMaterial, false);
+            oceanVisual->SetVisible(true);
 
             // add visual to parent
             auto parent = this->visual->Parent();
-            parent->AddChild(ogreVisual);
-            this->oceanOgreVisuals.push_back(ogreVisual);
+            parent->AddChild(oceanVisual);
+            this->oceanVisuals.push_back(oceanVisual);
 #else
             // create name
             std::stringstream ss;
@@ -893,29 +671,24 @@ void WavesVisualPrivate::OnUpdate()
             oceanVisual->SetLocalPosition(tilePosition);
 
             // create geometry
-            // gzmsg << "Creating geometry: tile: ["
-            //     << ix << ", " << iy << "]"
-            //     << ", name: " << objName << "\n";
-            auto geometry =
-                std::make_shared<rendering::Ogre2OceanGeometry>();
-            geometry->InitObject(ogre2Scene, objId, objName);
+            rendering::OceanGeometryPtr geometry =
+                sceneNodeFactory->CreateOceanGeometry(this->scene);
+
             geometry->LoadMesh(this->oceanTileMesh);
-
             geometry->SetMaterial(this->oceanMaterial, false);
-
             oceanVisual->AddGeometry(geometry);
 
             // add visual to parent
             auto parent = this->visual->Parent();
             parent->AddChild(oceanVisual);
-            this->oceanVisuals.push_back(oceanVisual);
+            this->oceanVisuals2.push_back(oceanVisual);
             this->oceanGeometries.push_back(geometry);
 #endif
           }
         }
       }
 
-      if ((this->oceanVisuals.empty() && oceanOgreVisuals.empty()) || this->isStatic)
+      if ((this->oceanVisuals2.empty() && oceanVisuals.empty()) || this->isStatic)
         return;
 
       if (this->waveParamsDirty)
@@ -930,7 +703,7 @@ void WavesVisualPrivate::OnUpdate()
       this->oceanTile->UpdateMesh(simTime, this->oceanTileMesh.get());
 
 #if GZ_WAVES_UPDATE_VISUALS
-      for (auto& vis : this->oceanOgreVisuals)
+      for (auto& vis : this->oceanVisuals)
       {
         vis->UpdateMesh(this->oceanTileMesh);
       }
@@ -945,22 +718,13 @@ void WavesVisualPrivate::OnUpdate()
     case MeshDeformationMethod::DYNAMIC_TEXTURE:
     {
       // Test attaching a gz::common::Mesh to the entity
-      if (this->oceanVisuals.empty())
+      if (this->oceanVisuals2.empty())
       {
         gzmsg << "WavesVisual: creating dynamic texture ocean visual\n";
 
         // create shader material
         this->CreateShaderMaterial();
 
-        /// \note: replaced with cloned geometry from primary visual 
-        // load mesh
-        // std::string meshPath = gz::common::findFile(
-        //     asFullPath("materials/mesh_256x256.dae", this->modelPath));
-        // rendering::MeshDescriptor descriptor;
-        // descriptor.meshName = meshPath;
-        // gz::common::MeshManager *meshManager = gz::common::MeshManager::Instance();
-        // descriptor.mesh = meshManager->Load(descriptor.meshName);
- 
         // Hide the primary visual
         this->visual->SetVisible(false);
 
@@ -997,7 +761,7 @@ void WavesVisualPrivate::OnUpdate()
             // add visual to parent
             auto parent = this->visual->Parent();
             parent->AddChild(oceanVisual);
-            this->oceanVisuals.push_back(oceanVisual);
+            this->oceanVisuals2.push_back(oceanVisual);
          }
         }
 
@@ -1006,7 +770,7 @@ void WavesVisualPrivate::OnUpdate()
         this->InitTextures();
       }
 
-      if (this->oceanVisuals.empty() || this->isStatic)
+      if (this->oceanVisuals2.empty() || this->isStatic)
         return;
 
       if (this->waveParamsDirty)
@@ -1302,196 +1066,12 @@ void WavesVisualPrivate::InitTextures()
 
   // ocean tile parameters
   uint32_t N = static_cast<uint32_t>(this->waveParams->CellCount());
-  double L   = this->waveParams->TileSize();
-  double ux  = this->waveParams->WindVelocity().X();
-  double uy  = this->waveParams->WindVelocity().Y();
 
-  if (!this->oceanMaterial)
-  {
-    gzerr << "Invalid Ocean Material\n";
-    return;
-  }
-
-  gz::rendering::Ogre2ScenePtr ogre2Scene =
-    std::dynamic_pointer_cast<gz::rendering::Ogre2Scene>(
-        this->scene);
-
-  gz::rendering::Ogre2MaterialPtr ogre2Material =
-    std::dynamic_pointer_cast<gz::rendering::Ogre2Material>(
-        this->oceanMaterial);
-
-  Ogre::SceneManager *ogre2SceneManager = ogre2Scene->OgreSceneManager();
-
-  Ogre::TextureGpuManager *ogre2TextureManager =
-      ogre2SceneManager->getDestinationRenderSystem()->getTextureGpuManager();
-
-  // Create empty image
-  uint32_t width{N};
-  uint32_t height{N};
-  uint32_t depthOrSlices{1};
-  Ogre::TextureTypes::TextureTypes textureType{
-      Ogre::TextureTypes::TextureTypes::Type2D};
-  Ogre::PixelFormatGpu format{
-      Ogre::PixelFormatGpu::PFG_RGBA32_FLOAT};
-  uint8_t numMipmaps{1u};
-
-  gzmsg << "Create HeightMap image\n";
-  mHeightMapImage = new Ogre::Image2();
-  mHeightMapImage->createEmptyImage(width, height, depthOrSlices,
-      textureType, format, numMipmaps);
-
-  gzmsg << "Create NormalMap image\n";
-  mNormalMapImage = new Ogre::Image2();
-  mNormalMapImage->createEmptyImage(width, height, depthOrSlices,
-      textureType, format, numMipmaps);
-
-  gzmsg << "Create TangentMap image\n";
-  mTangentMapImage = new Ogre::Image2();
-  mTangentMapImage->createEmptyImage(width, height, depthOrSlices,
-      textureType, format, numMipmaps);
-
-  gzmsg << "Initialising images\n";
-  memset(mHeightMapImage->getRawBuffer(), 0, sizeof(float) * 4 * width * height);
-  memset(mNormalMapImage->getRawBuffer(), 0, sizeof(float) * 4 * width * height);
-  memset(mTangentMapImage->getRawBuffer(), 0, sizeof(float) * 4 * width * height);
-
-  // Create displacement texture
-  gzmsg << "Create HeightMap texture\n";
-  mHeightMapTex = ogre2TextureManager->createTexture(
-      "HeightMapTex(" + std::to_string(this->entity) + ")",
-      Ogre::GpuPageOutStrategy::SaveToSystemRam,
-      Ogre::TextureFlags::ManualTexture,
-      Ogre::TextureTypes::Type2D );
-
-  mHeightMapTex->setResolution(mHeightMapImage->getWidth(),
-      mHeightMapImage->getHeight());
-  mHeightMapTex->setPixelFormat(mHeightMapImage->getPixelFormat());
-  mHeightMapTex->setNumMipmaps(Ogre::PixelFormatGpuUtils::getMaxMipmapCount(
-      mHeightMapTex->getWidth(), mHeightMapTex->getHeight()));
-
-  // Create normal texture
-  gzmsg << "Create NormalMap texture\n";
-  mNormalMapTex = ogre2TextureManager->createTexture(
-      "NormalMapTex(" + std::to_string(this->entity) + ")",
-      Ogre::GpuPageOutStrategy::SaveToSystemRam,
-      Ogre::TextureFlags::ManualTexture,
-      Ogre::TextureTypes::Type2D );
-
-  mNormalMapTex->setResolution(mNormalMapImage->getWidth(),
-      mNormalMapImage->getHeight());
-  mNormalMapTex->setPixelFormat(mNormalMapImage->getPixelFormat());
-  mNormalMapTex->setNumMipmaps(Ogre::PixelFormatGpuUtils::getMaxMipmapCount(
-      mNormalMapTex->getWidth(), mNormalMapTex->getHeight()));
-
-  // Create tangent texture
-  gzmsg << "Create TangentMap texture\n";
-  mTangentMapTex = ogre2TextureManager->createTexture(
-      "TangentMapTex(" + std::to_string(this->entity) + ")",
-      Ogre::GpuPageOutStrategy::SaveToSystemRam,
-      Ogre::TextureFlags::ManualTexture,
-      Ogre::TextureTypes::Type2D );
-
-  mTangentMapTex->setResolution(mTangentMapImage->getWidth(),
-      mTangentMapImage->getHeight());
-  mTangentMapTex->setPixelFormat(mTangentMapImage->getPixelFormat());
-  mTangentMapTex->setNumMipmaps(Ogre::PixelFormatGpuUtils::getMaxMipmapCount(
-      mTangentMapTex->getWidth(), mTangentMapTex->getHeight()));
-
-  // Set texture on wave material
-  gzmsg << "Assign dynamic textures to material\n";
-  auto mat = ogre2Material->Material();
-  auto pass = mat->getTechnique(0u)->getPass(0);
-  auto ogreParams = pass->getVertexProgramParameters();
-
-  {
-    auto texUnit = pass->getTextureUnitState("heightMap");
-    if (!texUnit)
-    {
-      texUnit = pass->createTextureUnitState();
-      texUnit->setName("heightMap");
-    }
-    texUnit->setTexture(mHeightMapTex);
-    texUnit->setTextureCoordSet(0);
-    int texIndex = static_cast<int>(pass->getTextureUnitStateIndex(texUnit));
-
-    gzmsg << "texNameStr:   " << mHeightMapTex->getNameStr() << "\n";
-    gzmsg << "texCoordSet:  " << 0 << "\n";
-    gzmsg << "texIndex:     " << texIndex << "\n";
-
-    // set to wrap mode otherwise default is clamp mode
-    Ogre::HlmsSamplerblock samplerBlockRef;
-    samplerBlockRef.mU = Ogre::TAM_WRAP;
-    samplerBlockRef.mV = Ogre::TAM_WRAP;
-    samplerBlockRef.mW = Ogre::TAM_WRAP;
-    texUnit->setSamplerblock(samplerBlockRef);
-
-    if (rendering::Ogre2RenderEngine::Instance()->GraphicsAPI() ==
-        rendering::GraphicsAPI::OPENGL)
-    {
-      // set the texture map index
-      ogreParams->setNamedConstant("heightMap", &texIndex, 1, 1);
-    }
-  }
-
-  {
-    auto texUnit = pass->getTextureUnitState("normalMap");
-    if (!texUnit)
-    {
-      texUnit = pass->createTextureUnitState();
-      texUnit->setName("normalMap");
-    }
-    texUnit->setTexture(mNormalMapTex);
-    texUnit->setTextureCoordSet(0);
-    int texIndex = static_cast<int>(pass->getTextureUnitStateIndex(texUnit));
-
-    gzmsg << "texNameStr:   " << mNormalMapTex->getNameStr() << "\n";
-    gzmsg << "texCoordSet:  " << 0 << "\n";
-    gzmsg << "texIndex:     " << texIndex << "\n";
-
-    // set to wrap mode otherwise default is clamp mode
-    Ogre::HlmsSamplerblock samplerBlockRef;
-    samplerBlockRef.mU = Ogre::TAM_WRAP;
-    samplerBlockRef.mV = Ogre::TAM_WRAP;
-    samplerBlockRef.mW = Ogre::TAM_WRAP;
-    texUnit->setSamplerblock(samplerBlockRef);
-
-    if (rendering::Ogre2RenderEngine::Instance()->GraphicsAPI() ==
-        rendering::GraphicsAPI::OPENGL)
-    {
-      // set the texture map index
-      ogreParams->setNamedConstant("normalMap", &texIndex, 1, 1);
-    }
-  }
-
-  {
-    auto texUnit = pass->getTextureUnitState("tangentMap");
-    if (!texUnit)
-    {
-      texUnit = pass->createTextureUnitState();
-      texUnit->setName("tangentMap");
-    }
-    texUnit->setTexture(mTangentMapTex);
-    texUnit->setTextureCoordSet(0);
-    int texIndex = static_cast<int>(pass->getTextureUnitStateIndex(texUnit));
-
-    gzmsg << "texNameStr:   " << mTangentMapTex->getNameStr() << "\n";
-    gzmsg << "texCoordSet:  " << 0 << "\n";
-    gzmsg << "texIndex:     " << texIndex << "\n";
-
-    // set to wrap mode otherwise default is clamp mode
-    Ogre::HlmsSamplerblock samplerBlockRef;
-    samplerBlockRef.mU = Ogre::TAM_WRAP;
-    samplerBlockRef.mV = Ogre::TAM_WRAP;
-    samplerBlockRef.mW = Ogre::TAM_WRAP;
-    texUnit->setSamplerblock(samplerBlockRef);
-
-    if (rendering::Ogre2RenderEngine::Instance()->GraphicsAPI() ==
-        rendering::GraphicsAPI::OPENGL)
-    {
-      // set the texture map index
-      ogreParams->setNamedConstant("tangentMap", &texIndex, 1, 1);
-    }
-  }
+  rendering::SceneNodeFactoryPtr sceneNodeFactory =
+      this->extension->SceneNodeFactory();
+  this->displacementMap = sceneNodeFactory->CreateDisplacementMap(
+    this->scene, this->oceanMaterial, this->entity, N, N);
+  this->displacementMap->InitTextures();
 }
 
 //////////////////////////////////////////////////
@@ -1529,173 +1109,26 @@ void WavesVisualPrivate::UpdateUniforms()
   }
 }
 
-//////////////////////////////////////////////////
+// //////////////////////////////////////////////////
 void WavesVisualPrivate::UpdateTextures()
 {
-  gz::rendering::Ogre2ScenePtr ogre2Scene =
-    std::dynamic_pointer_cast<gz::rendering::Ogre2Scene>(
-        this->scene);
-
-  Ogre::SceneManager *ogre2SceneManager = ogre2Scene->OgreSceneManager();
-
-  Ogre::TextureGpuManager *ogre2TextureManager =
-      ogre2SceneManager->getDestinationRenderSystem()->getTextureGpuManager();
-
-  // update the image data
-  uint32_t width  = mHeightMapImage->getWidth();
-  uint32_t height = mHeightMapImage->getHeight();
-
-  Ogre::TextureBox heightBox  = mHeightMapImage->getData(0);
-  Ogre::TextureBox normalBox  = mNormalMapImage->getData(0);
-  Ogre::TextureBox tangentBox = mTangentMapImage->getData(0);
-
-  for (uint32_t iv=0; iv < height; ++iv)
-  {
-      /// \todo: coordinates are flipped in the vertex shader
-      // texture index to vertex index
-      int32_t iy = /*height - 1 - */ iv;
-      for (uint32_t iu=0; iu < width; ++iu)
-      {
-          // texture index to vertex index
-          int32_t ix = /* width - 1 - */ iu;
-
-          float Dx{0.0}, Dy{0.0}, Dz{0.0};
-          float Tx{1.0}, Ty{0.0}, Tz{0.0};
-          float Bx{0.0}, By{1.0}, Bz{0.0};
-          float Nx{0.0}, Ny{0.0}, Nz{1.0};
-
-          int32_t idx = iy * width + ix;
-          double h  = mHeights[idx];
-          double sx = mDisplacementsX[idx];
-          double sy = mDisplacementsY[idx];
-          double dhdx  = mDhdx[idx]; 
-          double dhdy  = mDhdy[idx]; 
-          double dsxdx = mDxdx[idx]; 
-          double dsydy = mDydy[idx]; 
-          double dsxdy = mDxdy[idx]; 
-
-          // vertex displacements
-          Dx += sy;
-          Dy += sx;
-          Dz  = h;
-
-          // tangents
-          Tx = dsydy + 1.0;
-          Ty = dsxdy;
-          Tz = dhdy;
-
-          // bitangents
-          Bx = dsxdy;
-          By = dsxdx + 1.0;
-          Bz = dhdx;
-
-          // normals N = T x B
-          Nx = 1.0 * (Ty*Bz - Tz*Bx);
-          Ny = 1.0 * (Tz*Bx - Tx*Bz);
-          Nz = 1.0 * (Tx*By - Ty*Bx);
-
-          heightBox.setColourAt(Ogre::ColourValue(Dx, Dy, Dz, 0.0), iu, iv, 0,
-              mHeightMapImage->getPixelFormat());
-          normalBox.setColourAt(Ogre::ColourValue(Nx, Ny, Nz, 0.0), iu, iv, 0,
-              mNormalMapImage->getPixelFormat());
-          tangentBox.setColourAt(Ogre::ColourValue(Tx, Ty, Tz, 0.0), iu, iv, 0,
-              mTangentMapImage->getPixelFormat());
-      }
-  }
-
-  // schedule update to GPU
-  mHeightMapTex->scheduleTransitionTo(Ogre::GpuResidency::Resident, nullptr);
-  mNormalMapTex->scheduleTransitionTo(Ogre::GpuResidency::Resident, nullptr);
-  mTangentMapTex->scheduleTransitionTo(Ogre::GpuResidency::Resident, nullptr);
-
-  // Staging texture is required for upload from CPU -> GPU
-  {
-    if (!mHeightMapStagingTextures[mHeightMapFrameIdx]) {
-        mHeightMapStagingTextures[mHeightMapFrameIdx] =
-            ogre2TextureManager->getStagingTexture(
-                mHeightMapImage->getWidth(),
-                mHeightMapImage->getHeight(),
-                1u, 1u,
-                mHeightMapImage->getPixelFormat(),
-                100u);
-    }
-
-    Ogre::StagingTexture *stagingTexture = mHeightMapStagingTextures[mHeightMapFrameIdx];
-    mHeightMapFrameIdx = (mHeightMapFrameIdx + 1) % 3;
-
-    stagingTexture->startMapRegion();
-    Ogre::TextureBox texBox = stagingTexture->mapRegion(
-        mHeightMapImage->getWidth(), mHeightMapImage->getHeight(), 1u, 1u,
-        mHeightMapImage->getPixelFormat());
-
-    texBox.copyFrom(mHeightMapImage->getData(0));
-    stagingTexture->stopMapRegion();
-    stagingTexture->upload(texBox, mHeightMapTex, 0, 0, 0);
-    if (!mHeightMapTex->isDataReady()) {
-        mHeightMapTex->notifyDataIsReady();
-    }
-  }
-
-  {
-    if (!mNormalMapStagingTextures[mNormalMapFrameIdx]) {
-        mNormalMapStagingTextures[mNormalMapFrameIdx] =
-            ogre2TextureManager->getStagingTexture(
-                mNormalMapImage->getWidth(),
-                mNormalMapImage->getHeight(),
-                1u, 1u,
-                mNormalMapImage->getPixelFormat(),
-                100u);
-    }
-
-    Ogre::StagingTexture *stagingTexture = mNormalMapStagingTextures[mNormalMapFrameIdx];
-    mNormalMapFrameIdx = (mNormalMapFrameIdx + 1) % 3;
-    
-    stagingTexture->startMapRegion();
-    Ogre::TextureBox texBox = stagingTexture->mapRegion(
-        mNormalMapImage->getWidth(), mNormalMapImage->getHeight(), 1u, 1u,
-        mNormalMapImage->getPixelFormat());
-
-    texBox.copyFrom(mNormalMapImage->getData(0));
-    stagingTexture->stopMapRegion();
-    stagingTexture->upload(texBox, mNormalMapTex, 0, 0, 0);
-    if (!mNormalMapTex->isDataReady()) {
-        mNormalMapTex->notifyDataIsReady();
-    }
-  }
-
-  {
-    if (!mTangentMapStagingTextures[mTangentMapFrameIdx]) {
-        mTangentMapStagingTextures[mTangentMapFrameIdx] =
-            ogre2TextureManager->getStagingTexture(
-                mTangentMapImage->getWidth(),
-                mTangentMapImage->getHeight(),
-                1u, 1u,
-                mTangentMapImage->getPixelFormat(),
-                100u);
-    }
-
-    Ogre::StagingTexture *stagingTexture = mTangentMapStagingTextures[mTangentMapFrameIdx];
-    mTangentMapFrameIdx = (mTangentMapFrameIdx + 1) % 3;
-
-    stagingTexture->startMapRegion();
-    Ogre::TextureBox texBox = stagingTexture->mapRegion(
-        mTangentMapImage->getWidth(), mTangentMapImage->getHeight(), 1u, 1u,
-        mTangentMapImage->getPixelFormat());
-
-    texBox.copyFrom(mTangentMapImage->getData(0));
-    stagingTexture->stopMapRegion();
-    stagingTexture->upload(texBox, mTangentMapTex, 0, 0, 0);
-    if (!mTangentMapTex->isDataReady()) {
-      mTangentMapTex->notifyDataIsReady();
-    }
-  }
+  this->displacementMap->UpdateTextures(
+    this->mHeights,
+    this->mDhdx,
+    this->mDhdy,
+    this->mDisplacementsX,
+    this->mDisplacementsY,
+    this->mDxdx,
+    this->mDydy,
+    this->mDxdy
+  );
 }
 
 //////////////////////////////////////////////////
 GZ_ADD_PLUGIN(WavesVisual,
-                    gz::sim::System,
-                    WavesVisual::ISystemConfigure,
-                    WavesVisual::ISystemPreUpdate)
+              gz::sim::System,
+              WavesVisual::ISystemConfigure,
+              WavesVisual::ISystemPreUpdate)
 
 GZ_ADD_PLUGIN_ALIAS(WavesVisual,
   "gz::sim::systems::WavesVisual")


### PR DESCRIPTION
This PR adds the ability to control the order in which the rendering extension code in the `WavesVisual` plugin is loaded. The Ogre2 dependent code in the WaveVisual plugin is moved into a rendering plugin library which removes the need to directly link the system plugin to the ogre2 render engine.

## Details

We use the same approach as `gz-rendering`, using copies of the `RenderEngineManager` and associated classes to manage the loading and lifetime of render extension plugins. The `WavesVisual` plugin links against abstract base classes that are implemented by render engine specific extension plugins.

The render extension provides access to an abstract `SceneNodeFactory` class which provides methods to create the render extension objects needed by the waves rendering code (namely a custom `Visual` object and a class to load dynamic textures for custom shaders). 

## Testing

There are two ocean rendering approaches: dynamic geometry using HlmsPbs and dynamic texture using a custom shader that applies a displacement map to the vertices. Before this change, when running the dynamic geometry example on a M1 mac (arm64), it was necessary to load the client process first then the server to avoid a crash resulting from an invalid scene pointer. The custom shader example did not work at all. Both examples now work correctly (server / client start order is not important).

The examples also run on an Ubuntu VM using llvmpipe software rendering.

