### PR TITLE
Hydrodynamics: add link level buoyancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,15 +314,29 @@ The waves visual plugin has the same algorithm elements as the model plugin and 
 
 - The `filename` and `name` attributes for the hydrodynamics plugin have changed.
 - The hydrodynamics parameters are now scoped in an additional `<hydrodynamics>` element.
-- The `<wave_model>` element is not currently used.
+- The buoyancy and hydrodynamics forces can be applied to specific entities
+in a model using the `<enable>` element. The parameter should be a fully
+scoped model entity (model, link or collision name).
+- The `<wave_model>` element is not used.
 
 ```xml
 <plugin
   filename="gz-waves1-hydrodynamics-system"
   name="gz::sim::systems::Hydrodynamics">
 
-   <!-- Hydrodynamics -->
-   <hydrodynamics>
+  <!-- Apply hydrodynamics to the entire model (default) -->
+  <enable>model_name</enable>
+
+  <!-- Or apply hydrodynamics to named links -->
+  <enable>model_name::link1</enable>
+  <enable>model_name::link2</enable>
+
+  <!-- Or apply hydrodynamics to named collisions -->
+  <enable>model_name::link1::collision1</enable>
+  <enable>model_name::link1::collision2</enable>
+
+  <!-- Hydrodynamics -->
+  <hydrodynamics>
     <damping_on>1</damping_on>
     <viscous_drag_on>1</viscous_drag_on>
     <pressure_drag_on>1</pressure_drag_on>

--- a/gz-waves-models/worlds/graded_buoyancy_waves.sdf
+++ b/gz-waves-models/worlds/graded_buoyancy_waves.sdf
@@ -1,0 +1,486 @@
+<?xml version="1.0" ?>
+<!--
+  This is the Gazebo buoyancy plugin demo from gz-sim adapted to work
+  with gz-waves instead of the buoyancy system with graded buoyancy.
+  
+  This world demonstrates a graded buoyancy world consisting of some
+  basic shapes which should eventually float up.
+
+  Modifications
+
+  - The water plane is replaced with the waves model.
+  - The world level gz-sim-buoyancy-system is replaced with
+    the model level gz-waves1-hydrodynamics-system.
+  - Damping and drag forces are disabled.
+  - The mass and inertia for the models have been recalculated.
+  - The centre of mass has been moved slightly below the centre of
+    volume to improve the stability of each shape.
+  - Materials have been added to each shape to aid identification.
+-->
+<sdf version="1.6">
+  <world name="buoyancy">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+      <sky></sky>
+    </scene>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <include>
+      <pose>0 0 0 0 0 0</pose>
+      <uri>model://waves</uri>
+    </include>
+
+    <model name='lighter_than_water'>
+      <pose>0 0 0 0 0 0</pose>
+      <!-- This red sphere should bob up and down. -->
+      <model name="ball">
+        <plugin
+          filename="gz-waves1-hydrodynamics-system"
+          name="gz::sim::systems::Hydrodynamics">
+          <enable>lighter_than_water::ball</enable>
+          <hydrodynamics>
+              <damping_on>0</damping_on>
+              <viscous_drag_on>0</viscous_drag_on>
+              <pressure_drag_on>0</pressure_drag_on>
+          </hydrodynamics>
+        </plugin>
+        <link name='body'>
+          <pose>0 0 0 0 0 0</pose>
+          <inertial>
+            <mass>15</mass>
+            <inertia>
+              <ixx>0.24</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>0.24</iyy>
+              <iyz>0</iyz>
+              <izz>0.24</izz>
+            </inertia>
+          </inertial>
+          <visual name='body_visual'>
+            <geometry>
+              <sphere>
+                <radius>0.2</radius>
+              </sphere>
+            </geometry>
+            <material>
+              <ambient>1 0 0 1</ambient>
+              <diffuse>1 0 0 1</diffuse>
+              <specular>0.8 0.8 0.8 1</specular>
+            </material>
+          </visual>
+          <collision name='body_collision'>
+            <geometry>
+              <sphere>
+                <radius>0.2</radius>
+              </sphere>
+            </geometry>
+          </collision>
+        </link>
+      </model>
+
+      <!-- This green box should float. -->
+      <model name='box'>
+        <plugin
+          filename="gz-waves1-hydrodynamics-system"
+          name="gz::sim::systems::Hydrodynamics">
+          <enable>lighter_than_water::box</enable>
+          <hydrodynamics>
+              <damping_on>0</damping_on>
+              <viscous_drag_on>0</viscous_drag_on>
+              <pressure_drag_on>0</pressure_drag_on>
+          </hydrodynamics>
+        </plugin>
+        <pose>3 3 0 0.3 0.2 0.1</pose>
+        <link name='body'>
+          <inertial>
+            <mass>200</mass>
+            <inertia>
+              <ixx>33.33</ixx>
+              <ixy>0</ixy>
+              <ixz>0</ixz>
+              <iyy>33.33</iyy>
+              <iyz>0</iyz>
+              <izz>33.33</izz>
+            </inertia>
+          </inertial>
+          <visual name='body_visual'>
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+            <material>
+              <ambient>0 1 0 1</ambient>
+              <diffuse>0 1 0 1</diffuse>
+              <specular>0.8 0.8 0.8 1</specular>
+            </material>
+          </visual>
+          <collision name='body_collision'>
+            <geometry>
+               <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+        </link>
+      </model>
+    </model>
+
+    <!-- This yellow balloon should shoot up -->
+    <model name='balloon_lighter_than_air'>
+      <plugin
+        filename="gz-waves1-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <enable>balloon_lighter_than_air::body</enable>
+        <hydrodynamics>
+            <damping_on>0</damping_on>
+            <viscous_drag_on>0</viscous_drag_on>
+            <pressure_drag_on>0</pressure_drag_on>
+        </hydrodynamics>
+      </plugin>
+      <pose>0 -3 -0.1 0 0 0</pose>
+      <link name='body'>
+        <pose>0 0 0 0 0 0</pose>
+        <inertial>
+          <mass>0.1</mass>
+          <inertia>
+            <ixx>0.0016</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.0016</iyy>
+            <iyz>0</iyz>
+            <izz>0.0016</izz>
+          </inertia>
+        </inertial>
+        <visual name='body_visual'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>1 1 0 1</ambient>
+            <diffuse>1 1 0 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name='body_collision'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- This teal box is neutrally buoyant and therefore should stay still -->
+    <model name='box_neutral_buoyancy'>
+      <plugin
+        filename="gz-waves1-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <enable>box_neutral_buoyancy</enable>
+        <hydrodynamics>
+            <damping_on>0</damping_on>
+            <viscous_drag_on>0</viscous_drag_on>
+            <pressure_drag_on>0</pressure_drag_on>
+        </hydrodynamics>
+      </plugin>
+      <pose>0 3 -3 0 0 0</pose>
+      <link name='body'>
+        <inertial>
+          <mass>998.6</mass>
+          <pose>0 0 -0.1 0 0 0</pose>
+          <inertia>
+            <ixx>166.4333333</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>166.4333333</iyy>
+            <iyz>0</iyz>
+            <izz>166.4333333</izz>
+          </inertia>
+        </inertial>
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 1 1</ambient>
+            <diffuse>0 1 1 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name='body_collision'>
+          <geometry>
+             <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!--
+      This orange box is neutrally buoyant and therefore should stay still.
+      Its link origin is above water, but its collision is below.
+    -->
+    <model name='box_neutral_buoyancy_collision_offset'>
+      <plugin
+        filename="gz-waves1-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <enable>box_neutral_buoyancy_collision_offset::body::buoyancy_volume</enable>
+        <hydrodynamics>
+            <damping_on>0</damping_on>
+            <viscous_drag_on>0</viscous_drag_on>
+            <pressure_drag_on>0</pressure_drag_on>
+        </hydrodynamics>
+      </plugin>
+      <pose>-3 3 2 0 0 0</pose>
+      <link name='body'>
+        <inertial>
+          <mass>998.6</mass>
+          <pose>0 0 -5.1 0 0 0</pose>
+          <inertia>
+            <ixx>166.4333333</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>166.4333333</iyy>
+            <iyz>0</iyz>
+            <izz>166.4333333</izz>
+          </inertia>
+        </inertial>
+        <visual name='link_origin'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.25 0 1</ambient>
+            <diffuse>0.8 0.25 0 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <visual name='collision_origin'>
+          <pose>0 0 -5 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.25 0 1</ambient>
+            <diffuse>0.8 0.25 0 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name='buoyancy_volume'>
+          <pose>0 0 -5 0 0 0</pose>
+          <geometry>
+             <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!--
+      This purple and yellow box has multiple collision shapes.
+      It is neutrally buoyant if one collision is enabled and will float
+      if both are enabled.
+    -->
+    <model name='multi_collision_neutral_buoyancy'>
+      <plugin
+        filename="gz-waves1-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <!-- <enable>multi_collision_neutral_buoyancy::body::collision_1</enable> -->
+        <enable>multi_collision_neutral_buoyancy::body::collision_2</enable>
+        <hydrodynamics>
+            <damping_on>0</damping_on>
+            <viscous_drag_on>0</viscous_drag_on>
+            <pressure_drag_on>0</pressure_drag_on>
+        </hydrodynamics>
+      </plugin>
+      <pose>3 3 -3 0 0 0</pose>
+      <link name='body'>
+        <inertial>
+          <mass>499</mass>
+          <pose>0 0 -0.1 0 0 0</pose>
+          <inertia>
+            <ixx>83.2</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>83.2</iyy>
+            <iyz>0</iyz>
+            <izz>83.2</izz>
+          </inertia>
+        </inertial>
+        <visual name='collision_1_vis'>
+          <pose>0 0 -0.25 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 0 1</ambient>
+            <diffuse>1 1 0 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <visual name='collision_2_vis'>
+          <pose>0 0 0.25 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 1 1</ambient>
+            <diffuse>1 0 1 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name='collision_1'>
+          <pose>0 0 -0.25 0 0 0</pose>
+          <geometry>
+             <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+        <collision name='collision_2'>
+          <pose>0 0 0.25 0 0 0</pose>
+          <geometry>
+             <box>
+              <size>1 1 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- This purple box is negatively buoyant and therefore should sink -->
+    <model name='box_negative_buoyancy'>
+      <plugin
+        filename="gz-waves1-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <enable>box_negative_buoyancy</enable>
+        <hydrodynamics>
+            <damping_on>0</damping_on>
+            <viscous_drag_on>0</viscous_drag_on>
+            <pressure_drag_on>0</pressure_drag_on>
+        </hydrodynamics>
+      </plugin>
+      <pose>-3 -3 0 0 0 0</pose>
+      <link name='body'>
+        <inertial>
+          <mass>998.6</mass>
+          <pose>0 0 -0.1 0 0 0</pose>
+          <inertia>
+            <ixx>166.4333333</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>166.4333333</iyy>
+            <iyz>0</iyz>
+            <izz>166.4333333</izz>
+          </inertia>
+        </inertial>
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 1 1</ambient>
+            <diffuse>1 0 1 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name='body_collision'>
+          <geometry>
+             <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+    <!-- Not affected by buoyancy - will sink quickly -->
+    <model name='box_no_buoyancy'>
+      <pose>3 -3 0 0 0 0</pose>
+      <link name='body'>
+        <inertial>
+          <mass>998.6</mass>
+          <pose>0 0 -0.1 0 0 0</pose>
+          <inertia>
+            <ixx>166.4333333</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>166.4333333</iyy>
+            <iyz>0</iyz>
+            <izz>166.4333333</izz>
+          </inertia>
+        </inertial>
+        <visual name='body_visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 0.5 1</ambient>
+            <diffuse>0.5 0.5 0.5 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <collision name='body_collision'>
+          <geometry>
+             <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/gz-waves/src/systems/hydrodynamics/CMakeLists.txt
+++ b/gz-waves/src/systems/hydrodynamics/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 gz_add_system(hydrodynamics
   SOURCES
+    Collision.cc
     Hydrodynamics.cc
   PUBLIC_LINK_LIBS
     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}

--- a/gz-waves/src/systems/hydrodynamics/Collision.cc
+++ b/gz-waves/src/systems/hydrodynamics/Collision.cc
@@ -1,0 +1,92 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "Collision.hh"
+
+#include "gz/sim/components/Collision.hh"
+#include "gz/sim/components/Name.hh"
+#include "gz/sim/components/ParentEntity.hh"
+
+//////////////////////////////////////////////////
+class gz::sim::CollisionPrivate
+{
+  /// \brief Id of link entity.
+  public: Entity id{kNullEntity};
+};
+
+using namespace gz;
+using namespace sim;
+
+//////////////////////////////////////////////////
+Collision::~Collision() = default;
+
+//////////////////////////////////////////////////
+Collision::Collision(sim::Entity _entity)
+  : dataPtr(std::make_unique<CollisionPrivate>())
+{
+  this->dataPtr->id = _entity;
+}
+
+//////////////////////////////////////////////////
+Collision::Collision(const Collision &_collision)
+  : dataPtr(std::make_unique<CollisionPrivate>(*_collision.dataPtr))
+{
+}
+
+//////////////////////////////////////////////////
+Collision::Collision(Collision &&_collision) noexcept = default;
+
+//////////////////////////////////////////////////
+Collision &Collision::operator=(Collision &&_collision) noexcept = default;
+
+//////////////////////////////////////////////////
+Collision &Collision::operator=(const Collision &_collision)
+{
+  *this->dataPtr = (*_collision.dataPtr);
+  return *this;
+}
+
+//////////////////////////////////////////////////
+sim::Entity Collision::Entity() const
+{
+  return this->dataPtr->id;
+}
+
+//////////////////////////////////////////////////
+bool Collision::Valid(const EntityComponentManager &_ecm) const
+{
+  return nullptr != _ecm.Component<components::Collision>(
+      this->dataPtr->id);
+}
+
+//////////////////////////////////////////////////
+std::optional<std::string> Collision::Name(
+    const EntityComponentManager &_ecm) const
+{
+  return _ecm.ComponentData<components::Name>(this->dataPtr->id);
+}
+
+//////////////////////////////////////////////////
+std::optional<Model> Collision::ParentLink(
+    const EntityComponentManager &_ecm) const
+{
+  auto parent = _ecm.Component<components::ParentEntity>(this->dataPtr->id);
+
+  if (!parent)
+    return std::nullopt;
+
+  return std::optional<Model>(parent->Data());
+}
+

--- a/gz-waves/src/systems/hydrodynamics/Collision.hh
+++ b/gz-waves/src/systems/hydrodynamics/Collision.hh
@@ -1,0 +1,97 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_SIM_COLLISION_HH_
+#define GZ_SIM_COLLISION_HH_
+
+#include <gz/sim/config.hh>
+#include <gz/sim/EntityComponentManager.hh>
+#include <gz/sim/Export.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/System.hh>
+#include <gz/sim/Types.hh>
+
+#include <memory>
+#include <optional>
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+
+  // Forward declaration
+  class GZ_SIM_HIDDEN CollisionPrivate;
+
+  class GZ_SIM_VISIBLE Collision
+  {
+    /// \brief Destructor
+    public: ~Collision();
+
+    /// \brief Constructor
+    /// \param[in] _entity Collision entity
+    public: explicit Collision(sim::Entity _entity = kNullEntity);
+
+    /// \brief Copy constructor
+    /// \param[in] _collision Collision to copy.
+    public: Collision(const Collision &_collision);
+
+    /// \brief Move constructor
+    /// \param[in] _collision Collision to move.
+    public: Collision(Collision &&_collision) noexcept;
+
+    /// \brief Move assignment operator.
+    /// \param[in] _collision Collision component to move.
+    /// \return Reference to this.
+    public: Collision &operator=(Collision &&_collision) noexcept;
+
+    /// \brief Copy assignment operator.
+    /// \param[in] _collision Collision to copy.
+    /// \return Reference to this.
+    public: Collision &operator=(const Collision &_collision);
+
+    /// \brief Get the entity which this Collision is related to.
+    /// \return Collision entity.
+    public: sim::Entity Entity() const;
+
+    /// \brief Check whether this link correctly refers to an entity that
+    /// has a components::Collision.
+    /// \param[in] _ecm Entity-component manager.
+    /// \return True if it's a valid link in the manager.
+    public: bool Valid(const EntityComponentManager &_ecm) const;
+
+    /// \brief Get the link's unscoped name.
+    /// \param[in] _ecm Entity-component manager.
+    /// \return Collision's name or nullopt if the entity does not have a
+    /// components::Name component
+    public: std::optional<std::string> Name(
+        const EntityComponentManager &_ecm) const;
+
+    /// \brief Get the parent link
+    /// \param[in] _ecm Entity-component manager.
+    /// \return Parent Model or nullopt if the entity does not have a
+    /// components::ParentEntity component.
+    public: std::optional<Model> ParentLink(
+        const EntityComponentManager &_ecm) const;
+
+    /// \brief Pointer to private data.
+    private: std::unique_ptr<CollisionPrivate> dataPtr;
+  };
+}
+}
+}
+
+#endif

--- a/gz-waves/src/systems/hydrodynamics/Hydrodynamics.hh
+++ b/gz-waves/src/systems/hydrodynamics/Hydrodynamics.hh
@@ -41,6 +41,17 @@ namespace systems
   /// <plugin name="gz::sim::systems::Hydrodynamics"
   ///         filename="gz-waves1-hydrodynamics-system">
   ///
+  ///   <!-- Apply hydrodynamics to the entire model (default) -->
+  ///   <enable>model_name</enable>
+  ///
+  ///   <!-- Or apply hydrodynamics to named links -->
+  ///   <enable>model_name::link1</enable>
+  ///   <enable>model_name::link2</enable>
+  ///
+  ///   <!-- Or apply hydrodynamics to named collisions -->
+  ///   <enable>model_name::link1::collision1</enable>
+  ///   <enable>model_name::link1::collision2</enable>
+  ///
   ///   <!-- Hydrodynamics -->
   ///   <hydrodynamics>
   ///     <damping_on>1</damping_on>
@@ -62,6 +73,15 @@ namespace systems
   ///     <fSDrag>0.4</fSDrag>
   ///     <vRDrag>1.0</vRDrag>
   ///   </hydrodynamics>
+  ///
+  ///   <!-- Control visibility of markers -->
+  ///   <markers>
+  ///     <update_rate>10</update_rate>
+  ///     <water_patch>1</water_patch>
+  ///     <waterline>1</waterline>
+  ///     <underwater_surface>1</underwater_surface>
+  ///   </markers>
+  ///
   /// </plugin>
   /// \endcode
   ///


### PR DESCRIPTION
This PR adds the ability to enable buoyancy and hydrodynamic forces at the link and collision level.

Closes #43 

## Details

The choice of which entities to apply buoyancy and hydrodynamics forces is controlled using a new parameter `<enable>`. Usage is similar to the `gz-sim-buoyancy-system` plugin where the parameter is a fully scoped entity name using a double colon `::` as a separator.

The `graded_buoyancy` example from `gz-sim` has been modified to work with `gz-waves` and is added to the examples in `gz-waves-models/worlds`.

![link-level-buoyancy_2](https://user-images.githubusercontent.com/24916364/184860590-6f0053c1-a30c-41f5-b1ae-2af9683000ad.gif)