### PR TITLE
Wave Body: improve overrides - 8

### DIFF
--- a/gz-waves-models/worlds/ellipsoid_buoy.sdf
+++ b/gz-waves-models/worlds/ellipsoid_buoy.sdf
@@ -3,7 +3,7 @@
   <world name="waves">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>
-      <real_time_factor>-1</real_time_factor>
+      <real_time_factor>1</real_time_factor>
     </physics>
 
     <plugin filename="gz-sim-physics-system"
@@ -110,7 +110,7 @@
           <waves>
             <regular>
               <period>6</period>
-              <height>2</height>
+              <height>4</height>
               <direction>0</direction>
               <phase>0</phase>
             </regular>

--- a/gz-waves/src/systems/linear_wave_body/mlinterp
+++ b/gz-waves/src/systems/linear_wave_body/mlinterp
@@ -1,0 +1,25 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Parsiad Azimzadeh
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+
+#include <mlinterp.hpp>

--- a/gz-waves/src/systems/linear_wave_body/mlinterp.hpp
+++ b/gz-waves/src/systems/linear_wave_body/mlinterp.hpp
@@ -1,0 +1,169 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Parsiad Azimzadeh
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef MLINTERP_HPP
+#define MLINTERP_HPP
+
+#include <cassert>
+#include <cstddef>
+#include <limits>
+
+namespace mlinterp {
+
+namespace {
+
+template <typename T, typename...> struct helper {
+  template <typename Index> void run(const Index *, Index, Index *, T *) {}
+};
+
+template <typename T, typename T1, typename T2, typename... Args>
+struct helper<T, T1, T2, Args...> : helper<T, Args...> {
+  const T *xd;
+  const T *xi;
+
+  helper(T1 xd, T2 xi, Args... args)
+      : helper<T, Args...>(args...), xd(xd), xi(xi) {}
+
+  template <typename Index>
+  void run(const Index *nd, Index n, Index *indices, T *weights) {
+    // Must have at least one point per axis
+    assert(*nd > 0);
+
+    const T x = xi[n];
+
+    Index mid;
+    T weight;
+
+    if (*nd == 1 || x <= xd[0]) {
+      // Data point is less than left boundary
+      mid = 0;
+      weight = 1.;
+    } else if (x >= xd[*nd - 1]) {
+      // Data point is greater than right boundary
+      mid = *nd - 2;
+      weight = 0.;
+    } else {
+      // Binary search to find tick
+      Index lo = 0, hi = *nd - 2;
+      mid = 0;
+      weight = 0.;
+      while (lo <= hi) {
+        mid = lo + (hi - lo) / 2;
+        if (x < xd[mid]) {
+          hi = mid - 1;
+        } else if (x >= xd[mid + 1]) {
+          lo = mid + 1;
+        } else {
+          weight = (xd[mid + 1] - x) / (xd[mid + 1] - xd[mid]);
+          break;
+        }
+      }
+    }
+
+    *indices = mid;
+    *weights = weight;
+
+    helper<T, Args...> &base = (*this);
+    base.run(nd + 1, n, indices + 1, weights + 1);
+  }
+};
+
+} // namespace
+
+struct natord {
+  template <typename Index, Index Dimension>
+  static Index mux(const Index *nd, const Index *indices) {
+    Index index = 0, product = 1, i = Dimension - 1;
+    while (true) {
+      index += indices[i] * product;
+      if (i == 0) {
+        break;
+      }
+      product *= nd[i--];
+    }
+    return index;
+  }
+};
+
+struct rnatord {
+  template <typename Index, Index Dimension>
+  static Index mux(const Index *nd, const Index *indices) {
+    Index index = 0, product = 1, i = 0;
+    while (true) {
+      index += indices[i] * product;
+      if (i == Dimension - 1) {
+        break;
+      }
+      product *= nd[i++];
+    }
+    return index;
+  }
+};
+
+template <typename Order = natord, typename... Args, typename T, typename Index>
+static void interp(const Index *nd, Index ni, const T *yd, T *yi,
+                   Args... args) {
+  // Cannot have a negative number of points
+  assert(ni >= 0);
+
+  // Infer dimension from arguments
+  static_assert(sizeof...(Args) % 2 == 0, "needs 4+2*Dimension arguments");
+  constexpr Index Dimension = sizeof...(Args) / 2;
+
+  // Compute 2^Dimension
+  constexpr Index Power = 1 << Dimension;
+
+  // Unpack arguments
+  helper<T, Args...> h(args...);
+
+  // Perform interpolation for each point
+  Index indices[Dimension];
+  T weights[Dimension];
+  Index buffer[Dimension];
+  T factor;
+  for (Index n = 0; n < ni; ++n) {
+    yi[n] = 0.;
+    h.run(nd, n, indices, weights);
+    for (Index bitstr = 0; bitstr < Power; ++bitstr) {
+      factor = 1.;
+      for (Index i = 0; i < Dimension; ++i) {
+        if (bitstr & (1 << i)) {
+          buffer[i] = indices[i];
+          factor *= weights[i];
+        } else {
+          buffer[i] = indices[i] + 1;
+          factor *= 1 - weights[i];
+        }
+      }
+      if (factor > std::numeric_limits<T>::epsilon()) {
+        const Index k = Order::template mux<Index, Dimension>(nd, buffer);
+        yi[n] += factor * yd[k];
+      }
+    }
+  }
+}
+
+} // namespace mlinterp
+
+#endif


### PR DESCRIPTION
This PR linearly interpolates the hydro coefficients given a regular wave frequency.

Previously the hydro coefficients lookup from hdf5 was hardcoded to a frequency 1.042 rad/s (wave period 6s).

The simulation should now use the correct coefficients from the hdf5 file when no overrides are provided in the sdf file.

Other minor fixes:
- Make wave model amplitude and linear wave body wave heights consistent 
- Run at RTF 1 as the data publishers struggle at higher rates (affects plotting)
- Update debug messages during configuration

The interpolation uses Parsiad Azimzadeh's [mlinterp](https://github.com/parsiad/mlinterp) library which is covered by the MIT license.