### PR TITLE
Waves simulation optimisation - part 2

### DIFF
--- a/gz-waves/include/gz/waves/WaveSimulation.hh
+++ b/gz-waves/include/gz/waves/WaveSimulation.hh
@@ -31,35 +31,35 @@ namespace waves
 
     WaveSimulation();
 
-    virtual void SetWindVelocity(double _ux, double _uy) = 0;
+    virtual void SetWindVelocity(double ux, double uy) = 0;
 
-    virtual void SetTime(double _value) = 0;
+    virtual void SetTime(double value) = 0;
 
     virtual void ComputeElevation(
-        Eigen::Ref<Eigen::MatrixXd> _h) = 0;
+        Eigen::Ref<Eigen::MatrixXd> h) = 0;
 
     virtual void ComputeElevationDerivatives(
-        Eigen::Ref<Eigen::MatrixXd> _dhdx,
-        Eigen::Ref<Eigen::MatrixXd> _dhdy) = 0;
+        Eigen::Ref<Eigen::MatrixXd> dhdx,
+        Eigen::Ref<Eigen::MatrixXd> dhdy) = 0;
 
     virtual void ComputeDisplacements(
-        Eigen::Ref<Eigen::MatrixXd> _sx,
-        Eigen::Ref<Eigen::MatrixXd> _sy) = 0;
+        Eigen::Ref<Eigen::MatrixXd> sx,
+        Eigen::Ref<Eigen::MatrixXd> sy) = 0;
 
     virtual void ComputeDisplacementsDerivatives(
-        Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-        Eigen::Ref<Eigen::MatrixXd> _dsydy,
-        Eigen::Ref<Eigen::MatrixXd> _dsxdy) = 0;
+        Eigen::Ref<Eigen::MatrixXd> dsxdx,
+        Eigen::Ref<Eigen::MatrixXd> dsydy,
+        Eigen::Ref<Eigen::MatrixXd> dsxdy) = 0;
 
     virtual void ComputeDisplacementsAndDerivatives(
-        Eigen::Ref<Eigen::MatrixXd> _h,
-        Eigen::Ref<Eigen::MatrixXd> _sx,
-        Eigen::Ref<Eigen::MatrixXd> _sy,
-        Eigen::Ref<Eigen::MatrixXd> _dhdx,
-        Eigen::Ref<Eigen::MatrixXd> _dhdy,
-        Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-        Eigen::Ref<Eigen::MatrixXd> _dsydy,
-        Eigen::Ref<Eigen::MatrixXd> _dsxdy) = 0;
+        Eigen::Ref<Eigen::MatrixXd> h,
+        Eigen::Ref<Eigen::MatrixXd> sx,
+        Eigen::Ref<Eigen::MatrixXd> sy,
+        Eigen::Ref<Eigen::MatrixXd> dhdx,
+        Eigen::Ref<Eigen::MatrixXd> dhdy,
+        Eigen::Ref<Eigen::MatrixXd> dsxdx,
+        Eigen::Ref<Eigen::MatrixXd> dsydy,
+        Eigen::Ref<Eigen::MatrixXd> dsxdy) = 0;
   };
 }
 }

--- a/gz-waves/include/gz/waves/WaveSimulationFFT2.hh
+++ b/gz-waves/include/gz/waves/WaveSimulationFFT2.hh
@@ -16,11 +16,9 @@
 #ifndef GZ_WAVES_WAVESIMULATIONFFT2_HH_
 #define GZ_WAVES_WAVESIMULATIONFFT2_HH_
 
-#include "WaveSimulation.hh"
-
-using Eigen::MatrixXd;
-
 #include <memory>
+
+#include "WaveSimulation.hh"
 
 using Eigen::MatrixXd;
 
@@ -35,45 +33,45 @@ namespace waves
     public:
       virtual ~WaveSimulationFFT2();
 
-      WaveSimulationFFT2(double _lx, double _ly, int _nx, int _ny);
+      WaveSimulationFFT2(double lx, double ly, int nx, int ny);
 
-      void SetUseVectorised(bool _value);
+      void SetUseVectorised(bool value);
 
       /// \brief Set lambda which controls the horizontal wave displacement.
-      void SetLambda(double _lambda);
+      void SetLambda(double lambda);
 
-      virtual void SetWindVelocity(double _ux, double _uy) override;
+      virtual void SetWindVelocity(double ux, double uy) override;
 
-      virtual void SetTime(double _value) override;
+      virtual void SetTime(double value) override;
 
       virtual void ComputeElevation(
-          Eigen::Ref<Eigen::MatrixXd> _h) override;
+          Eigen::Ref<Eigen::MatrixXd> h) override;
 
       virtual void ComputeElevationDerivatives(
-          Eigen::Ref<Eigen::MatrixXd> _dhdx,
-          Eigen::Ref<Eigen::MatrixXd> _dhdy) override;
+          Eigen::Ref<Eigen::MatrixXd> dhdx,
+          Eigen::Ref<Eigen::MatrixXd> dhdy) override;
 
       virtual void ComputeDisplacements(
-          Eigen::Ref<Eigen::MatrixXd> _sx,
-          Eigen::Ref<Eigen::MatrixXd> _sy) override;
+          Eigen::Ref<Eigen::MatrixXd> sx,
+          Eigen::Ref<Eigen::MatrixXd> sy) override;
 
       virtual void ComputeDisplacementsDerivatives(
-          Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-          Eigen::Ref<Eigen::MatrixXd> _dsydy,
-          Eigen::Ref<Eigen::MatrixXd> _dsxdy) override;
+          Eigen::Ref<Eigen::MatrixXd> dsxdx,
+          Eigen::Ref<Eigen::MatrixXd> dsydy,
+          Eigen::Ref<Eigen::MatrixXd> dsxdy) override;
 
       virtual void ComputeDisplacementsAndDerivatives(
-          Eigen::Ref<Eigen::MatrixXd> _h,
-          Eigen::Ref<Eigen::MatrixXd> _sx,
-          Eigen::Ref<Eigen::MatrixXd> _sy,
-          Eigen::Ref<Eigen::MatrixXd> _dhdx,
-          Eigen::Ref<Eigen::MatrixXd> _dhdy,
-          Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-          Eigen::Ref<Eigen::MatrixXd> _dsydy,
-          Eigen::Ref<Eigen::MatrixXd> _dsxdy) override;
+          Eigen::Ref<Eigen::MatrixXd> h,
+          Eigen::Ref<Eigen::MatrixXd> sx,
+          Eigen::Ref<Eigen::MatrixXd> sy,
+          Eigen::Ref<Eigen::MatrixXd> dhdx,
+          Eigen::Ref<Eigen::MatrixXd> dhdy,
+          Eigen::Ref<Eigen::MatrixXd> dsxdx,
+          Eigen::Ref<Eigen::MatrixXd> dsydy,
+          Eigen::Ref<Eigen::MatrixXd> dsxdy) override;
 
     private:
-      std::unique_ptr<WaveSimulationFFT2Impl> impl;
+      std::unique_ptr<WaveSimulationFFT2Impl> impl_;
   };
 }
 }

--- a/gz-waves/include/gz/waves/WaveSimulationSinusoid.hh
+++ b/gz-waves/include/gz/waves/WaveSimulationSinusoid.hh
@@ -16,11 +16,11 @@
 #ifndef GZ_WAVES_WAVESIMULATIONSINUSOID_HH_
 #define GZ_WAVES_WAVESIMULATIONSINUSOID_HH_
 
-#include "WaveSimulation.hh"
+#include <memory>
 
 #include <Eigen/Dense>
 
-#include <memory>
+#include "WaveSimulation.hh"
 
 using Eigen::MatrixXd;
 
@@ -45,49 +45,49 @@ namespace waves
     public:
       ~WaveSimulationSinusoid();
 
-      WaveSimulationSinusoid(double _lx, double _ly, int _nx, int _ny);
+      WaveSimulationSinusoid(double lx, double ly, int nx, int ny);
 
-      void SetUseVectorised(bool _value);
+      void SetUseVectorised(bool value);
 
-      void SetDirection(double _dir_x, double _dir_y);
+      void SetDirection(double dir_x, double dir_y);
 
-      void SetAmplitude(double _value);
+      void SetAmplitude(double value);
 
-      void SetPeriod(double _value);
+      void SetPeriod(double value);
 
-      virtual void SetWindVelocity(double _ux, double _uy) override;
+      virtual void SetWindVelocity(double ux, double uy) override;
 
-      virtual void SetTime(double _value) override;
+      virtual void SetTime(double value) override;
 
       virtual void ComputeElevation(
-          Eigen::Ref<Eigen::MatrixXd> _h) override;
+          Eigen::Ref<Eigen::MatrixXd> h) override;
 
       virtual void ComputeElevationDerivatives(
-          Eigen::Ref<Eigen::MatrixXd> _dhdx,
-          Eigen::Ref<Eigen::MatrixXd> _dhdy) override;
+          Eigen::Ref<Eigen::MatrixXd> dhdx,
+          Eigen::Ref<Eigen::MatrixXd> dhdy) override;
 
       virtual void ComputeDisplacements(
-          Eigen::Ref<Eigen::MatrixXd> _sx,
-          Eigen::Ref<Eigen::MatrixXd> _sy) override;
+          Eigen::Ref<Eigen::MatrixXd> sx,
+          Eigen::Ref<Eigen::MatrixXd> sy) override;
 
       virtual void ComputeDisplacementsDerivatives(
-          Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-          Eigen::Ref<Eigen::MatrixXd> _dsydy,
-          Eigen::Ref<Eigen::MatrixXd> _dsxdy) override;
+          Eigen::Ref<Eigen::MatrixXd> dsxdx,
+          Eigen::Ref<Eigen::MatrixXd> dsydy,
+          Eigen::Ref<Eigen::MatrixXd> dsxdy) override;
 
       virtual void ComputeDisplacementsAndDerivatives(
-          Eigen::Ref<Eigen::MatrixXd> _h,
-          Eigen::Ref<Eigen::MatrixXd> _sx,
-          Eigen::Ref<Eigen::MatrixXd> _sy,
-          Eigen::Ref<Eigen::MatrixXd> _dhdx,
-          Eigen::Ref<Eigen::MatrixXd> _dhdy,
-          Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-          Eigen::Ref<Eigen::MatrixXd> _dsydy,
-          Eigen::Ref<Eigen::MatrixXd> _dsxdy) override;
+          Eigen::Ref<Eigen::MatrixXd> h,
+          Eigen::Ref<Eigen::MatrixXd> sx,
+          Eigen::Ref<Eigen::MatrixXd> sy,
+          Eigen::Ref<Eigen::MatrixXd> dhdx,
+          Eigen::Ref<Eigen::MatrixXd> dhdy,
+          Eigen::Ref<Eigen::MatrixXd> dsxdx,
+          Eigen::Ref<Eigen::MatrixXd> dsydy,
+          Eigen::Ref<Eigen::MatrixXd> dsxdy) override;
 
     private:
       class Impl;
-      std::unique_ptr<Impl> impl;
+      std::unique_ptr<Impl> impl_;
   };
 }
 }

--- a/gz-waves/include/gz/waves/WaveSimulationTrochoid.hh
+++ b/gz-waves/include/gz/waves/WaveSimulationTrochoid.hh
@@ -16,11 +16,11 @@
 #ifndef GZ_WAVES_WAVESIMULATIONTROCHOID_HH_
 #define GZ_WAVES_WAVESIMULATIONTROCHOID_HH_
 
-#include "WaveSimulation.hh"
+#include <memory>
 
 #include <Eigen/Dense>
 
-#include <memory>
+#include "WaveSimulation.hh"
 
 using Eigen::MatrixXd;
 
@@ -37,42 +37,42 @@ namespace waves
     virtual ~WaveSimulationTrochoid();
 
     WaveSimulationTrochoid(
-      int _N,
-      double _L,
-      std::shared_ptr<WaveParameters> _params);
+      int nx,
+      double lx,
+      std::shared_ptr<WaveParameters> params);
 
-    virtual void SetWindVelocity(double _ux, double _uy) override;
+    virtual void SetWindVelocity(double ux, double uy) override;
 
-    virtual void SetTime(double _time) override;
+    virtual void SetTime(double time) override;
 
     virtual void ComputeElevation(
-        Eigen::Ref<Eigen::MatrixXd> _h) override;
+        Eigen::Ref<Eigen::MatrixXd> h) override;
 
     virtual void ComputeElevationDerivatives(
-        Eigen::Ref<Eigen::MatrixXd> _dhdx,
-        Eigen::Ref<Eigen::MatrixXd> _dhdy) override;
+        Eigen::Ref<Eigen::MatrixXd> dhdx,
+        Eigen::Ref<Eigen::MatrixXd> dhdy) override;
 
     virtual void ComputeDisplacements(
-        Eigen::Ref<Eigen::MatrixXd> _sx,
-        Eigen::Ref<Eigen::MatrixXd> _sy) override;
+        Eigen::Ref<Eigen::MatrixXd> sx,
+        Eigen::Ref<Eigen::MatrixXd> sy) override;
 
     virtual void ComputeDisplacementsDerivatives(
-        Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-        Eigen::Ref<Eigen::MatrixXd> _dsydy,
-        Eigen::Ref<Eigen::MatrixXd> _dsxdy) override;
+        Eigen::Ref<Eigen::MatrixXd> dsxdx,
+        Eigen::Ref<Eigen::MatrixXd> dsydy,
+        Eigen::Ref<Eigen::MatrixXd> dsxdy) override;
 
     virtual void ComputeDisplacementsAndDerivatives(
-        Eigen::Ref<Eigen::MatrixXd> _h,
-        Eigen::Ref<Eigen::MatrixXd> _sx,
-        Eigen::Ref<Eigen::MatrixXd> _sy,
-        Eigen::Ref<Eigen::MatrixXd> _dhdx,
-        Eigen::Ref<Eigen::MatrixXd> _dhdy,
-        Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-        Eigen::Ref<Eigen::MatrixXd> _dsydy,
-        Eigen::Ref<Eigen::MatrixXd> _dsxdy) override;
+        Eigen::Ref<Eigen::MatrixXd> h,
+        Eigen::Ref<Eigen::MatrixXd> sx,
+        Eigen::Ref<Eigen::MatrixXd> sy,
+        Eigen::Ref<Eigen::MatrixXd> dhdx,
+        Eigen::Ref<Eigen::MatrixXd> dhdy,
+        Eigen::Ref<Eigen::MatrixXd> dsxdx,
+        Eigen::Ref<Eigen::MatrixXd> dsydy,
+        Eigen::Ref<Eigen::MatrixXd> dsxdy) override;
 
   private:
-    std::unique_ptr<WaveSimulationTrochoidImpl> impl;
+    std::unique_ptr<WaveSimulationTrochoidImpl> impl_;
   };
 }
 }

--- a/gz-waves/include/gz/waves/WaveSpectrum.hh
+++ b/gz-waves/include/gz/waves/WaveSpectrum.hh
@@ -31,11 +31,11 @@ inline namespace v2
   public:
     virtual ~OmniDirectionalWaveSpectrum();
 
-    virtual double Evaluate(double _k) const = 0;
+    virtual double Evaluate(double k) const = 0;
 
     virtual void Evaluate(
-        Eigen::Ref<Eigen::MatrixXd> _spectrum,
-        const Eigen::Ref<const Eigen::MatrixXd> &_k) const = 0;
+        Eigen::Ref<Eigen::MatrixXd> spectrum,
+        const Eigen::Ref<const Eigen::MatrixXd> &k) const = 0;
   };
 
   class PiersonMoskowitzWaveSpectrum : public OmniDirectionalWaveSpectrum
@@ -43,25 +43,25 @@ inline namespace v2
   public:
     virtual ~PiersonMoskowitzWaveSpectrum();
 
-    PiersonMoskowitzWaveSpectrum(double _u19=5.0, double _gravity=9.81);
+    PiersonMoskowitzWaveSpectrum(double u19=5.0, double gravity=9.81);
 
-    virtual double Evaluate(double _k) const override;
+    virtual double Evaluate(double k) const override;
 
     virtual void Evaluate(
-        Eigen::Ref<Eigen::MatrixXd> _spectrum,
-        const Eigen::Ref<const Eigen::MatrixXd> &_k) const override;
+        Eigen::Ref<Eigen::MatrixXd> spectrum,
+        const Eigen::Ref<const Eigen::MatrixXd> &k) const override;
 
     double Gravity() const;
 
-    void SetGravity(double _value);
+    void SetGravity(double value);
 
     double U19() const;
 
-    void SetU19(double _value);
+    void SetU19(double value);
 
   private:
-    double _gravity{9.81};
-    double _u19{5.0};
+    double gravity_{9.81};
+    double u19_{5.0};
   };
 
   class ECKVWaveSpectrum : public OmniDirectionalWaveSpectrum
@@ -70,32 +70,32 @@ inline namespace v2
     virtual ~ECKVWaveSpectrum();
 
     ECKVWaveSpectrum(
-        double _u10=5.0,
-        double _cap_omega_c=0.84,
-        double _gravity=9.81);
+        double u10=5.0,
+        double cap_omega_c=0.84,
+        double gravity=9.81);
 
-    virtual double Evaluate(double _k) const override;
+    virtual double Evaluate(double k) const override;
 
     virtual void Evaluate(
-        Eigen::Ref<Eigen::MatrixXd> _spectrum,
-        const Eigen::Ref<const Eigen::MatrixXd> &_k) const override;
+        Eigen::Ref<Eigen::MatrixXd> spectrum,
+        const Eigen::Ref<const Eigen::MatrixXd> &k) const override;
 
     double Gravity() const;
 
-    void SetGravity(double _value);
+    void SetGravity(double value);
 
     double U10() const;
 
-    void SetU10(double _value);
+    void SetU10(double value);
 
     double CapOmegaC() const;
 
-    void SetCapOmegaC(double _value);
+    void SetCapOmegaC(double value);
 
   private:
-    double _gravity{9.81};
-    double _u10{5.0};
-    double _cap_omega_c{0.84};
+    double gravity_{9.81};
+    double u10_{5.0};
+    double cap_omega_c_{0.84};
   };
 
 }

--- a/gz-waves/include/gz/waves/WaveSpreadingFunction.hh
+++ b/gz-waves/include/gz/waves/WaveSpreadingFunction.hh
@@ -32,13 +32,13 @@ inline namespace v2
     virtual ~DirectionalSpreadingFunction();
 
     virtual double Evaluate(
-        double _theta, double _theta_mean, double _k=1.0) const = 0;
+        double theta, double theta_mean, double k=1.0) const = 0;
 
     virtual void Evaluate(
-        Eigen::Ref<Eigen::MatrixXd> _phi,
-        const Eigen::Ref<const Eigen::MatrixXd> &_theta,
-        double _theta_mean,
-        const Eigen::Ref<const Eigen::MatrixXd> &_k=Eigen::MatrixXd())
+        Eigen::Ref<Eigen::MatrixXd> phi,
+        const Eigen::Ref<const Eigen::MatrixXd> &theta,
+        double theta_mean,
+        const Eigen::Ref<const Eigen::MatrixXd> &k=Eigen::MatrixXd())
         const = 0;
   };
 
@@ -47,27 +47,27 @@ inline namespace v2
   public:
     virtual ~Cos2sSpreadingFunction();
 
-    Cos2sSpreadingFunction(double _spread=10.0);
+    Cos2sSpreadingFunction(double spread=10.0);
 
     virtual double Evaluate(
-        double _theta, double _theta_mean, double _k=1.0) const override;
+        double theta, double theta_mean, double k=1.0) const override;
 
     virtual void Evaluate(
-        Eigen::Ref<Eigen::MatrixXd> _phi,
-        const Eigen::Ref<const Eigen::MatrixXd> &_theta,
-        double _theta_mean,
-        const Eigen::Ref<const Eigen::MatrixXd> &_k=Eigen::MatrixXd())
+        Eigen::Ref<Eigen::MatrixXd> phi,
+        const Eigen::Ref<const Eigen::MatrixXd> &theta,
+        double theta_mean,
+        const Eigen::Ref<const Eigen::MatrixXd> &k=Eigen::MatrixXd())
         const override;
 
     double Spread() const;
 
-    void SetSpread(double _value);
+    void SetSpread(double value);
 
   private:
-    void _RecalcCoeffs();
+    void RecalcCoeffs();
 
-    double _spread{10.0};
-    double _cap_c_s{0.0};
+    double spread_{10.0};
+    double cap_c_s_{0.0};
   };
 
   class ECKVSpreadingFunction : public DirectionalSpreadingFunction
@@ -76,36 +76,36 @@ inline namespace v2
     virtual ~ECKVSpreadingFunction();
 
     ECKVSpreadingFunction(
-        double _u10=5.0,
-        double _cap_omega_c=0.84,
-        double _gravity=9.81);
+        double u10=5.0,
+        double cap_omega_c=0.84,
+        double gravity=9.81);
 
     virtual double Evaluate(
-        double _theta, double _theta_mean, double _k=1.0) const override;
+        double theta, double theta_mean, double k=1.0) const override;
 
     virtual void Evaluate(
-        Eigen::Ref<Eigen::MatrixXd> _phi,
-        const Eigen::Ref<const Eigen::MatrixXd> &_theta,
-        double _theta_mean,
-        const Eigen::Ref<const Eigen::MatrixXd> &_k=Eigen::MatrixXd())
+        Eigen::Ref<Eigen::MatrixXd> phi,
+        const Eigen::Ref<const Eigen::MatrixXd> &theta,
+        double theta_mean,
+        const Eigen::Ref<const Eigen::MatrixXd> &k=Eigen::MatrixXd())
         const override;
 
     double Gravity() const;
 
-    void SetGravity(double _value);
+    void SetGravity(double value);
 
     double U10() const;
 
-    void SetU10(double _value);
+    void SetU10(double value);
 
     double CapOmegaC() const;
 
-    void SetCapOmegaC(double _value);
+    void SetCapOmegaC(double value);
 
   private:
-    double _gravity{9.81};
-    double _u10{5.0};
-    double _cap_omega_c{0.84};
+    double gravity_{9.81};
+    double u10_{5.0};
+    double cap_omega_c_{0.84};
   };
 }
 }

--- a/gz-waves/src/CMakeLists.txt
+++ b/gz-waves/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set(gtest_sources
   ${gtest_sources}
   Algorithm_TEST.cc
   CGAL_TEST.cc
+  EigenFFTW_TEST.cc
   Geometry_TEST.cc
   Grid_TEST.cc
   MeshTools_TEST.cc

--- a/gz-waves/src/EigenFFTW_TEST.cc
+++ b/gz-waves/src/EigenFFTW_TEST.cc
@@ -93,8 +93,8 @@ TEST(EigenFFWT, EigenFFT1D)
     // https://stackoverflow.com/questions/4214400/problem-casting-stl-complexdouble-to-fftw-complex
     fftw_plan plan = fftw_plan_dft_1d(
       n,
-      reinterpret_cast<fftw_complex*>(&in[0]),
-      reinterpret_cast<fftw_complex*>(&out[0]),
+      reinterpret_cast<fftw_complex*>(in.data()),
+      reinterpret_cast<fftw_complex*>(out.data()),
       FFTW_BACKWARD, FFTW_ESTIMATE);
 
     // populate input
@@ -121,8 +121,8 @@ TEST(EigenFFWT, EigenFFT1D)
     // create plan
     fftw_plan plan = fftw_plan_dft_1d(
       n,
-      reinterpret_cast<fftw_complex*>(&in(0)),
-      reinterpret_cast<fftw_complex*>(&out(0)),
+      reinterpret_cast<fftw_complex*>(in.data()),
+      reinterpret_cast<fftw_complex*>(out.data()),
       FFTW_BACKWARD, FFTW_ESTIMATE);
 
     // populate input
@@ -142,6 +142,74 @@ TEST(EigenFFWT, EigenFFT1D)
     }
   }
 }
+
+namespace Eigen
+{ 
+  typedef Eigen::Matrix<
+    double,
+    Eigen::Dynamic,
+    Eigen::Dynamic,
+    Eigen::RowMajor
+  > MatrixXdRowMajor;
+}
+
+//////////////////////////////////////////////////
+/// This test demonstrates changing storage order and accessing
+/// the flattened data in either row major or column major format.
+///
+TEST(EigenFFWT, EigenStorageOrdering)
+{
+  {
+    std::cerr << "MatrixXd" << "\n";
+
+    Eigen::MatrixXd col_maj(2, 3);
+    col_maj << 1, 2, 3,
+               4, 5, 6;
+
+    std::cerr << "col-major:" << "\n";
+    std::cerr << col_maj << "\n";
+
+    std::cerr << "in memory (col-major):" << "\n";
+    for (int i = 0; i < col_maj.size(); i++)
+      std::cerr << *(col_maj.data() + i) << " ";
+    std::cerr << "\n";
+    std::cerr << col_maj.reshaped().transpose() << "\n";
+
+    Eigen::MatrixXdRowMajor row_maj = col_maj;
+
+    std::cerr << "in memory (row-major):" << "\n";
+    for (int i = 0; i < row_maj.size(); i++)
+      std::cerr << *(row_maj.data() + i) << " ";
+    std::cerr << "\n";
+    std::cerr << row_maj.reshaped<Eigen::RowMajor>().transpose() << "\n";
+  }
+
+  {
+    std::cerr << "Matrix2x3d" << "\n";
+
+    Eigen::Matrix<double, 2, 3, Eigen::ColMajor> col_maj;
+    col_maj << 1, 2, 3,
+               4, 5, 6;
+
+    std::cerr << "col-major:" << "\n";
+    std::cerr << col_maj << "\n";
+
+    std::cerr << "in memory (col-major):" << "\n";
+    for (int i = 0; i < col_maj.size(); i++)
+      std::cerr << *(col_maj.data() + i) << " ";
+    std::cerr << "\n";
+    std::cerr << col_maj.reshaped().transpose() << "\n";
+    
+    Eigen::Matrix<double, 2, 3, Eigen::RowMajor> row_maj = col_maj;
+
+    std::cerr << "in memory (row-major):" << "\n";
+    for (int i = 0; i < row_maj.size(); i++)
+      std::cerr << *(row_maj.data() + i) << " ";
+    std::cerr << "\n";
+    std::cerr << row_maj.reshaped<Eigen::RowMajor>().transpose() << "\n";
+  }
+}
+
 
 //////////////////////////////////////////////////
 // Run tests

--- a/gz-waves/src/EigenFFTW_TEST.cc
+++ b/gz-waves/src/EigenFFTW_TEST.cc
@@ -1,0 +1,46 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+using Eigen::MatrixXd;
+
+//////////////////////////////////////////////////
+TEST(EigenFFWT, EigenFFT1D)
+{
+
+  // Eigen::MatrixXd dsxdx = Eigen::MatrixXd::Zero(n2, 1);
+  // Eigen::MatrixXd dsydy = Eigen::MatrixXd::Zero(n2, 1);
+  // Eigen::MatrixXd dsxdy = Eigen::MatrixXd::Zero(n2, 1);
+
+  // EXPECT_EQ(dsxdy.size(), n2);
+  // EXPECT_DOUBLE_EQ(dsxdx(i, 0), ref_dsxdx(i, 0));
+}
+
+//////////////////////////////////////////////////
+// Run tests
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -326,7 +326,10 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
       // FFT2
       std::unique_ptr<WaveSimulationFFT2> waveSim(
           new WaveSimulationFFT2(_L, _L, _N, _N));
-      waveSim->SetLambda(_params->Steepness());  // larger lambda => steeper waves.
+      
+      waveSim->SetUseVectorised(true);
+      // larger lambda => steeper waves.
+      waveSim->SetLambda(_params->Steepness());
       mWaveSim = std::move(waveSim);
       break;
     }

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -58,6 +58,8 @@ template <typename Vector3>
 class OceanTilePrivate
 {
 public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  
   ~OceanTilePrivate();
 
   OceanTilePrivate(unsigned int _N, double _L, bool _hasVisuals=true);

--- a/gz-waves/src/WaveSimulationFFT2.cc
+++ b/gz-waves/src/WaveSimulationFFT2.cc
@@ -327,6 +327,24 @@ namespace waves
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeBaseAmplitudes()
   {
+    if (use_vectorised_)
+      ComputeBaseAmplitudesVectorised();
+    else
+      ComputeBaseAmplitudesNonVectorised();
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudes(double time)
+  {
+    if (use_vectorised_)
+      ComputeCurrentAmplitudesVectorised(time);
+    else
+      ComputeCurrentAmplitudesNonVectorised(time);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFT2Impl::ComputeBaseAmplitudesNonVectorised()
+  {
     // gravity acceleration [m/s^2] 
     const double g = gravity_;
 
@@ -453,7 +471,8 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudes(double time)
+  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesNonVectorised(
+      double time)
   {
     // alias
     auto& r = rho_;
@@ -722,7 +741,8 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesVectorised(double time)
+  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesVectorised(
+      double time)
   {
     // alias
     auto& r = rho_;
@@ -1068,7 +1088,8 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesReference(double time)
+  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesReference(
+      double time)
   {
     // alias
     auto& r = rho_ref_;

--- a/gz-waves/src/WaveSimulationFFT2.cc
+++ b/gz-waves/src/WaveSimulationFFT2.cc
@@ -93,7 +93,7 @@ namespace waves
     ComputeBaseAmplitudes();
 
     // FFT 2D.
-    size_t n2 = this->nx_ * this->ny_;
+    size_t n2 = nx_ * ny_;
 
     // For height
     fft_in0_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
@@ -135,7 +135,7 @@ namespace waves
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::SetUseVectorised(bool value)
   {
-    this->use_vectorised = value;
+    use_vectorised_ = value;
     ComputeBaseAmplitudes();
   }
 
@@ -150,8 +150,8 @@ namespace waves
   void WaveSimulationFFT2Impl::SetWindVelocity(double ux, double uy)
   {
     // Update wind velocity and recompute base amplitudes.
-    this->u10_ = sqrt(ux*ux + uy *uy);
-    this->phi10_ = atan2(uy, ux);
+    u10_ = sqrt(ux*ux + uy *uy);
+    phi10_ = atan2(uy, ux);
 
     ComputeBaseAmplitudes();
   }
@@ -167,7 +167,7 @@ namespace waves
     Eigen::Ref<Eigen::MatrixXd> h)
   {
     // Populate input array
-    for (size_t i=0; i<this->nx_ * this->ny_; ++i)
+    for (size_t i=0; i<nx_ * ny_; ++i)
     {
       fft_in0_[i][0] = fft_h_[i].real();
       fft_in0_[i][1] = fft_h_[i].imag();
@@ -182,12 +182,12 @@ namespace waves
     // }
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // z(i,j) => z(x, y): x = j, y = i
-    for (size_t ikx = 0; ikx < this->nx_; ++ikx)
+    for (size_t ikx = 0; ikx < nx_; ++ikx)
     {
-      for (size_t iky = 0; iky < this->ny_; ++iky)
+      for (size_t iky = 0; iky < ny_; ++iky)
       {
-        int ij = ikx * this->ny_ + iky;
-        int xy = iky * this->nx_ + ikx;
+        int ij = ikx * ny_ + iky;
+        int xy = iky * nx_ + ikx;
         h(xy, 0) = fft_out0_[ij][0];
       }
     }
@@ -198,7 +198,7 @@ namespace waves
     Eigen::Ref<Eigen::MatrixXd> dhdx,
     Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
-    size_t n2 = this->nx_ * this->ny_;
+    size_t n2 = nx_ * ny_;
 
     // Populate input array
     for (size_t i=0; i<n2; ++i)
@@ -223,12 +223,12 @@ namespace waves
     // z(i,j) => z(x, y): x = j, y = i
     // dz(i,j)/di => dz(x, y)/dy: x = j, y = i
     // dz(i,j)/dj => dz(x, y)/dx: x = j, y = i
-    for (size_t ikx = 0; ikx < this->nx_; ++ikx)
+    for (size_t ikx = 0; ikx < nx_; ++ikx)
     {
-      for (size_t iky = 0; iky < this->ny_; ++iky)
+      for (size_t iky = 0; iky < ny_; ++iky)
       {
-        int ij = ikx * this->ny_ + iky;
-        int xy = iky * this->nx_ + ikx;
+        int ij = ikx * ny_ + iky;
+        int xy = iky * nx_ + ikx;
         dhdy(xy, 0) = fft_out1_[ij][0];
         dhdx(xy, 0) = fft_out2_[ij][0];
       }
@@ -240,7 +240,7 @@ namespace waves
     Eigen::Ref<Eigen::MatrixXd> sx,
     Eigen::Ref<Eigen::MatrixXd> sy)
   {
-    size_t n2 = this->nx_ * this->ny_;
+    size_t n2 = nx_ * ny_;
 
     // Populate input array
     for (size_t i=0; i<n2; ++i)
@@ -264,12 +264,12 @@ namespace waves
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // sy(i,j) => si(x, y): x = j, y = i
     // sx(i,j) => sj(x, y): x = j, y = i
-    for (size_t ikx = 0; ikx < this->nx_; ++ikx)
+    for (size_t ikx = 0; ikx < nx_; ++ikx)
     {
-      for (size_t iky = 0; iky < this->ny_; ++iky)
+      for (size_t iky = 0; iky < ny_; ++iky)
       {
-        int ij = ikx * this->ny_ + iky;
-        int xy = iky * this->nx_ + ikx;
+        int ij = ikx * ny_ + iky;
+        int xy = iky * nx_ + ikx;
         sy(xy, 0) = fft_out3_[ij][0] * lambda_ * -1.0;
         sx(xy, 0) = fft_out4_[ij][0] * lambda_ * -1.0;
       }
@@ -282,7 +282,7 @@ namespace waves
     Eigen::Ref<Eigen::MatrixXd> dsydy,
     Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    size_t n2 = this->nx_ * this->ny_;
+    size_t n2 = nx_ * ny_;
 
     // Populate input array
     for (size_t i=0; i<n2; ++i)
@@ -311,12 +311,12 @@ namespace waves
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // sy(i,j) => si(x, y): x = j, y = i
     // sx(i,j) => sj(x, y): x = j, y = i
-    for (size_t ikx = 0; ikx < this->nx_; ++ikx)
+    for (size_t ikx = 0; ikx < nx_; ++ikx)
     {
-      for (size_t iky = 0; iky < this->ny_; ++iky)
+      for (size_t iky = 0; iky < ny_; ++iky)
       {
-        int ij = ikx * this->ny_ + iky;
-        int xy = iky * this->nx_ + ikx;
+        int ij = ikx * ny_ + iky;
+        int xy = iky * nx_ + ikx;
         dsydy(xy, 0) = fft_out5_[ij][0] * lambda_ * -1.0;
         dsxdx(xy, 0) = fft_out6_[ij][0] * lambda_ * -1.0;
         dsxdy(xy, 0) = fft_out7_[ij][0] * lambda_ *  1.0;
@@ -330,7 +330,7 @@ namespace waves
     // gravity acceleration [m/s^2] 
     const double g = 9.81;
 
-    size_t n2 = this->nx_ * this->ny_;
+    size_t n2 = nx_ * ny_;
 
     // storage for Fourier coefficients
     fft_h_ = Eigen::VectorXcd::Zero(n2);
@@ -344,30 +344,30 @@ namespace waves
 
     // continuous two-sided elevation variance spectrum
     Eigen::VectorXd cap_psi_2s_math =
-        Eigen::VectorXd::Zero(this->nx_ * this->ny_);
+        Eigen::VectorXd::Zero(nx_ * ny_);
 
     // calculate spectrum in math-order (not vectorised)
-    for (int ikx = 0; ikx < this->nx_; ++ikx)
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
       // kx: fftfreq and ifftshift
-      const double kx = (ikx - this->nx_/2) * this->kx_f_;
+      const double kx = (ikx - nx_/2) * kx_f_;
       const double kx2 = kx*kx;
-      this->kx_math_[ikx] = kx;
-      this->kx_fft_[(ikx + nx_/2) % nx_] = kx;
+      kx_math_[ikx] = kx;
+      kx_fft_[(ikx + nx_/2) % nx_] = kx;
 
-      for (int iky = 0; iky < this->ny_; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
         // ky: fftfreq and ifftshift
-        const double ky = (iky - this->ny_/2) * this->ky_f_;
+        const double ky = (iky - ny_/2) * ky_f_;
         const double ky2 = ky*ky;
-        this->ky_math_[iky] = ky;
-        this->ky_fft_[(iky + ny_/2) % ny_] = ky;
+        ky_math_[iky] = ky;
+        ky_fft_[(iky + ny_/2) % ny_] = ky;
         
         const double k = sqrt(kx2 + ky2);
         const double phi = atan2(ky, kx);
 
         // index for flattened array
-        int idx = ikx * this->ny_ + iky;
+        int idx = ikx * ny_ + iky;
 
         if (k == 0.0)
         {
@@ -376,38 +376,38 @@ namespace waves
         else
         {
           double cap_psi = 0.0;
-          if (this->use_symmetric_spreading_fn_)
+          if (use_symmetric_spreading_fn_)
           {
             // standing waves - symmetric spreading function
             cap_psi = WaveSimulationFFT2Impl::ECKVSpreadingFunction(
-                k, phi - this->phi10_, this->u10_, this->cap_omega_c_);
+                k, phi - phi10_, u10_, cap_omega_c_);
           }
           else
           {
             // travelling waves - asymmetric spreading function
             cap_psi = WaveSimulationFFT2Impl::Cos2SSpreadingFunction(
-                this->s_param_, phi - this->phi10_, this->u10_, this->cap_omega_c_);
+                s_param_, phi - phi10_, u10_, cap_omega_c_);
           }
           const double cap_s =
               WaveSimulationFFT2Impl::ECKVOmniDirectionalSpectrum(
-                  k, this->u10_, this->cap_omega_c_);
+                  k, u10_, cap_omega_c_);
           cap_psi_2s_math[idx] = cap_s * cap_psi / k;
         }
       }
     }
 
     // convert to fft-order
-    Eigen::VectorXd cap_psi_2s_fft = Eigen::VectorXd::Zero(this->nx_ * this->ny_);
-    for (int ikx = 0; ikx < this->nx_; ++ikx)
+    Eigen::VectorXd cap_psi_2s_fft = Eigen::VectorXd::Zero(nx_ * ny_);
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
       int ikx_fft = (ikx + nx_/2) % nx_;
-      for (int iky = 0; iky < this->ny_; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
         int iky_fft = (iky + ny_/2) % ny_;
 
         // index for flattened array
-        int idx = ikx * this->ny_ + iky;
-        int idx_fft = ikx_fft * this->ny_ + iky_fft;
+        int idx = ikx * ny_ + iky;
+        int idx_fft = ikx_fft * ny_ + iky_fft;
 
         cap_psi_2s_fft[idx_fft] = cap_psi_2s_math[idx];
       }
@@ -415,8 +415,8 @@ namespace waves
 
     // square-root of two-sided discrete elevation variance spectrum
     double cap_psi_norm = 0.5;
-    double delta_kx = this->kx_f_;
-    double delta_ky = this->ky_f_;
+    double delta_kx = kx_f_;
+    double delta_ky = ky_f_;
     // double c1 = cap_psi_norm * sqrt(delta_kx * delta_ky);
 
     // iid random normals for real and imaginary parts of the amplitudes
@@ -426,29 +426,29 @@ namespace waves
 
     for (int i = 0; i < n2; ++i)
     {
-      // this->cap_psi_2s_root[i] = c1 * sqrt(cap_psi_2s_fft[i]);
-      this->cap_psi_2s_root_[i] =
+      // cap_psi_2s_root[i] = c1 * sqrt(cap_psi_2s_fft[i]);
+      cap_psi_2s_root_[i] =
           cap_psi_norm * sqrt(cap_psi_2s_fft[i] * delta_kx * delta_ky);
 
-      this->rho_[i] = distribution(generator);
-      this->sigma_[i] = distribution(generator);
+      rho_[i] = distribution(generator);
+      sigma_[i] = distribution(generator);
     }
 
 
     // angular temporal frequency for time-dependent (from dispersion)
-    for (int ikx = 0; ikx < this->nx_; ++ikx)
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      double kx = this->kx_fft_[ikx];
+      double kx = kx_fft_[ikx];
       double kx2 = kx*kx;
-      for (int iky = 0; iky < this->ny_; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
-        double ky = this->ky_fft_[iky];
+        double ky = ky_fft_[iky];
         double ky2 = ky*ky;
         double k = sqrt(kx2 + ky2);
 
         // index for flattened array
-        int idx = ikx * this->ny_ + iky;
-        this->omega_k_[idx] = sqrt(g * k);
+        int idx = ikx * ny_ + iky;
+        omega_k_[idx] = sqrt(g * k);
       }
     }
   }
@@ -457,11 +457,9 @@ namespace waves
   void WaveSimulationFFT2Impl::ComputeCurrentAmplitudes(double time)
   {
     // alias
-    auto& nx_ = this->nx_;
-    auto& ny_ = this->ny_;
-    auto& r = this->rho_;
-    auto& s = this->sigma_;
-    auto& psi_root = this->cap_psi_2s_root_;
+    auto& r = rho_;
+    auto& s = sigma_;
+    auto& psi_root = cap_psi_2s_root_;
 
     // time update
     Eigen::VectorXd cos_omega_k = Eigen::VectorXd::Zero(nx_ * ny_);
@@ -471,9 +469,9 @@ namespace waves
       for (int iky = 0; iky < ny_; ++iky)
       {
         // index for flattened array
-        int idx = ikx * this->ny_ + iky;
+        int idx = ikx * ny_ + iky;
 
-        double omega_t = this->omega_k_[idx] * time;
+        double omega_t = omega_k_[idx] * time;
         cos_omega_k(idx) = cos(omega_t);
         sin_omega_k(idx) = sin(omega_t);
       }
@@ -486,10 +484,10 @@ namespace waves
       for (int iky = 1; iky < ny_; ++iky)
       {
         // index for flattened array (ikx, iky)
-        int idx = ikx * this->ny_ + iky;
+        int idx = ikx * ny_ + iky;
 
         // index for conjugate (nx_-ikx, ny_-iky)
-        int cdx = (nx_-ikx) * this->ny_ + (ny_-iky);
+        int cdx = (nx_-ikx) * ny_ + (ny_-iky);
 
         zhat[idx] = complex(
             + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
@@ -504,10 +502,10 @@ namespace waves
       int ikx = 0;
 
       // index for flattened array (ikx, iky)
-      int idx = ikx * this->ny_ + iky;
+      int idx = ikx * ny_ + iky;
 
       // index for conjugate (ikx, ny_-iky)
-      int cdx = ikx * this->ny_ + (ny_-iky);
+      int cdx = ikx * ny_ + (ny_-iky);
 
       zhat[idx] = complex(
           + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
@@ -522,10 +520,10 @@ namespace waves
       int iky = 0;
 
       // index for flattened array (ikx, iky)
-      int idx = ikx * this->ny_ + iky;
+      int idx = ikx * ny_ + iky;
 
       // index for conjugate (nx_-ikx, iky)
-      int cdx = (nx_-ikx) * this->ny_ + iky;
+      int cdx = (nx_-ikx) * ny_ + iky;
 
       zhat[idx] = complex(
           + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
@@ -542,11 +540,11 @@ namespace waves
     const complex czero(0.0, 0.0);
     for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      double kx = this->kx_fft_[ikx];
+      double kx = kx_fft_[ikx];
       double kx2 = kx*kx;
       for (int iky = 0; iky < ny_; ++iky)
       {
-        double ky = this->ky_fft_[iky];
+        double ky = ky_fft_[iky];
         double ky2 = ky*ky;
         double k = sqrt(kx2 + ky2);
         double ook = 1.0 / k;
@@ -560,14 +558,14 @@ namespace waves
         complex hiok = hi * ook;
 
         // height (amplitude)
-        this->fft_h_[idx] = h;
+        fft_h_[idx] = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        this->fft_h_ikx_[idx] = hi * kx;
-        this->fft_h_iky_[idx] = hi * ky;
+        fft_h_ikx_[idx] = hi * kx;
+        fft_h_iky_[idx] = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
@@ -599,7 +597,7 @@ namespace waves
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeBaseAmplitudesReference()
   {
-    size_t n2 = this->nx_ * this->ny_;
+    size_t n2 = nx_ * ny_;
 
     // storage for Fourier coefficients
     fft_h_ = Eigen::VectorXcd::Zero(n2);
@@ -612,14 +610,14 @@ namespace waves
     fft_h_kxky_ = Eigen::VectorXcd::Zero(n2);
 
     // arrays for reference version
-    if (this->cap_psi_2s_root_ref_.size() == 0 || 
-        this->cap_psi_2s_root_ref_.rows() != this->nx_ ||
-        this->cap_psi_2s_root_ref_.cols() != this->ny_)
+    if (cap_psi_2s_root_ref_.size() == 0 || 
+        cap_psi_2s_root_ref_.rows() != nx_ ||
+        cap_psi_2s_root_ref_.cols() != ny_)
     {
-      this->cap_psi_2s_root_ref_ = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
-      this->rho_ref_ = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
-      this->sigma_ref_ = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
-      this->omega_k_ref_ = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
+      cap_psi_2s_root_ref_ = Eigen::MatrixXd::Zero(nx_, ny_);
+      rho_ref_ = Eigen::MatrixXd::Zero(nx_, ny_);
+      sigma_ref_ = Eigen::MatrixXd::Zero(nx_, ny_);
+      omega_k_ref_ = Eigen::MatrixXd::Zero(nx_, ny_);
     }
 
     // Guide to indexing conventions:  1. index, 2. math-order, 3. fft-order
@@ -630,72 +628,72 @@ namespace waves
     // 
 
     // fftfreq and ifftshift
-    for(int ikx = 0; ikx < this->nx_; ++ikx)
+    for(int ikx = 0; ikx < nx_; ++ikx)
     {
-      const double kx = (ikx - this->nx_/2) * this->kx_f_;
+      const double kx = (ikx - nx_/2) * kx_f_;
       kx_math_[ikx] = kx;
       kx_fft_[(ikx + nx_/2) % nx_] = kx;
     }
 
-    for(int iky = 0; iky < this->ny_; ++iky)
+    for(int iky = 0; iky < ny_; ++iky)
     {
-      const double ky = (iky - this->ny_/2) * this->ky_f_;
+      const double ky = (iky - ny_/2) * ky_f_;
       ky_math_[iky] = ky;
       ky_fft_[(iky + ny_/2) % ny_] = ky;
     }
 
     // debug
     gzmsg << "WaveSimulationFFT2" << "\n";
-    gzmsg << "lx:          " << this->lx_ << "\n";
-    gzmsg << "ly:          " << this->ly_ << "\n";
-    gzmsg << "nx:          " << this->nx_ << "\n";
-    gzmsg << "ny:          " << this->ny_ << "\n";
-    gzmsg << "delta_x:     " << this->delta_x_ << "\n";
-    gzmsg << "delta_y:     " << this->delta_y_ << "\n";
-    gzmsg << "lambda_x_f:  " << this->lambda_x_f_ << "\n";
-    gzmsg << "lambda_y_f:  " << this->lambda_y_f_ << "\n";
-    gzmsg << "nu_x_f:      " << this->nu_x_f_ << "\n";
-    gzmsg << "nu_y_f:      " << this->nu_y_f_ << "\n";
-    gzmsg << "nu_x_ny:     " << this->nu_x_ny_ << "\n";
-    gzmsg << "nu_y_ny:     " << this->nu_y_ny_ << "\n";
-    gzmsg << "kx_f:        " << this->kx_f_ << "\n";
-    gzmsg << "ky_f:        " << this->ky_f_ << "\n";
-    gzmsg << "kx_ny:       " << this->kx_ny_ << "\n";
-    gzmsg << "ky_ny:       " << this->ky_ny_ << "\n";
+    gzmsg << "lx:          " << lx_ << "\n";
+    gzmsg << "ly:          " << ly_ << "\n";
+    gzmsg << "nx:          " << nx_ << "\n";
+    gzmsg << "ny:          " << ny_ << "\n";
+    gzmsg << "delta_x:     " << delta_x_ << "\n";
+    gzmsg << "delta_y:     " << delta_y_ << "\n";
+    gzmsg << "lambda_x_f:  " << lambda_x_f_ << "\n";
+    gzmsg << "lambda_y_f:  " << lambda_y_f_ << "\n";
+    gzmsg << "nu_x_f:      " << nu_x_f_ << "\n";
+    gzmsg << "nu_y_f:      " << nu_y_f_ << "\n";
+    gzmsg << "nu_x_ny:     " << nu_x_ny_ << "\n";
+    gzmsg << "nu_y_ny:     " << nu_y_ny_ << "\n";
+    gzmsg << "kx_f:        " << kx_f_ << "\n";
+    gzmsg << "ky_f:        " << ky_f_ << "\n";
+    gzmsg << "kx_ny:       " << kx_ny_ << "\n";
+    gzmsg << "ky_ny:       " << ky_ny_ << "\n";
     #if 0
     {
       std::ostringstream os;
-      os << "[ "; for (auto& v : this->kx_fft_) os << v << " "; os << "]\n";
+      os << "[ "; for (auto& v : kx_fft_) os << v << " "; os << "]\n";
       gzmsg << "kx_fft:      " << os.str();
     }
     {
       std::ostringstream os;
-      os << "[ "; for (auto& v : this->ky_fft_) os << v << " "; os << "]\n";
+      os << "[ "; for (auto& v : ky_fft_) os << v << " "; os << "]\n";
       gzmsg << "ky_fft:      " << os.str();
     }
     {
       std::ostringstream os;
-      os << "[ "; for (auto& v : this->kx_math_) os << v << " "; os << "]\n";
+      os << "[ "; for (auto& v : kx_math_) os << v << " "; os << "]\n";
       gzmsg << "kx_math:     " << os.str();
     }
     {
       std::ostringstream os;
-      os << "[ "; for (auto& v : this->ky_math_) os << v << " "; os << "]\n";
+      os << "[ "; for (auto& v : ky_math_) os << v << " "; os << "]\n";
       gzmsg << "ky_math:     " << os.str();
     }
     #endif
 
     // continuous two-sided elevation variance spectrum
-    Eigen::MatrixXd cap_psi_2s_math = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
+    Eigen::MatrixXd cap_psi_2s_math = Eigen::MatrixXd::Zero(nx_, ny_);
 
     // calculate spectrum in math-order (not vectorised)
-    for (int ikx = 0; ikx < this->nx_; ++ikx)
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      for (int iky = 0; iky < this->ny_; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
-        double k = sqrt(this->kx_math_[ikx]*this->kx_math_[ikx]
-            + this->ky_math_[iky]*this->ky_math_[iky]);
-        double phi = atan2(this->ky_math_[iky], this->kx_math_[ikx]);
+        double k = sqrt(kx_math_[ikx]*kx_math_[ikx]
+            + ky_math_[iky]*ky_math_[iky]);
+        double phi = atan2(ky_math_[iky], kx_math_[ikx]);
 
         if (k == 0.0)
         {
@@ -704,20 +702,20 @@ namespace waves
         else
         {
           double cap_psi = 0.0;
-          if (this->use_symmetric_spreading_fn_)
+          if (use_symmetric_spreading_fn_)
           {
             // standing waves - symmetric spreading function
             cap_psi = WaveSimulationFFT2Impl::ECKVSpreadingFunction(
-                k, phi - this->phi10_, this->u10_, this->cap_omega_c_);
+                k, phi - phi10_, u10_, cap_omega_c_);
           }
           else
           {
             // travelling waves - asymmetric spreading function
             cap_psi = WaveSimulationFFT2Impl::Cos2SSpreadingFunction(
-                this->s_param_, phi - this->phi10_, this->u10_, this->cap_omega_c_);
+                s_param_, phi - phi10_, u10_, cap_omega_c_);
           }
           double cap_s = WaveSimulationFFT2Impl::ECKVOmniDirectionalSpectrum(
-              k, this->u10_, this->cap_omega_c_);
+              k, u10_, cap_omega_c_);
           cap_psi_2s_math(ikx, iky) = cap_s * cap_psi / k;
         }
       }
@@ -728,7 +726,7 @@ namespace waves
     {
       std::ostringstream os;
       os << "[\n";
-      for (int ikx = 0; ikx < this->nx_; ++ikx)
+      for (int ikx = 0; ikx < nx_; ++ikx)
       {
         os << " [ ";
         for (auto& v : cap_psi_2s_math[ikx])
@@ -744,11 +742,11 @@ namespace waves
     #endif
 
     // convert to fft-order
-    Eigen::MatrixXd cap_psi_2s_fft = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
-    for (int ikx = 0; ikx < this->nx_; ++ikx)
+    Eigen::MatrixXd cap_psi_2s_fft = Eigen::MatrixXd::Zero(nx_, ny_);
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
       int ikx_fft = (ikx + nx_/2) % nx_;
-      for (int iky = 0; iky < this->ny_; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
         int iky_fft = (iky + ny_/2) % ny_;
         cap_psi_2s_fft(ikx_fft, iky_fft) = cap_psi_2s_math(ikx, iky);
@@ -757,14 +755,14 @@ namespace waves
 
     // square-root of two-sided discrete elevation variance spectrum
     double cap_psi_norm = 0.5;
-    double delta_kx = this->kx_f_;
-    double delta_ky = this->ky_f_;
+    double delta_kx = kx_f_;
+    double delta_ky = ky_f_;
 
-    for (int ikx = 0; ikx < this->nx_; ++ikx)
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      for (int iky = 0; iky < this->ny_; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
-        this->cap_psi_2s_root_ref_(ikx, iky) =
+        cap_psi_2s_root_ref_(ikx, iky) =
             cap_psi_norm * sqrt(cap_psi_2s_fft(ikx, iky) * delta_kx * delta_ky);
       }
     }
@@ -774,12 +772,12 @@ namespace waves
     std::default_random_engine generator(seed);
     std::normal_distribution<double> distribution(0.0, 1.0);
 
-    for (int ikx = 0; ikx < this->nx_; ++ikx)
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      for (int iky = 0; iky < this->ny_; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
-        this->rho_ref_(ikx, iky) = distribution(generator);
-        this->sigma_ref_(ikx, iky) = distribution(generator);
+        rho_ref_(ikx, iky) = distribution(generator);
+        sigma_ref_(ikx, iky) = distribution(generator);
       }
     }
 
@@ -787,16 +785,16 @@ namespace waves
     double g = 9.81;
 
     // angular temporal frequency for time-dependent (from dispersion)
-    for (int ikx = 0; ikx < this->nx_; ++ikx)
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      double kx = this->kx_fft_[ikx];
+      double kx = kx_fft_[ikx];
       double kx2 = kx*kx;
-      for (int iky = 0; iky < this->ny_; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
-        double ky = this->ky_fft_[iky];
+        double ky = ky_fft_[iky];
         double ky2 = ky*ky;
         double k = sqrt(kx2 + ky2);
-        this->omega_k_ref_(ikx, iky) = sqrt(g * k);
+        omega_k_ref_(ikx, iky) = sqrt(g * k);
       }
     }
   }
@@ -805,11 +803,9 @@ namespace waves
   void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesReference(double time)
   {
     // alias
-    auto& nx_ = this->nx_;
-    auto& ny_ = this->ny_;
-    auto& r = this->rho_ref_;
-    auto& s = this->sigma_ref_;
-    auto& psi_root = this->cap_psi_2s_root_ref_;
+    auto& r = rho_ref_;
+    auto& s = sigma_ref_;
+    auto& psi_root = cap_psi_2s_root_ref_;
 
     // time update
     Eigen::MatrixXd cos_omega_k = Eigen::MatrixXd::Zero(nx_, ny_);
@@ -818,8 +814,8 @@ namespace waves
     {
       for (int iky = 0; iky < ny_; ++iky)
       {
-        cos_omega_k(ikx, iky) = cos(this->omega_k_ref_(ikx, iky) * time);
-        sin_omega_k(ikx, iky) = sin(this->omega_k_ref_(ikx, iky) * time);
+        cos_omega_k(ikx, iky) = cos(omega_k_ref_(ikx, iky) * time);
+        sin_omega_k(ikx, iky) = sin(omega_k_ref_(ikx, iky) * time);
       }
     }
 
@@ -868,11 +864,11 @@ namespace waves
     const complex czero(0.0, 0.0);
     for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      double kx = this->kx_fft_[ikx];
+      double kx = kx_fft_[ikx];
       double kx2 = kx*kx;
       for (int iky = 0; iky < ny_; ++iky)
       {
-        double ky = this->ky_fft_[iky];
+        double ky = ky_fft_[iky];
         double ky2 = ky*ky;
         double k = sqrt(kx2 + ky2);
         double ook = 1.0 / k;
@@ -886,20 +882,20 @@ namespace waves
         complex hiok = hi * ook;
 
         // height (amplitude)
-        this->fft_h_[idx] = h;
+        fft_h_[idx] = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        this->fft_h_ikx_[idx] = hi * kx;
-        this->fft_h_iky_[idx] = hi * ky;
+        fft_h_ikx_[idx] = hi * kx;
+        fft_h_iky_[idx] = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
         {          
-          fft_sx_[idx]    = czero;
-          fft_sy_[idx]    = czero;
+          fft_sx_[idx]     = czero;
+          fft_sy_[idx]     = czero;
           fft_h_kxkx_[idx] = czero;
           fft_h_kyky_[idx] = czero;
           fft_h_kxky_[idx] = czero;
@@ -912,8 +908,8 @@ namespace waves
           complex hkyky = hok * ky2;
           complex hkxky = hok * kx * ky;
           
-          fft_sx_[idx]    = dx;
-          fft_sy_[idx]    = dy;
+          fft_sx_[idx]     = dx;
+          fft_sy_[idx]     = dy;
           fft_h_kxkx_[idx] = hkxkx;
           fft_h_kyky_[idx] = hkyky;
           fft_h_kxky_[idx] = hkxky;

--- a/gz-waves/src/WaveSimulationFFT2.cc
+++ b/gz-waves/src/WaveSimulationFFT2.cc
@@ -113,7 +113,7 @@ namespace waves
       {
         int ij = ikx * ny_ + iky;
         int xy = iky * nx_ + ikx;
-        h(xy, 0) = fft_out0_(ij, 0).real();
+        h(xy, 0) = fft_out0_(ikx, iky).real();
       }
     }
 #else
@@ -142,8 +142,8 @@ namespace waves
       {
         int ij = ikx * ny_ + iky;
         int xy = iky * nx_ + ikx;
-        dhdy(xy, 0) = fft_out1_(ij, 0).real();
-        dhdx(xy, 0) = fft_out2_(ij, 0).real();
+        dhdy(xy, 0) = fft_out1_(ikx, iky).real();
+        dhdx(xy, 0) = fft_out2_(ikx, iky).real();
       }
     }
 #else
@@ -178,8 +178,8 @@ namespace waves
       {
         int ij = ikx * ny_ + iky;
         int xy = iky * nx_ + ikx;
-        sy(xy, 0) = fft_out3_(ij, 0).real() * lambda_ * -1.0;
-        sx(xy, 0) = fft_out4_(ij, 0).real() * lambda_ * -1.0;
+        sy(xy, 0) = fft_out3_(ikx, iky).real() * lambda_ * -1.0;
+        sx(xy, 0) = fft_out4_(ikx, iky).real() * lambda_ * -1.0;
       }
     }
 #else
@@ -211,9 +211,9 @@ namespace waves
       {
         int ij = ikx * ny_ + iky;
         int xy = iky * nx_ + ikx;
-        dsydy(xy, 0) = fft_out5_(ij, 0).real() * lambda_ * -1.0;
-        dsxdx(xy, 0) = fft_out6_(ij, 0).real() * lambda_ * -1.0;
-        dsxdy(xy, 0) = fft_out7_(ij, 0).real() * lambda_ *  1.0;
+        dsydy(xy, 0) = fft_out5_(ikx, iky).real() * lambda_ * -1.0;
+        dsxdx(xy, 0) = fft_out6_(ikx, iky).real() * lambda_ * -1.0;
+        dsxdy(xy, 0) = fft_out7_(ikx, iky).real() * lambda_ *  1.0;
       }
     }
 #else
@@ -471,23 +471,23 @@ namespace waves
         complex hiok = hi * ook;
 
         // height (amplitude)
-        fft_h_(idx, 0) = h;
+        fft_h_(ikx, iky) = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        fft_h_ikx_(idx, 0) = hi * kx;
-        fft_h_iky_(idx, 0) = hi * ky;
+        fft_h_ikx_(ikx, iky) = hi * kx;
+        fft_h_iky_(ikx, iky) = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
         {          
-          fft_sx_(idx, 0)     = czero;
-          fft_sy_(idx, 0)     = czero;
-          fft_h_kxkx_(idx, 0) = czero;
-          fft_h_kyky_(idx, 0) = czero;
-          fft_h_kxky_(idx, 0) = czero;
+          fft_sx_(ikx, iky)     = czero;
+          fft_sy_(ikx, iky)     = czero;
+          fft_h_kxkx_(ikx, iky) = czero;
+          fft_h_kyky_(ikx, iky) = czero;
+          fft_h_kxky_(ikx, iky) = czero;
         }
         else
         {
@@ -497,11 +497,11 @@ namespace waves
           complex hkyky = hok * ky2;
           complex hkxky = hok * kx * ky;
           
-          fft_sx_(idx, 0)     = dx;
-          fft_sy_(idx, 0)     = dy;
-          fft_h_kxkx_(idx, 0) = hkxkx;
-          fft_h_kyky_(idx, 0) = hkyky;
-          fft_h_kxky_(idx, 0) = hkxky;
+          fft_sx_(ikx, iky)     = dx;
+          fft_sy_(ikx, iky)     = dy;
+          fft_h_kxkx_(ikx, iky) = hkxkx;
+          fft_h_kyky_(ikx, iky) = hkyky;
+          fft_h_kxky_(ikx, iky) = hkxky;
         }
       }
     }
@@ -671,32 +671,29 @@ namespace waves
         double k = sqrt(kx2 + ky2);
         double ook = 1.0 / k;
 
-        // index for flattened arrays
-        int idx = ikx * ny_ + iky;
-
         complex h  = zhat(ikx, iky);
         complex hi = h * iunit;
         complex hok = h * ook;
         complex hiok = hi * ook;
 
         // height (amplitude)
-        fft_h_(idx, 0) = h;
+        fft_h_(ikx, iky) = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        fft_h_ikx_(idx, 0) = hi * kx;
-        fft_h_iky_(idx, 0) = hi * ky;
+        fft_h_ikx_(ikx, iky) = hi * kx;
+        fft_h_iky_(ikx, iky) = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
         {          
-          fft_sx_(idx, 0)     = czero;
-          fft_sy_(idx, 0)     = czero;
-          fft_h_kxkx_(idx, 0) = czero;
-          fft_h_kyky_(idx, 0) = czero;
-          fft_h_kxky_(idx, 0) = czero;
+          fft_sx_(ikx, iky)     = czero;
+          fft_sy_(ikx, iky)     = czero;
+          fft_h_kxkx_(ikx, iky) = czero;
+          fft_h_kyky_(ikx, iky) = czero;
+          fft_h_kxky_(ikx, iky) = czero;
         }
         else
         {
@@ -706,11 +703,11 @@ namespace waves
           complex hkyky = hok * ky2;
           complex hkxky = hok * kx * ky;
           
-          fft_sx_(idx, 0)     = dx;
-          fft_sy_(idx, 0)     = dy;
-          fft_h_kxkx_(idx, 0) = hkxkx;
-          fft_h_kyky_(idx, 0) = hkyky;
-          fft_h_kxky_(idx, 0) = hkxky;
+          fft_sx_(ikx, iky)     = dx;
+          fft_sy_(ikx, iky)     = dy;
+          fft_h_kxkx_(ikx, iky) = hkxkx;
+          fft_h_kyky_(ikx, iky) = hkyky;
+          fft_h_kxky_(ikx, iky) = hkxky;
         }
       }
     }
@@ -968,32 +965,29 @@ namespace waves
         double k = sqrt(kx2 + ky2);
         double ook = 1.0 / k;
 
-        // index for flattened arrays
-        int idx = ikx * ny_ + iky;
-
         complex h  = zhat(ikx, iky);
         complex hi = h * iunit;
         complex hok = h * ook;
         complex hiok = hi * ook;
 
         // height (amplitude)
-        fft_h_(idx, 0) = h;
+        fft_h_(ikx, iky) = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        fft_h_ikx_(idx, 0) = hi * kx;
-        fft_h_iky_(idx, 0) = hi * ky;
+        fft_h_ikx_(ikx, iky) = hi * kx;
+        fft_h_iky_(ikx, iky) = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
         {          
-          fft_sx_(idx, 0)     = czero;
-          fft_sy_(idx, 0)     = czero;
-          fft_h_kxkx_(idx, 0) = czero;
-          fft_h_kyky_(idx, 0) = czero;
-          fft_h_kxky_(idx, 0) = czero;
+          fft_sx_(ikx, iky)     = czero;
+          fft_sy_(ikx, iky)     = czero;
+          fft_h_kxkx_(ikx, iky) = czero;
+          fft_h_kyky_(ikx, iky) = czero;
+          fft_h_kxky_(ikx, iky) = czero;
         }
         else
         {
@@ -1003,11 +997,11 @@ namespace waves
           complex hkyky = hok * ky2;
           complex hkxky = hok * kx * ky;
           
-          fft_sx_(idx, 0)     = dx;
-          fft_sy_(idx, 0)     = dy;
-          fft_h_kxkx_(idx, 0) = hkxkx;
-          fft_h_kyky_(idx, 0) = hkyky;
-          fft_h_kxky_(idx, 0) = hkxky;
+          fft_sx_(ikx, iky)     = dx;
+          fft_sy_(ikx, iky)     = dy;
+          fft_h_kxkx_(ikx, iky) = hkxkx;
+          fft_h_kyky_(ikx, iky) = hkyky;
+          fft_h_kxky_(ikx, iky) = hkxky;
         }
       }
     }
@@ -1016,17 +1010,15 @@ namespace waves
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::InitFFTCoeffStorage()
   {
-    size_t n2 = nx_ * ny_;
-
     // initialise storage for Fourier coefficients
-    fft_h_      = Eigen::VectorXcd::Zero(n2, 1);
-    fft_h_ikx_  = Eigen::VectorXcd::Zero(n2, 1);
-    fft_h_iky_  = Eigen::VectorXcd::Zero(n2, 1);
-    fft_sx_     = Eigen::VectorXcd::Zero(n2, 1);
-    fft_sy_     = Eigen::VectorXcd::Zero(n2, 1);
-    fft_h_kxkx_ = Eigen::VectorXcd::Zero(n2, 1);
-    fft_h_kyky_ = Eigen::VectorXcd::Zero(n2, 1);
-    fft_h_kxky_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_h_      = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_ikx_  = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_iky_  = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_sx_     = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_sy_     = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_kxkx_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_kyky_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_kxky_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
   }
 
   //////////////////////////////////////////////////
@@ -1056,19 +1048,17 @@ namespace waves
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::CreateFFTWPlans()
   {
-    size_t n2 = nx_ * ny_;
-
     // elevation
-    fft_out0_ = Eigen::VectorXcd::Zero(n2, 1);
-    fft_out1_ = Eigen::VectorXcd::Zero(n2, 1);
-    fft_out2_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_out0_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out1_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out2_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
 
     // xy-displacements
-    fft_out3_ = Eigen::VectorXcd::Zero(n2, 1);
-    fft_out4_ = Eigen::VectorXcd::Zero(n2, 1);
-    fft_out5_ = Eigen::VectorXcd::Zero(n2, 1);
-    fft_out6_ = Eigen::VectorXcd::Zero(n2, 1);
-    fft_out7_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_out3_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out4_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out5_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out6_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out7_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
 
     // elevation
     fft_plan0_ = fftw_plan_dft_2d(nx_, ny_,

--- a/gz-waves/src/WaveSimulationFFT2.cc
+++ b/gz-waves/src/WaveSimulationFFT2.cc
@@ -123,22 +123,9 @@ namespace waves
   void WaveSimulationFFT2Impl::ComputeElevation(
     Eigen::Ref<Eigen::MatrixXd> h)
   {
-    // Populate input array
-    // for (size_t i=0; i<nx_ * ny_; ++i)
-    // {
-    //   fft_in0_[i][0] = fft_h_[i].real();
-    //   fft_in0_[i][1] = fft_h_[i].imag();
-    // }
-
-    // fft_in0_ = fft_h_;
-
-    // Run the FFT
+    // run the FFT
     fftw_execute(fft_plan0_);
 
-    // for (size_t i=0; i<n2; ++i)
-    // {
-    //   _heights[i] = fft_out0_[i][0];
-    // }
 #if USE_LOOP_FOR_OUTPUT_MAPPING
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // z(i,j) => z(x, y): x = j, y = i
@@ -162,30 +149,10 @@ namespace waves
     Eigen::Ref<Eigen::MatrixXd> dhdx,
     Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
-    // size_t n2 = nx_ * ny_;
-
-    // Populate input array
-    // for (size_t i=0; i<n2; ++i)
-    // {
-    //   fft_in1_[i][0] = fft_h_ikx_[i].real();
-    //   fft_in1_[i][1] = fft_h_ikx_[i].imag();
-
-    //   fft_in2_[i][0] = fft_h_iky_[i].real();
-    //   fft_in2_[i][1] = fft_h_iky_[i].imag();
-    // }
-
-    // fft_in1_ = fft_h_ikx_;
-    // fft_in2_ = fft_h_iky_;
-
-    // Run the FFTs
+    // run the FFTs
     fftw_execute(fft_plan1_);
     fftw_execute(fft_plan2_);
 
-    // for (size_t i=0; i<n2; ++i)
-    // {
-    //   dhdx[i] = fft_out1_[i][0];
-    //   dhdy[i] = fft_out2_[i][0];
-    // }
 #if USE_LOOP_FOR_OUTPUT_MAPPING
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // z(i,j) => z(x, y): x = j, y = i
@@ -214,22 +181,7 @@ namespace waves
     Eigen::Ref<Eigen::MatrixXd> sx,
     Eigen::Ref<Eigen::MatrixXd> sy)
   {
-    // size_t n2 = nx_ * ny_;
-
-    // Populate input array
-    // for (size_t i=0; i<n2; ++i)
-    // {
-    //   fft_in3_[i][0] = fft_sx_[i].real();
-    //   fft_in3_[i][1] = fft_sx_[i].imag();
-
-    //   fft_in4_[i][0] = fft_sy_[i].real();
-    //   fft_in4_[i][1] = fft_sy_[i].imag();
-    // }
-
-    // fft_in3_ = fft_sx_;
-    // fft_in4_ = fft_sy_;
-
-    // Run the FFTs
+    // run the FFTs
     fftw_execute(fft_plan3_);
     fftw_execute(fft_plan4_);
 
@@ -266,36 +218,11 @@ namespace waves
     Eigen::Ref<Eigen::MatrixXd> dsydy,
     Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    // size_t n2 = nx_ * ny_;
-
-    // Populate input array
-    // for (size_t i=0; i<n2; ++i)
-    // {
-    //   fft_in5_[i][0] = fft_h_kxkx_[i].real();
-    //   fft_in5_[i][1] = fft_h_kxkx_[i].imag();
-
-    //   fft_in6_[i][0] = fft_h_kyky_[i].real();
-    //   fft_in6_[i][1] = fft_h_kyky_[i].imag();
-
-    //   fft_in7_[i][0] = fft_h_kxky_[i].real();
-    //   fft_in7_[i][1] = fft_h_kxky_[i].imag();
-    // }
-
-    // fft_in5_ = fft_h_kxkx_;
-    // fft_in6_ = fft_h_kyky_;
-    // fft_in7_ = fft_h_kxky_;
-
-    // Run the FFTs
+    // run the FFTs
     fftw_execute(fft_plan5_);
     fftw_execute(fft_plan6_);
     fftw_execute(fft_plan7_);
 
-    // for (size_t i=0; i<n2; ++i)
-    // {
-    //   _dsxdx[i] = fft_out5_[i][0] * lambda_;
-    //   _dsydy[i] = fft_out6_[i][0] * lambda_;
-    //   _dsxdy[i] = fft_out7_[i][0] * lambda_;
-    // }
 #if USE_LOOP_FOR_OUTPUT_MAPPING
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // sy(i,j) => si(x, y): x = j, y = i
@@ -441,7 +368,6 @@ namespace waves
       rho_[i] = distribution(generator);
       sigma_[i] = distribution(generator);
     }
-
 
     // angular temporal frequency for time-dependent (from dispersion)
     for (int ikx = 0; ikx < nx_; ++ikx)
@@ -854,7 +780,8 @@ namespace waves
     gzmsg << "ky_f:         " << ky_f_ << "\n";
     gzmsg << "kx_nyquist:   " << kx_nyquist_ << "\n";
     gzmsg << "ky_nyquist:   " << ky_nyquist_ << "\n";
-    #if 0
+
+#if 0
     {
       std::ostringstream os;
       os << "[ "; for (auto& v : kx_fft_) os << v << " "; os << "]\n";
@@ -875,7 +802,7 @@ namespace waves
       os << "[ "; for (auto& v : ky_math_) os << v << " "; os << "]\n";
       gzmsg << "ky_math:     " << os.str();
     }
-    #endif
+#endif
 
     // continuous two-sided elevation variance spectrum
     Eigen::MatrixXd cap_psi_2s_math = Eigen::MatrixXd::Zero(nx_, ny_);
@@ -916,7 +843,7 @@ namespace waves
     }
 
     // debug
-    #if 0
+#if 0
     {
       std::ostringstream os;
       os << "[\n";
@@ -933,7 +860,7 @@ namespace waves
 
       gzmsg << "cap_psi_2s:  " << os.str();
     }
-    #endif
+#endif
 
     // convert to fft-order
     Eigen::MatrixXd cap_psi_2s_fft = Eigen::MatrixXd::Zero(nx_, ny_);
@@ -1049,8 +976,6 @@ namespace waves
 
     zhat(0, 0) = complex(0.0, 0.0);
 
-    /// \todo: change zhat to 1D array and use directly
-
     // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
     const complex iunit(0.0, 1.0);
     const complex czero(0.0, 0.0);
@@ -1155,53 +1080,19 @@ namespace waves
   {
     size_t n2 = nx_ * ny_;
 
-    // For height
-    // fft_in0_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    // fft_in1_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    // fft_in2_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    // fft_in0_  = Eigen::VectorXcd::Zero(n2);
-    // fft_in1_  = Eigen::VectorXcd::Zero(n2);
-    // fft_in2_  = Eigen::VectorXcd::Zero(n2);
-
-    // For xy-displacements
-    // fft_in3_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    // fft_in4_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    // fft_in5_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    // fft_in6_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    // fft_in7_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    // fft_in3_  = Eigen::VectorXcd::Zero(n2);
-    // fft_in4_  = Eigen::VectorXcd::Zero(n2);
-    // fft_in5_  = Eigen::VectorXcd::Zero(n2);
-    // fft_in6_  = Eigen::VectorXcd::Zero(n2);
-    // fft_in7_  = Eigen::VectorXcd::Zero(n2);
-
-    // For height
-    // fft_out0_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    // fft_out1_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    // fft_out2_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    // elevation
     fft_out0_ = Eigen::VectorXcd::Zero(n2);
     fft_out1_ = Eigen::VectorXcd::Zero(n2);
     fft_out2_ = Eigen::VectorXcd::Zero(n2);
 
-    // For xy-displacements
-    // fft_out3_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    // fft_out4_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    // fft_out5_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    // fft_out6_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    // fft_out7_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    // xy-displacements
     fft_out3_ = Eigen::VectorXcd::Zero(n2);
     fft_out4_ = Eigen::VectorXcd::Zero(n2);
     fft_out5_ = Eigen::VectorXcd::Zero(n2);
     fft_out6_ = Eigen::VectorXcd::Zero(n2);
     fft_out7_ = Eigen::VectorXcd::Zero(n2);
 
-    // For height
-    // fft_plan0_ = fftw_plan_dft_2d(nx_, ny_, fft_in0_, fft_out0_,
-    //     FFTW_BACKWARD, FFTW_ESTIMATE);
-    // fft_plan1_ = fftw_plan_dft_2d(nx_, ny_, fft_in1_, fft_out1_,
-    //     FFTW_BACKWARD, FFTW_ESTIMATE);
-    // fft_plan2_ = fftw_plan_dft_2d(nx_, ny_, fft_in2_, fft_out2_,
-    //     FFTW_BACKWARD, FFTW_ESTIMATE);
+    // elevation
     fft_plan0_ = fftw_plan_dft_2d(nx_, ny_,
         reinterpret_cast<fftw_complex*>(fft_h_.data()),
         reinterpret_cast<fftw_complex*>(fft_out0_.data()),
@@ -1215,17 +1106,7 @@ namespace waves
         reinterpret_cast<fftw_complex*>(fft_out2_.data()),
         FFTW_BACKWARD, FFTW_ESTIMATE);
 
-    // For xy-displacements
-    // fft_plan3_ = fftw_plan_dft_2d(nx_, ny_, fft_in3_, fft_out3_,
-    //     FFTW_BACKWARD, FFTW_ESTIMATE);
-    // fft_plan4_ = fftw_plan_dft_2d(nx_, ny_, fft_in4_, fft_out4_,
-    //     FFTW_BACKWARD, FFTW_ESTIMATE);
-    // fft_plan5_ = fftw_plan_dft_2d(nx_, ny_, fft_in5_, fft_out5_,
-    //     FFTW_BACKWARD, FFTW_ESTIMATE);
-    // fft_plan6_ = fftw_plan_dft_2d(nx_, ny_, fft_in6_, fft_out6_,
-    //     FFTW_BACKWARD, FFTW_ESTIMATE);
-    // fft_plan7_ = fftw_plan_dft_2d(nx_, ny_, fft_in7_, fft_out7_,
-    //     FFTW_BACKWARD, FFTW_ESTIMATE);
+    // xy-displacements
     fft_plan3_ = fftw_plan_dft_2d(nx_, ny_,
         reinterpret_cast<fftw_complex*>(fft_sx_.data()),
         reinterpret_cast<fftw_complex*>(fft_out3_.data()),
@@ -1259,24 +1140,6 @@ namespace waves
     fftw_destroy_plan(fft_plan5_);
     fftw_destroy_plan(fft_plan6_);
     fftw_destroy_plan(fft_plan7_);
-
-    // fftw_free(fft_out0_);
-    // fftw_free(fft_out1_);
-    // fftw_free(fft_out2_);
-    // fftw_free(fft_out3_);
-    // fftw_free(fft_out4_);
-    // fftw_free(fft_out5_);
-    // fftw_free(fft_out6_);
-    // fftw_free(fft_out7_);
-
-    // fftw_free(fft_in0_);
-    // fftw_free(fft_in1_);
-    // fftw_free(fft_in2_);
-    // fftw_free(fft_in3_);
-    // fftw_free(fft_in4_);
-    // fftw_free(fft_in5_);
-    // fftw_free(fft_in6_);
-    // fftw_free(fft_in7_);
   }
 
   //////////////////////////////////////////////////

--- a/gz-waves/src/WaveSimulationFFT2.cc
+++ b/gz-waves/src/WaveSimulationFFT2.cc
@@ -28,18 +28,18 @@
 //***************************************************************************************************
 
 #include "gz/waves/WaveSimulationFFT2.hh"
-#include "gz/waves/WaveSpectrum.hh"
-
-#include "WaveSimulationFFT2Impl.hh"
-
-#include <Eigen/Dense>
-
-#include <gz/common.hh>
-
-#include <fftw3.h>
 
 #include <complex>
 #include <random>
+
+#include <Eigen/Dense>
+
+#include <fftw3.h>
+
+#include <gz/common.hh>
+
+#include "gz/waves/WaveSpectrum.hh"
+#include "WaveSimulationFFT2Impl.hh"
 
 using Eigen::MatrixXcd;
 using Eigen::MatrixXd;
@@ -53,273 +53,273 @@ namespace waves
   //////////////////////////////////////////////////
   WaveSimulationFFT2Impl::~WaveSimulationFFT2Impl()
   {
-    fftw_destroy_plan(fft_plan0);
-    fftw_destroy_plan(fft_plan1);
-    fftw_destroy_plan(fft_plan2);
-    fftw_destroy_plan(fft_plan3);
-    fftw_destroy_plan(fft_plan4);
-    fftw_destroy_plan(fft_plan5);
-    fftw_destroy_plan(fft_plan6);
-    fftw_destroy_plan(fft_plan7);
+    fftw_destroy_plan(fft_plan0_);
+    fftw_destroy_plan(fft_plan1_);
+    fftw_destroy_plan(fft_plan2_);
+    fftw_destroy_plan(fft_plan3_);
+    fftw_destroy_plan(fft_plan4_);
+    fftw_destroy_plan(fft_plan5_);
+    fftw_destroy_plan(fft_plan6_);
+    fftw_destroy_plan(fft_plan7_);
 
-    fftw_free(fft_out0);
-    fftw_free(fft_out1);
-    fftw_free(fft_out2);
-    fftw_free(fft_out3);
-    fftw_free(fft_out4);
-    fftw_free(fft_out5);
-    fftw_free(fft_out6);
-    fftw_free(fft_out7);
+    fftw_free(fft_out0_);
+    fftw_free(fft_out1_);
+    fftw_free(fft_out2_);
+    fftw_free(fft_out3_);
+    fftw_free(fft_out4_);
+    fftw_free(fft_out5_);
+    fftw_free(fft_out6_);
+    fftw_free(fft_out7_);
 
-    fftw_free(fft_in0);
-    fftw_free(fft_in1);
-    fftw_free(fft_in2);
-    fftw_free(fft_in3);
-    fftw_free(fft_in4);
-    fftw_free(fft_in5);
-    fftw_free(fft_in6);
-    fftw_free(fft_in7);
+    fftw_free(fft_in0_);
+    fftw_free(fft_in1_);
+    fftw_free(fft_in2_);
+    fftw_free(fft_in3_);
+    fftw_free(fft_in4_);
+    fftw_free(fft_in5_);
+    fftw_free(fft_in6_);
+    fftw_free(fft_in7_);
   }
 
   //////////////////////////////////////////////////
   WaveSimulationFFT2Impl::WaveSimulationFFT2Impl(
-    double _lx, double _ly, int _nx, int _ny) :
-    nx(_nx),
-    ny(_ny),
-    lx(_lx),
-    ly(_ly),
-    lambda(0.6)
+    double lx, double ly, int nx, int ny) :
+    nx_(nx),
+    ny_(ny),
+    lx_(lx),
+    ly_(ly),
+    lambda_(0.6)
   {
     ComputeBaseAmplitudes();
 
     // FFT 2D.
-    size_t n2 = this->nx * this->ny;
+    size_t n2 = this->nx_ * this->ny_;
 
     // For height
-    fft_in0  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    fft_in1  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    fft_in2  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
+    fft_in0_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
+    fft_in1_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
+    fft_in2_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
 
     // For xy-displacements
-    fft_in3  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    fft_in4  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    fft_in5  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    fft_in6  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
-    fft_in7  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
+    fft_in3_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
+    fft_in4_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
+    fft_in5_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
+    fft_in6_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
+    fft_in7_  = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));
 
     // For height
-    fft_out0 = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    fft_out1 = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    fft_out2 = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    fft_out0_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    fft_out1_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    fft_out2_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
 
     // For xy-displacements
-    fft_out3 = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    fft_out4 = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    fft_out5 = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    fft_out6 = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
-    fft_out7 = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    fft_out3_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    fft_out4_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    fft_out5_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    fft_out6_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
+    fft_out7_ = (fftw_complex*)fftw_malloc(n2 * sizeof(fftw_complex));  
 
     // For height
-    fft_plan0 = fftw_plan_dft_2d(nx, ny, fft_in0, fft_out0, FFTW_BACKWARD, FFTW_ESTIMATE);
-    fft_plan1 = fftw_plan_dft_2d(nx, ny, fft_in1, fft_out1, FFTW_BACKWARD, FFTW_ESTIMATE);
-    fft_plan2 = fftw_plan_dft_2d(nx, ny, fft_in2, fft_out2, FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan0_ = fftw_plan_dft_2d(nx_, ny_, fft_in0_, fft_out0_, FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan1_ = fftw_plan_dft_2d(nx_, ny_, fft_in1_, fft_out1_, FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan2_ = fftw_plan_dft_2d(nx_, ny_, fft_in2_, fft_out2_, FFTW_BACKWARD, FFTW_ESTIMATE);
 
     // For xy-displacements
-    fft_plan3 = fftw_plan_dft_2d(nx, ny, fft_in3, fft_out3, FFTW_BACKWARD, FFTW_ESTIMATE);
-    fft_plan4 = fftw_plan_dft_2d(nx, ny, fft_in4, fft_out4, FFTW_BACKWARD, FFTW_ESTIMATE);
-    fft_plan5 = fftw_plan_dft_2d(nx, ny, fft_in5, fft_out5, FFTW_BACKWARD, FFTW_ESTIMATE);
-    fft_plan6 = fftw_plan_dft_2d(nx, ny, fft_in6, fft_out6, FFTW_BACKWARD, FFTW_ESTIMATE);
-    fft_plan7 = fftw_plan_dft_2d(nx, ny, fft_in7, fft_out7, FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan3_ = fftw_plan_dft_2d(nx_, ny_, fft_in3_, fft_out3_, FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan4_ = fftw_plan_dft_2d(nx_, ny_, fft_in4_, fft_out4_, FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan5_ = fftw_plan_dft_2d(nx_, ny_, fft_in5_, fft_out5_, FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan6_ = fftw_plan_dft_2d(nx_, ny_, fft_in6_, fft_out6_, FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan7_ = fftw_plan_dft_2d(nx_, ny_, fft_in7_, fft_out7_, FFTW_BACKWARD, FFTW_ESTIMATE);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::SetUseVectorised(bool _value)
+  void WaveSimulationFFT2Impl::SetUseVectorised(bool value)
   {
-    this->use_vectorised = _value;
+    this->use_vectorised = value;
     ComputeBaseAmplitudes();
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::SetLambda(double _value)
+  void WaveSimulationFFT2Impl::SetLambda(double value)
   {
-    lambda = _value;
+    lambda_ = value;
     ComputeBaseAmplitudes();
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::SetWindVelocity(double _ux, double _uy)
+  void WaveSimulationFFT2Impl::SetWindVelocity(double ux, double uy)
   {
     // Update wind velocity and recompute base amplitudes.
-    this->u10 = sqrt(_ux*_ux + _uy *_uy);
-    this->phi10 = atan2(_uy, _ux);
+    this->u10_ = sqrt(ux*ux + uy *uy);
+    this->phi10_ = atan2(uy, ux);
 
     ComputeBaseAmplitudes();
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::SetTime(double _time)
+  void WaveSimulationFFT2Impl::SetTime(double time)
   {
-    ComputeCurrentAmplitudes(_time);
+    ComputeCurrentAmplitudes(time);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeElevation(
-    Eigen::Ref<Eigen::MatrixXd> _h)
+    Eigen::Ref<Eigen::MatrixXd> h)
   {
     // Populate input array
-    for (size_t i=0; i<this->nx * this->ny; ++i)
+    for (size_t i=0; i<this->nx_ * this->ny_; ++i)
     {
-      fft_in0[i][0] = fft_h[i].real();
-      fft_in0[i][1] = fft_h[i].imag();
+      fft_in0_[i][0] = fft_h_[i].real();
+      fft_in0_[i][1] = fft_h_[i].imag();
     }
 
     // Run the FFT
-    fftw_execute(fft_plan0);
+    fftw_execute(fft_plan0_);
 
     // for (size_t i=0; i<n2; ++i)
     // {
-    //   _heights[i] = fft_out0[i][0];
+    //   _heights[i] = fft_out0_[i][0];
     // }
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // z(i,j) => z(x, y): x = j, y = i
-    for (size_t ikx = 0; ikx < this->nx; ++ikx)
+    for (size_t ikx = 0; ikx < this->nx_; ++ikx)
     {
-      for (size_t iky = 0; iky < this->ny; ++iky)
+      for (size_t iky = 0; iky < this->ny_; ++iky)
       {
-        int ij = ikx * this->ny + iky;
-        int xy = iky * this->nx + ikx;
-        _h(xy, 0) = fft_out0[ij][0];
+        int ij = ikx * this->ny_ + iky;
+        int xy = iky * this->nx_ + ikx;
+        h(xy, 0) = fft_out0_[ij][0];
       }
     }
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeElevationDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy)
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
-    size_t n2 = this->nx * this->ny;
+    size_t n2 = this->nx_ * this->ny_;
 
     // Populate input array
     for (size_t i=0; i<n2; ++i)
     {
-      fft_in1[i][0] = fft_h_ikx[i].real();
-      fft_in1[i][1] = fft_h_ikx[i].imag();
+      fft_in1_[i][0] = fft_h_ikx_[i].real();
+      fft_in1_[i][1] = fft_h_ikx_[i].imag();
 
-      fft_in2[i][0] = fft_h_iky[i].real();
-      fft_in2[i][1] = fft_h_iky[i].imag();
+      fft_in2_[i][0] = fft_h_iky_[i].real();
+      fft_in2_[i][1] = fft_h_iky_[i].imag();
     }
 
     // Run the FFTs
-    fftw_execute(fft_plan1);
-    fftw_execute(fft_plan2);
+    fftw_execute(fft_plan1_);
+    fftw_execute(fft_plan2_);
 
     // for (size_t i=0; i<n2; ++i)
     // {
-    //   _dhdx[i] = fft_out1[i][0];
-    //   _dhdy[i] = fft_out2[i][0];
+    //   dhdx[i] = fft_out1_[i][0];
+    //   dhdy[i] = fft_out2_[i][0];
     // }
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // z(i,j) => z(x, y): x = j, y = i
     // dz(i,j)/di => dz(x, y)/dy: x = j, y = i
     // dz(i,j)/dj => dz(x, y)/dx: x = j, y = i
-    for (size_t ikx = 0; ikx < this->nx; ++ikx)
+    for (size_t ikx = 0; ikx < this->nx_; ++ikx)
     {
-      for (size_t iky = 0; iky < this->ny; ++iky)
+      for (size_t iky = 0; iky < this->ny_; ++iky)
       {
-        int ij = ikx * this->ny + iky;
-        int xy = iky * this->nx + ikx;
-        _dhdy(xy, 0) = fft_out1[ij][0];
-        _dhdx(xy, 0) = fft_out2[ij][0];
+        int ij = ikx * this->ny_ + iky;
+        int xy = iky * this->nx_ + ikx;
+        dhdy(xy, 0) = fft_out1_[ij][0];
+        dhdx(xy, 0) = fft_out2_[ij][0];
       }
     }
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeDisplacements(
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy)
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy)
   {
-    size_t n2 = this->nx * this->ny;
+    size_t n2 = this->nx_ * this->ny_;
 
     // Populate input array
     for (size_t i=0; i<n2; ++i)
     {
-      fft_in3[i][0] = fft_sx[i].real();
-      fft_in3[i][1] = fft_sx[i].imag();
+      fft_in3_[i][0] = fft_sx_[i].real();
+      fft_in3_[i][1] = fft_sx_[i].imag();
 
-      fft_in4[i][0] = fft_sy[i].real();
-      fft_in4[i][1] = fft_sy[i].imag();
+      fft_in4_[i][0] = fft_sy_[i].real();
+      fft_in4_[i][1] = fft_sy_[i].imag();
     }
 
     // Run the FFTs
-    fftw_execute(fft_plan3);
-    fftw_execute(fft_plan4);
+    fftw_execute(fft_plan3_);
+    fftw_execute(fft_plan4_);
 
     // for (size_t i=0; i<n2; ++i)
     // {
-    //   _sx[i] = fft_out3[i][0] * lambda;
-    //   _sy[i] = fft_out4[i][0] * lambda;
+    //   sx[i] = fft_out3_[i][0] * lambda_;
+    //   sy[i] = fft_out4_[i][0] * lambda_;
     // }
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // sy(i,j) => si(x, y): x = j, y = i
     // sx(i,j) => sj(x, y): x = j, y = i
-    for (size_t ikx = 0; ikx < this->nx; ++ikx)
+    for (size_t ikx = 0; ikx < this->nx_; ++ikx)
     {
-      for (size_t iky = 0; iky < this->ny; ++iky)
+      for (size_t iky = 0; iky < this->ny_; ++iky)
       {
-        int ij = ikx * this->ny + iky;
-        int xy = iky * this->nx + ikx;
-        _sy(xy, 0) = fft_out3[ij][0] * lambda * -1.0;
-        _sx(xy, 0) = fft_out4[ij][0] * lambda * -1.0;
+        int ij = ikx * this->ny_ + iky;
+        int xy = iky * this->nx_ + ikx;
+        sy(xy, 0) = fft_out3_[ij][0] * lambda_ * -1.0;
+        sx(xy, 0) = fft_out4_[ij][0] * lambda_ * -1.0;
       }
     }
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeDisplacementsDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    size_t n2 = this->nx * this->ny;
+    size_t n2 = this->nx_ * this->ny_;
 
     // Populate input array
     for (size_t i=0; i<n2; ++i)
     {
-      fft_in5[i][0] = fft_h_kxkx[i].real();
-      fft_in5[i][1] = fft_h_kxkx[i].imag();
+      fft_in5_[i][0] = fft_h_kxkx_[i].real();
+      fft_in5_[i][1] = fft_h_kxkx_[i].imag();
 
-      fft_in6[i][0] = fft_h_kyky[i].real();
-      fft_in6[i][1] = fft_h_kyky[i].imag();
+      fft_in6_[i][0] = fft_h_kyky_[i].real();
+      fft_in6_[i][1] = fft_h_kyky_[i].imag();
 
-      fft_in7[i][0] = fft_h_kxky[i].real();
-      fft_in7[i][1] = fft_h_kxky[i].imag();
+      fft_in7_[i][0] = fft_h_kxky_[i].real();
+      fft_in7_[i][1] = fft_h_kxky_[i].imag();
     }
 
     // Run the FFTs
-    fftw_execute(fft_plan5);
-    fftw_execute(fft_plan6);
-    fftw_execute(fft_plan7);
+    fftw_execute(fft_plan5_);
+    fftw_execute(fft_plan6_);
+    fftw_execute(fft_plan7_);
 
     // for (size_t i=0; i<n2; ++i)
     // {
-    //   _dsxdx[i] = fft_out5[i][0] * lambda;
-    //   _dsydy[i] = fft_out6[i][0] * lambda;
-    //   _dsxdy[i] = fft_out7[i][0] * lambda;
+    //   _dsxdx[i] = fft_out5_[i][0] * lambda_;
+    //   _dsydy[i] = fft_out6_[i][0] * lambda_;
+    //   _dsxdy[i] = fft_out7_[i][0] * lambda_;
     // }
     // change from matrix 'ij' to cartesian 'xy' coordinates
     // sy(i,j) => si(x, y): x = j, y = i
     // sx(i,j) => sj(x, y): x = j, y = i
-    for (size_t ikx = 0; ikx < this->nx; ++ikx)
+    for (size_t ikx = 0; ikx < this->nx_; ++ikx)
     {
-      for (size_t iky = 0; iky < this->ny; ++iky)
+      for (size_t iky = 0; iky < this->ny_; ++iky)
       {
-        int ij = ikx * this->ny + iky;
-        int xy = iky * this->nx + ikx;
-        _dsydy(xy, 0) = fft_out5[ij][0] * lambda * -1.0;
-        _dsxdx(xy, 0) = fft_out6[ij][0] * lambda * -1.0;
-        _dsxdy(xy, 0) = fft_out7[ij][0] * lambda *  1.0;
+        int ij = ikx * this->ny_ + iky;
+        int xy = iky * this->nx_ + ikx;
+        dsydy(xy, 0) = fft_out5_[ij][0] * lambda_ * -1.0;
+        dsxdx(xy, 0) = fft_out6_[ij][0] * lambda_ * -1.0;
+        dsxdy(xy, 0) = fft_out7_[ij][0] * lambda_ *  1.0;
       }
     }
   }
@@ -330,44 +330,44 @@ namespace waves
     // gravity acceleration [m/s^2] 
     const double g = 9.81;
 
-    size_t n2 = this->nx * this->ny;
+    size_t n2 = this->nx_ * this->ny_;
 
     // storage for Fourier coefficients
-    fft_h = Eigen::VectorXcd::Zero(n2);
-    fft_h_ikx = Eigen::VectorXcd::Zero(n2);
-    fft_h_iky = Eigen::VectorXcd::Zero(n2);
-    fft_sx = Eigen::VectorXcd::Zero(n2);
-    fft_sy = Eigen::VectorXcd::Zero(n2);
-    fft_h_kxkx = Eigen::VectorXcd::Zero(n2);
-    fft_h_kyky = Eigen::VectorXcd::Zero(n2);
-    fft_h_kxky = Eigen::VectorXcd::Zero(n2);
+    fft_h_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_ikx_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_iky_ = Eigen::VectorXcd::Zero(n2);
+    fft_sx_ = Eigen::VectorXcd::Zero(n2);
+    fft_sy_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_kxkx_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_kyky_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_kxky_ = Eigen::VectorXcd::Zero(n2);
 
     // continuous two-sided elevation variance spectrum
     Eigen::VectorXd cap_psi_2s_math =
-        Eigen::VectorXd::Zero(this->nx * this->ny);
+        Eigen::VectorXd::Zero(this->nx_ * this->ny_);
 
     // calculate spectrum in math-order (not vectorised)
-    for (int ikx = 0; ikx < this->nx; ++ikx)
+    for (int ikx = 0; ikx < this->nx_; ++ikx)
     {
       // kx: fftfreq and ifftshift
-      const double kx = (ikx - this->nx/2) * this->kx_f;
+      const double kx = (ikx - this->nx_/2) * this->kx_f_;
       const double kx2 = kx*kx;
-      this->kx_math[ikx] = kx;
-      this->kx_fft[(ikx + nx/2) % nx] = kx;
+      this->kx_math_[ikx] = kx;
+      this->kx_fft_[(ikx + nx_/2) % nx_] = kx;
 
-      for (int iky = 0; iky < this->ny; ++iky)
+      for (int iky = 0; iky < this->ny_; ++iky)
       {
         // ky: fftfreq and ifftshift
-        const double ky = (iky - this->ny/2) * this->ky_f;
+        const double ky = (iky - this->ny_/2) * this->ky_f_;
         const double ky2 = ky*ky;
-        this->ky_math[iky] = ky;
-        this->ky_fft[(iky + ny/2) % ny] = ky;
+        this->ky_math_[iky] = ky;
+        this->ky_fft_[(iky + ny_/2) % ny_] = ky;
         
         const double k = sqrt(kx2 + ky2);
         const double phi = atan2(ky, kx);
 
         // index for flattened array
-        int idx = ikx * this->ny + iky;
+        int idx = ikx * this->ny_ + iky;
 
         if (k == 0.0)
         {
@@ -376,38 +376,38 @@ namespace waves
         else
         {
           double cap_psi = 0.0;
-          if (this->use_symmetric_spreading_fn)
+          if (this->use_symmetric_spreading_fn_)
           {
             // standing waves - symmetric spreading function
             cap_psi = WaveSimulationFFT2Impl::ECKVSpreadingFunction(
-                k, phi - this->phi10, this->u10, this->cap_omega_c);
+                k, phi - this->phi10_, this->u10_, this->cap_omega_c_);
           }
           else
           {
             // travelling waves - asymmetric spreading function
             cap_psi = WaveSimulationFFT2Impl::Cos2SSpreadingFunction(
-                this->s_param, phi - this->phi10, this->u10, this->cap_omega_c);
+                this->s_param_, phi - this->phi10_, this->u10_, this->cap_omega_c_);
           }
           const double cap_s =
               WaveSimulationFFT2Impl::ECKVOmniDirectionalSpectrum(
-                  k, this->u10, this->cap_omega_c);
+                  k, this->u10_, this->cap_omega_c_);
           cap_psi_2s_math[idx] = cap_s * cap_psi / k;
         }
       }
     }
 
     // convert to fft-order
-    Eigen::VectorXd cap_psi_2s_fft = Eigen::VectorXd::Zero(this->nx * this->ny);
-    for (int ikx = 0; ikx < this->nx; ++ikx)
+    Eigen::VectorXd cap_psi_2s_fft = Eigen::VectorXd::Zero(this->nx_ * this->ny_);
+    for (int ikx = 0; ikx < this->nx_; ++ikx)
     {
-      int ikx_fft = (ikx + nx/2) % nx;
-      for (int iky = 0; iky < this->ny; ++iky)
+      int ikx_fft = (ikx + nx_/2) % nx_;
+      for (int iky = 0; iky < this->ny_; ++iky)
       {
-        int iky_fft = (iky + ny/2) % ny;
+        int iky_fft = (iky + ny_/2) % ny_;
 
         // index for flattened array
-        int idx = ikx * this->ny + iky;
-        int idx_fft = ikx_fft * this->ny + iky_fft;
+        int idx = ikx * this->ny_ + iky;
+        int idx_fft = ikx_fft * this->ny_ + iky_fft;
 
         cap_psi_2s_fft[idx_fft] = cap_psi_2s_math[idx];
       }
@@ -415,8 +415,8 @@ namespace waves
 
     // square-root of two-sided discrete elevation variance spectrum
     double cap_psi_norm = 0.5;
-    double delta_kx = this->kx_f;
-    double delta_ky = this->ky_f;
+    double delta_kx = this->kx_f_;
+    double delta_ky = this->ky_f_;
     // double c1 = cap_psi_norm * sqrt(delta_kx * delta_ky);
 
     // iid random normals for real and imaginary parts of the amplitudes
@@ -427,69 +427,69 @@ namespace waves
     for (int i = 0; i < n2; ++i)
     {
       // this->cap_psi_2s_root[i] = c1 * sqrt(cap_psi_2s_fft[i]);
-      this->cap_psi_2s_root[i] =
+      this->cap_psi_2s_root_[i] =
           cap_psi_norm * sqrt(cap_psi_2s_fft[i] * delta_kx * delta_ky);
 
-      this->rho[i] = distribution(generator);
-      this->sigma[i] = distribution(generator);
+      this->rho_[i] = distribution(generator);
+      this->sigma_[i] = distribution(generator);
     }
 
 
     // angular temporal frequency for time-dependent (from dispersion)
-    for (int ikx = 0; ikx < this->nx; ++ikx)
+    for (int ikx = 0; ikx < this->nx_; ++ikx)
     {
-      double kx = this->kx_fft[ikx];
+      double kx = this->kx_fft_[ikx];
       double kx2 = kx*kx;
-      for (int iky = 0; iky < this->ny; ++iky)
+      for (int iky = 0; iky < this->ny_; ++iky)
       {
-        double ky = this->ky_fft[iky];
+        double ky = this->ky_fft_[iky];
         double ky2 = ky*ky;
         double k = sqrt(kx2 + ky2);
 
         // index for flattened array
-        int idx = ikx * this->ny + iky;
-        this->omega_k[idx] = sqrt(g * k);
+        int idx = ikx * this->ny_ + iky;
+        this->omega_k_[idx] = sqrt(g * k);
       }
     }
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudes(double _time)
+  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudes(double time)
   {
     // alias
-    auto& nx = this->nx;
-    auto& ny = this->ny;
-    auto& r = this->rho;
-    auto& s = this->sigma;
-    auto& psi_root = this->cap_psi_2s_root;
+    auto& nx_ = this->nx_;
+    auto& ny_ = this->ny_;
+    auto& r = this->rho_;
+    auto& s = this->sigma_;
+    auto& psi_root = this->cap_psi_2s_root_;
 
     // time update
-    Eigen::VectorXd cos_omega_k = Eigen::VectorXd::Zero(nx * ny);
-    Eigen::VectorXd sin_omega_k = Eigen::VectorXd::Zero(nx * ny);
-    for (int ikx = 0; ikx < nx; ++ikx)
+    Eigen::VectorXd cos_omega_k = Eigen::VectorXd::Zero(nx_ * ny_);
+    Eigen::VectorXd sin_omega_k = Eigen::VectorXd::Zero(nx_ * ny_);
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      for (int iky = 0; iky < ny; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
         // index for flattened array
-        int idx = ikx * this->ny + iky;
+        int idx = ikx * this->ny_ + iky;
 
-        double omega_t = this->omega_k[idx] * _time;
+        double omega_t = this->omega_k_[idx] * time;
         cos_omega_k(idx) = cos(omega_t);
         sin_omega_k(idx) = sin(omega_t);
       }
     }
 
     // non-vectorised reference version
-    Eigen::VectorXcd zhat = Eigen::VectorXcd::Zero(nx * ny);
-    for (int ikx = 1; ikx < nx; ++ikx)
+    Eigen::VectorXcd zhat = Eigen::VectorXcd::Zero(nx_ * ny_);
+    for (int ikx = 1; ikx < nx_; ++ikx)
     {
-      for (int iky = 1; iky < ny; ++iky)
+      for (int iky = 1; iky < ny_; ++iky)
       {
         // index for flattened array (ikx, iky)
-        int idx = ikx * this->ny + iky;
+        int idx = ikx * this->ny_ + iky;
 
-        // index for conjugate (nx-ikx, ny-iky)
-        int cdx = (nx-ikx) * this->ny + (ny-iky);
+        // index for conjugate (nx_-ikx, ny_-iky)
+        int cdx = (nx_-ikx) * this->ny_ + (ny_-iky);
 
         zhat[idx] = complex(
             + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
@@ -499,15 +499,15 @@ namespace waves
       }
     }
 
-    for (int iky = 1; iky < ny/2+1; ++iky)
+    for (int iky = 1; iky < ny_/2+1; ++iky)
     {
       int ikx = 0;
 
       // index for flattened array (ikx, iky)
-      int idx = ikx * this->ny + iky;
+      int idx = ikx * this->ny_ + iky;
 
-      // index for conjugate (ikx, ny-iky)
-      int cdx = ikx * this->ny + (ny-iky);
+      // index for conjugate (ikx, ny_-iky)
+      int cdx = ikx * this->ny_ + (ny_-iky);
 
       zhat[idx] = complex(
           + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
@@ -517,15 +517,15 @@ namespace waves
       zhat[cdx] = std::conj(zhat[idx]);
     }
 
-    for (int ikx = 1; ikx < nx/2+1; ++ikx)
+    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
     {
       int iky = 0;
 
       // index for flattened array (ikx, iky)
-      int idx = ikx * this->ny + iky;
+      int idx = ikx * this->ny_ + iky;
 
-      // index for conjugate (nx-ikx, iky)
-      int cdx = (nx-ikx) * this->ny + iky;
+      // index for conjugate (nx_-ikx, iky)
+      int cdx = (nx_-ikx) * this->ny_ + iky;
 
       zhat[idx] = complex(
           + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
@@ -537,22 +537,22 @@ namespace waves
 
     zhat[0] = complex(0.0, 0.0);
 
-    // write into fft_h, fft_h_ikx, fft_h_iky, etc.
+    // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
     const complex iunit(0.0, 1.0);
     const complex czero(0.0, 0.0);
-    for (int ikx = 0; ikx < nx; ++ikx)
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      double kx = this->kx_fft[ikx];
+      double kx = this->kx_fft_[ikx];
       double kx2 = kx*kx;
-      for (int iky = 0; iky < ny; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
-        double ky = this->ky_fft[iky];
+        double ky = this->ky_fft_[iky];
         double ky2 = ky*ky;
         double k = sqrt(kx2 + ky2);
         double ook = 1.0 / k;
 
         // index for flattened arrays
-        int idx = ikx * ny + iky;
+        int idx = ikx * ny_ + iky;
 
         complex h  = zhat[idx];
         complex hi = h * iunit;
@@ -560,23 +560,23 @@ namespace waves
         complex hiok = hi * ook;
 
         // height (amplitude)
-        this->fft_h[idx] = h;
+        this->fft_h_[idx] = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        this->fft_h_ikx[idx] = hi * kx;
-        this->fft_h_iky[idx] = hi * ky;
+        this->fft_h_ikx_[idx] = hi * kx;
+        this->fft_h_iky_[idx] = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
         {          
-          fft_sx[idx]    = czero;
-          fft_sy[idx]    = czero;
-          fft_h_kxkx[idx] = czero;
-          fft_h_kyky[idx] = czero;
-          fft_h_kxky[idx] = czero;
+          fft_sx_[idx]    = czero;
+          fft_sy_[idx]    = czero;
+          fft_h_kxkx_[idx] = czero;
+          fft_h_kyky_[idx] = czero;
+          fft_h_kxky_[idx] = czero;
         }
         else
         {
@@ -586,11 +586,11 @@ namespace waves
           complex hkyky = hok * ky2;
           complex hkxky = hok * kx * ky;
           
-          fft_sx[idx]    = dx;
-          fft_sy[idx]    = dy;
-          fft_h_kxkx[idx] = hkxkx;
-          fft_h_kyky[idx] = hkyky;
-          fft_h_kxky[idx] = hkxky;
+          fft_sx_[idx]    = dx;
+          fft_sy_[idx]    = dy;
+          fft_h_kxkx_[idx] = hkxkx;
+          fft_h_kyky_[idx] = hkyky;
+          fft_h_kxky_[idx] = hkxky;
         }
       }
     }
@@ -599,27 +599,27 @@ namespace waves
   //////////////////////////////////////////////////
   void WaveSimulationFFT2Impl::ComputeBaseAmplitudesReference()
   {
-    size_t n2 = this->nx * this->ny;
+    size_t n2 = this->nx_ * this->ny_;
 
     // storage for Fourier coefficients
-    fft_h = Eigen::VectorXcd::Zero(n2);
-    fft_h_ikx = Eigen::VectorXcd::Zero(n2);
-    fft_h_iky = Eigen::VectorXcd::Zero(n2);
-    fft_sx = Eigen::VectorXcd::Zero(n2);
-    fft_sy = Eigen::VectorXcd::Zero(n2);
-    fft_h_kxkx = Eigen::VectorXcd::Zero(n2);
-    fft_h_kyky = Eigen::VectorXcd::Zero(n2);
-    fft_h_kxky = Eigen::VectorXcd::Zero(n2);
+    fft_h_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_ikx_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_iky_ = Eigen::VectorXcd::Zero(n2);
+    fft_sx_ = Eigen::VectorXcd::Zero(n2);
+    fft_sy_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_kxkx_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_kyky_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_kxky_ = Eigen::VectorXcd::Zero(n2);
 
     // arrays for reference version
-    if (this->cap_psi_2s_root_ref.size() == 0 || 
-        this->cap_psi_2s_root_ref.rows() != this->nx ||
-        this->cap_psi_2s_root_ref.cols() != this->ny)
+    if (this->cap_psi_2s_root_ref_.size() == 0 || 
+        this->cap_psi_2s_root_ref_.rows() != this->nx_ ||
+        this->cap_psi_2s_root_ref_.cols() != this->ny_)
     {
-      this->cap_psi_2s_root_ref = Eigen::MatrixXd::Zero(this->nx, this->ny);
-      this->rho_ref = Eigen::MatrixXd::Zero(this->nx, this->ny);
-      this->sigma_ref = Eigen::MatrixXd::Zero(this->nx, this->ny);
-      this->omega_k_ref = Eigen::MatrixXd::Zero(this->nx, this->ny);
+      this->cap_psi_2s_root_ref_ = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
+      this->rho_ref_ = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
+      this->sigma_ref_ = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
+      this->omega_k_ref_ = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
     }
 
     // Guide to indexing conventions:  1. index, 2. math-order, 3. fft-order
@@ -630,72 +630,72 @@ namespace waves
     // 
 
     // fftfreq and ifftshift
-    for(int ikx = 0; ikx < this->nx; ++ikx)
+    for(int ikx = 0; ikx < this->nx_; ++ikx)
     {
-      const double kx = (ikx - this->nx/2) * this->kx_f;
-      kx_math[ikx] = kx;
-      kx_fft[(ikx + nx/2) % nx] = kx;
+      const double kx = (ikx - this->nx_/2) * this->kx_f_;
+      kx_math_[ikx] = kx;
+      kx_fft_[(ikx + nx_/2) % nx_] = kx;
     }
 
-    for(int iky = 0; iky < this->ny; ++iky)
+    for(int iky = 0; iky < this->ny_; ++iky)
     {
-      const double ky = (iky - this->ny/2) * this->ky_f;
-      ky_math[iky] = ky;
-      ky_fft[(iky + ny/2) % ny] = ky;
+      const double ky = (iky - this->ny_/2) * this->ky_f_;
+      ky_math_[iky] = ky;
+      ky_fft_[(iky + ny_/2) % ny_] = ky;
     }
 
     // debug
     gzmsg << "WaveSimulationFFT2" << "\n";
-    gzmsg << "Lx:          " << this->lx << "\n";
-    gzmsg << "Ly:          " << this->ly << "\n";
-    gzmsg << "nx:          " << this->nx << "\n";
-    gzmsg << "ny:          " << this->ny << "\n";
-    gzmsg << "delta_x:     " << this->delta_x << "\n";
-    gzmsg << "delta_x:     " << this->delta_y << "\n";
-    gzmsg << "lambda_x_f:  " << this->lambda_x_f << "\n";
-    gzmsg << "lambda_y_f:  " << this->lambda_y_f << "\n";
-    gzmsg << "nu_x_f:      " << this->nu_x_f << "\n";
-    gzmsg << "nu_y_f:      " << this->nu_y_f << "\n";
-    gzmsg << "nu_x_ny:     " << this->nu_x_ny << "\n";
-    gzmsg << "nu_y_ny:     " << this->nu_y_ny << "\n";
-    gzmsg << "kx_f:        " << this->kx_f << "\n";
-    gzmsg << "ky_f:        " << this->ky_f << "\n";
-    gzmsg << "kx_ny:       " << this->kx_ny << "\n";
-    gzmsg << "ky_ny:       " << this->ky_ny << "\n";
+    gzmsg << "lx:          " << this->lx_ << "\n";
+    gzmsg << "ly:          " << this->ly_ << "\n";
+    gzmsg << "nx:          " << this->nx_ << "\n";
+    gzmsg << "ny:          " << this->ny_ << "\n";
+    gzmsg << "delta_x:     " << this->delta_x_ << "\n";
+    gzmsg << "delta_y:     " << this->delta_y_ << "\n";
+    gzmsg << "lambda_x_f:  " << this->lambda_x_f_ << "\n";
+    gzmsg << "lambda_y_f:  " << this->lambda_y_f_ << "\n";
+    gzmsg << "nu_x_f:      " << this->nu_x_f_ << "\n";
+    gzmsg << "nu_y_f:      " << this->nu_y_f_ << "\n";
+    gzmsg << "nu_x_ny:     " << this->nu_x_ny_ << "\n";
+    gzmsg << "nu_y_ny:     " << this->nu_y_ny_ << "\n";
+    gzmsg << "kx_f:        " << this->kx_f_ << "\n";
+    gzmsg << "ky_f:        " << this->ky_f_ << "\n";
+    gzmsg << "kx_ny:       " << this->kx_ny_ << "\n";
+    gzmsg << "ky_ny:       " << this->ky_ny_ << "\n";
     #if 0
     {
       std::ostringstream os;
-      os << "[ "; for (auto& v : this->kx_fft) os << v << " "; os << "]\n";
+      os << "[ "; for (auto& v : this->kx_fft_) os << v << " "; os << "]\n";
       gzmsg << "kx_fft:      " << os.str();
     }
     {
       std::ostringstream os;
-      os << "[ "; for (auto& v : this->ky_fft) os << v << " "; os << "]\n";
+      os << "[ "; for (auto& v : this->ky_fft_) os << v << " "; os << "]\n";
       gzmsg << "ky_fft:      " << os.str();
     }
     {
       std::ostringstream os;
-      os << "[ "; for (auto& v : this->kx_math) os << v << " "; os << "]\n";
+      os << "[ "; for (auto& v : this->kx_math_) os << v << " "; os << "]\n";
       gzmsg << "kx_math:     " << os.str();
     }
     {
       std::ostringstream os;
-      os << "[ "; for (auto& v : this->ky_math) os << v << " "; os << "]\n";
+      os << "[ "; for (auto& v : this->ky_math_) os << v << " "; os << "]\n";
       gzmsg << "ky_math:     " << os.str();
     }
     #endif
 
     // continuous two-sided elevation variance spectrum
-    Eigen::MatrixXd cap_psi_2s_math = Eigen::MatrixXd::Zero(this->nx, this->ny);
+    Eigen::MatrixXd cap_psi_2s_math = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
 
     // calculate spectrum in math-order (not vectorised)
-    for (int ikx = 0; ikx < this->nx; ++ikx)
+    for (int ikx = 0; ikx < this->nx_; ++ikx)
     {
-      for (int iky = 0; iky < this->ny; ++iky)
+      for (int iky = 0; iky < this->ny_; ++iky)
       {
-        double k = sqrt(this->kx_math[ikx]*this->kx_math[ikx]
-            + this->ky_math[iky]*this->ky_math[iky]);
-        double phi = atan2(this->ky_math[iky], this->kx_math[ikx]);
+        double k = sqrt(this->kx_math_[ikx]*this->kx_math_[ikx]
+            + this->ky_math_[iky]*this->ky_math_[iky]);
+        double phi = atan2(this->ky_math_[iky], this->kx_math_[ikx]);
 
         if (k == 0.0)
         {
@@ -704,20 +704,20 @@ namespace waves
         else
         {
           double cap_psi = 0.0;
-          if (this->use_symmetric_spreading_fn)
+          if (this->use_symmetric_spreading_fn_)
           {
             // standing waves - symmetric spreading function
             cap_psi = WaveSimulationFFT2Impl::ECKVSpreadingFunction(
-                k, phi - this->phi10, this->u10, this->cap_omega_c);
+                k, phi - this->phi10_, this->u10_, this->cap_omega_c_);
           }
           else
           {
             // travelling waves - asymmetric spreading function
             cap_psi = WaveSimulationFFT2Impl::Cos2SSpreadingFunction(
-                this->s_param, phi - this->phi10, this->u10, this->cap_omega_c);
+                this->s_param_, phi - this->phi10_, this->u10_, this->cap_omega_c_);
           }
           double cap_s = WaveSimulationFFT2Impl::ECKVOmniDirectionalSpectrum(
-              k, this->u10, this->cap_omega_c);
+              k, this->u10_, this->cap_omega_c_);
           cap_psi_2s_math(ikx, iky) = cap_s * cap_psi / k;
         }
       }
@@ -728,7 +728,7 @@ namespace waves
     {
       std::ostringstream os;
       os << "[\n";
-      for (int ikx = 0; ikx < this->nx; ++ikx)
+      for (int ikx = 0; ikx < this->nx_; ++ikx)
       {
         os << " [ ";
         for (auto& v : cap_psi_2s_math[ikx])
@@ -744,27 +744,27 @@ namespace waves
     #endif
 
     // convert to fft-order
-    Eigen::MatrixXd cap_psi_2s_fft = Eigen::MatrixXd::Zero(this->nx, this->ny);
-    for (int ikx = 0; ikx < this->nx; ++ikx)
+    Eigen::MatrixXd cap_psi_2s_fft = Eigen::MatrixXd::Zero(this->nx_, this->ny_);
+    for (int ikx = 0; ikx < this->nx_; ++ikx)
     {
-      int ikx_fft = (ikx + nx/2) % nx;
-      for (int iky = 0; iky < this->ny; ++iky)
+      int ikx_fft = (ikx + nx_/2) % nx_;
+      for (int iky = 0; iky < this->ny_; ++iky)
       {
-        int iky_fft = (iky + ny/2) % ny;
+        int iky_fft = (iky + ny_/2) % ny_;
         cap_psi_2s_fft(ikx_fft, iky_fft) = cap_psi_2s_math(ikx, iky);
       }
     }
 
     // square-root of two-sided discrete elevation variance spectrum
     double cap_psi_norm = 0.5;
-    double delta_kx = this->kx_f;
-    double delta_ky = this->ky_f;
+    double delta_kx = this->kx_f_;
+    double delta_ky = this->ky_f_;
 
-    for (int ikx = 0; ikx < this->nx; ++ikx)
+    for (int ikx = 0; ikx < this->nx_; ++ikx)
     {
-      for (int iky = 0; iky < this->ny; ++iky)
+      for (int iky = 0; iky < this->ny_; ++iky)
       {
-        this->cap_psi_2s_root_ref(ikx, iky) =
+        this->cap_psi_2s_root_ref_(ikx, iky) =
             cap_psi_norm * sqrt(cap_psi_2s_fft(ikx, iky) * delta_kx * delta_ky);
       }
     }
@@ -774,12 +774,12 @@ namespace waves
     std::default_random_engine generator(seed);
     std::normal_distribution<double> distribution(0.0, 1.0);
 
-    for (int ikx = 0; ikx < this->nx; ++ikx)
+    for (int ikx = 0; ikx < this->nx_; ++ikx)
     {
-      for (int iky = 0; iky < this->ny; ++iky)
+      for (int iky = 0; iky < this->ny_; ++iky)
       {
-        this->rho_ref(ikx, iky) = distribution(generator);
-        this->sigma_ref(ikx, iky) = distribution(generator);
+        this->rho_ref_(ikx, iky) = distribution(generator);
+        this->sigma_ref_(ikx, iky) = distribution(generator);
       }
     }
 
@@ -787,98 +787,98 @@ namespace waves
     double g = 9.81;
 
     // angular temporal frequency for time-dependent (from dispersion)
-    for (int ikx = 0; ikx < this->nx; ++ikx)
+    for (int ikx = 0; ikx < this->nx_; ++ikx)
     {
-      double kx = this->kx_fft[ikx];
+      double kx = this->kx_fft_[ikx];
       double kx2 = kx*kx;
-      for (int iky = 0; iky < this->ny; ++iky)
+      for (int iky = 0; iky < this->ny_; ++iky)
       {
-        double ky = this->ky_fft[iky];
+        double ky = this->ky_fft_[iky];
         double ky2 = ky*ky;
         double k = sqrt(kx2 + ky2);
-        this->omega_k_ref(ikx, iky) = sqrt(g * k);
+        this->omega_k_ref_(ikx, iky) = sqrt(g * k);
       }
     }
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesReference(double _time)
+  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesReference(double time)
   {
     // alias
-    auto& nx = this->nx;
-    auto& ny = this->ny;
-    auto& r = this->rho_ref;
-    auto& s = this->sigma_ref;
-    auto& psi_root = this->cap_psi_2s_root_ref;
+    auto& nx_ = this->nx_;
+    auto& ny_ = this->ny_;
+    auto& r = this->rho_ref_;
+    auto& s = this->sigma_ref_;
+    auto& psi_root = this->cap_psi_2s_root_ref_;
 
     // time update
-    Eigen::MatrixXd cos_omega_k = Eigen::MatrixXd::Zero(nx, ny);
-    Eigen::MatrixXd sin_omega_k = Eigen::MatrixXd::Zero(nx, ny);
-    for (int ikx = 0; ikx < nx; ++ikx)
+    Eigen::MatrixXd cos_omega_k = Eigen::MatrixXd::Zero(nx_, ny_);
+    Eigen::MatrixXd sin_omega_k = Eigen::MatrixXd::Zero(nx_, ny_);
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      for (int iky = 0; iky < ny; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
-        cos_omega_k(ikx, iky) = cos(this->omega_k_ref(ikx, iky) * _time);
-        sin_omega_k(ikx, iky) = sin(this->omega_k_ref(ikx, iky) * _time);
+        cos_omega_k(ikx, iky) = cos(this->omega_k_ref_(ikx, iky) * time);
+        sin_omega_k(ikx, iky) = sin(this->omega_k_ref_(ikx, iky) * time);
       }
     }
 
     // non-vectorised reference version
-    Eigen::MatrixXcd zhat = Eigen::MatrixXcd::Zero(nx, ny);
-    for (int ikx = 1; ikx < nx; ++ikx)
+    Eigen::MatrixXcd zhat = Eigen::MatrixXcd::Zero(nx_, ny_);
+    for (int ikx = 1; ikx < nx_; ++ikx)
     {
-      for (int iky = 1; iky < ny; ++iky)
+      for (int iky = 1; iky < ny_; ++iky)
       {
         zhat(ikx, iky) = complex(
-            + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx-ikx, ny-iky) * psi_root(nx-ikx, ny-iky) ) * cos_omega_k(ikx, iky)
-            + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx-ikx, ny-iky) * psi_root(nx-ikx, ny-iky) ) * sin_omega_k(ikx, iky),
-            - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx-ikx, ny-iky) * psi_root(nx-ikx, ny-iky) ) * sin_omega_k(ikx, iky)
-            + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx-ikx, ny-iky) * psi_root(nx-ikx, ny-iky) ) * cos_omega_k(ikx, iky));
+            + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * cos_omega_k(ikx, iky)
+            + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * sin_omega_k(ikx, iky),
+            - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * sin_omega_k(ikx, iky)
+            + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * cos_omega_k(ikx, iky));
       }
     }
 
-    for (int iky = 1; iky < ny/2+1; ++iky)
+    for (int iky = 1; iky < ny_/2+1; ++iky)
     {
       int ikx = 0;
       zhat(ikx, iky) = complex(
-          + ( r(ikx, iky) * psi_root(ikx, iky) + r(ikx, ny-iky) * psi_root(ikx, ny-iky) ) * cos_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) + s(ikx, ny-iky) * psi_root(ikx, ny-iky) ) * sin_omega_k(ikx, iky),
-          - ( r(ikx, iky) * psi_root(ikx, iky) - r(ikx, ny-iky) * psi_root(ikx, ny-iky) ) * sin_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) - s(ikx, ny-iky) * psi_root(ikx, ny-iky) ) * cos_omega_k(ikx, iky));
-      zhat(ikx, ny-iky) = std::conj(zhat(ikx, iky));
+          + ( r(ikx, iky) * psi_root(ikx, iky) + r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * cos_omega_k(ikx, iky)
+          + ( s(ikx, iky) * psi_root(ikx, iky) + s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * sin_omega_k(ikx, iky),
+          - ( r(ikx, iky) * psi_root(ikx, iky) - r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * sin_omega_k(ikx, iky)
+          + ( s(ikx, iky) * psi_root(ikx, iky) - s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * cos_omega_k(ikx, iky));
+      zhat(ikx, ny_-iky) = std::conj(zhat(ikx, iky));
     }
 
-    for (int ikx = 1; ikx < nx/2+1; ++ikx)
+    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
     {
       int iky = 0;
       zhat(ikx, iky) = complex(
-          + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx-ikx, iky) * psi_root(nx-ikx, iky) ) * cos_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx-ikx, iky) * psi_root(nx-ikx, iky) ) * sin_omega_k(ikx, iky),
-          - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx-ikx, iky) * psi_root(nx-ikx, iky) ) * sin_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx-ikx, iky) * psi_root(nx-ikx, iky) ) * cos_omega_k(ikx, iky));
-      zhat(nx-ikx, iky) = std::conj(zhat(ikx, iky));
+          + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * cos_omega_k(ikx, iky)
+          + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * sin_omega_k(ikx, iky),
+          - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * sin_omega_k(ikx, iky)
+          + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * cos_omega_k(ikx, iky));
+      zhat(nx_-ikx, iky) = std::conj(zhat(ikx, iky));
     }
 
     zhat(0, 0) = complex(0.0, 0.0);
 
     /// \todo: change zhat to 1D array and use directly
 
-    // write into fft_h, fft_h_ikx, fft_h_iky, etc.
+    // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
     const complex iunit(0.0, 1.0);
     const complex czero(0.0, 0.0);
-    for (int ikx = 0; ikx < nx; ++ikx)
+    for (int ikx = 0; ikx < nx_; ++ikx)
     {
-      double kx = this->kx_fft[ikx];
+      double kx = this->kx_fft_[ikx];
       double kx2 = kx*kx;
-      for (int iky = 0; iky < ny; ++iky)
+      for (int iky = 0; iky < ny_; ++iky)
       {
-        double ky = this->ky_fft[iky];
+        double ky = this->ky_fft_[iky];
         double ky2 = ky*ky;
         double k = sqrt(kx2 + ky2);
         double ook = 1.0 / k;
 
         // index for flattened arrays
-        int idx = ikx * ny + iky;
+        int idx = ikx * ny_ + iky;
 
         complex h  = zhat(ikx, iky);
         complex hi = h * iunit;
@@ -886,23 +886,23 @@ namespace waves
         complex hiok = hi * ook;
 
         // height (amplitude)
-        this->fft_h[idx] = h;
+        this->fft_h_[idx] = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        this->fft_h_ikx[idx] = hi * kx;
-        this->fft_h_iky[idx] = hi * ky;
+        this->fft_h_ikx_[idx] = hi * kx;
+        this->fft_h_iky_[idx] = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
         {          
-          fft_sx[idx]    = czero;
-          fft_sy[idx]    = czero;
-          fft_h_kxkx[idx] = czero;
-          fft_h_kyky[idx] = czero;
-          fft_h_kxky[idx] = czero;
+          fft_sx_[idx]    = czero;
+          fft_sy_[idx]    = czero;
+          fft_h_kxkx_[idx] = czero;
+          fft_h_kyky_[idx] = czero;
+          fft_h_kxky_[idx] = czero;
         }
         else
         {
@@ -912,11 +912,11 @@ namespace waves
           complex hkyky = hok * ky2;
           complex hkxky = hok * kx * ky;
           
-          fft_sx[idx]    = dx;
-          fft_sy[idx]    = dy;
-          fft_h_kxkx[idx] = hkxkx;
-          fft_h_kyky[idx] = hkyky;
-          fft_h_kxky[idx] = hkxky;
+          fft_sx_[idx]    = dx;
+          fft_sy_[idx]    = dy;
+          fft_h_kxkx_[idx] = hkxkx;
+          fft_h_kyky_[idx] = hkyky;
+          fft_h_kxky_[idx] = hkxky;
         }
       }
     }
@@ -1062,82 +1062,82 @@ namespace waves
 
   //////////////////////////////////////////////////
   WaveSimulationFFT2::WaveSimulationFFT2(
-    double _lx, double _ly, int _nx, int _ny) :
-    impl(new WaveSimulationFFT2Impl(_lx, _ly, _nx, _ny))
+    double lx, double ly, int nx, int ny) :
+    impl_(new WaveSimulationFFT2Impl(lx, ly, nx, ny))
   {
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::SetUseVectorised(bool _value)
+  void WaveSimulationFFT2::SetUseVectorised(bool value)
   {
-    impl->SetUseVectorised(_value);
+    impl_->SetUseVectorised(value);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::SetLambda(double _value)
+  void WaveSimulationFFT2::SetLambda(double value)
   {
-    impl->SetLambda(_value);
+    impl_->SetLambda(value);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::SetWindVelocity(double _ux, double _uy)
+  void WaveSimulationFFT2::SetWindVelocity(double ux, double uy)
   {
-    impl->SetWindVelocity(_ux, _uy);
+    impl_->SetWindVelocity(ux, uy);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::SetTime(double _value)
+  void WaveSimulationFFT2::SetTime(double value)
   {
-    impl->SetTime(_value);
+    impl_->SetTime(value);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationFFT2::ComputeElevation(
-    Eigen::Ref<Eigen::MatrixXd> _h)
+    Eigen::Ref<Eigen::MatrixXd> h)
   {
-    impl->ComputeElevation(_h);
+    impl_->ComputeElevation(h);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationFFT2::ComputeElevationDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy)
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
-    impl->ComputeElevationDerivatives(_dhdx, _dhdy);
+    impl_->ComputeElevationDerivatives(dhdx, dhdy);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationFFT2::ComputeDisplacements(
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy)
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy)
   {
-    impl->ComputeDisplacements(_sx, _sy);
+    impl_->ComputeDisplacements(sx, sy);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationFFT2::ComputeDisplacementsDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    impl->ComputeDisplacementsDerivatives(_dsxdx, _dsxdy, _dsxdy);
+    impl_->ComputeDisplacementsDerivatives(dsxdx, dsxdy, dsxdy);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationFFT2::ComputeDisplacementsAndDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _h,
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy,
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> h,
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy,
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    impl->ComputeElevation(_h);
-    impl->ComputeElevationDerivatives(_dhdx, _dhdy);
-    impl->ComputeDisplacements(_sx, _sy);
-    impl->ComputeDisplacementsDerivatives(_dsxdx, _dsydy, _dsxdy);
+    impl_->ComputeElevation(h);
+    impl_->ComputeElevationDerivatives(dhdx, dhdy);
+    impl_->ComputeDisplacements(sx, sy);
+    impl_->ComputeDisplacementsDerivatives(dsxdx, dsydy, dsxdy);
   }
 }
 }

--- a/gz-waves/src/WaveSimulationFFT2.cc
+++ b/gz-waves/src/WaveSimulationFFT2.cc
@@ -42,28 +42,6 @@
 #include "gz/waves/WaveSpreadingFunction.hh"
 #include "WaveSimulationFFT2Impl.hh"
 
-using Eigen::MatrixXcd;
-using Eigen::MatrixXd;
-using Eigen::VectorXcd;
-using Eigen::VectorXd;
-
-namespace Eigen
-{ 
-  typedef Eigen::Matrix<
-    std::complex<double>,
-    Eigen::Dynamic,
-    Eigen::Dynamic,
-    Eigen::RowMajor
-  > MatrixXcdRowMajor;
-
-  typedef Eigen::Matrix<
-    double,
-    Eigen::Dynamic,
-    Eigen::Dynamic,
-    Eigen::RowMajor
-  > MatrixXdRowMajor;
-}
-
 #define USE_LOOP_FOR_OUTPUT_MAPPING 1
 
 namespace gz
@@ -135,7 +113,7 @@ namespace waves
       {
         int ij = ikx * ny_ + iky;
         int xy = iky * nx_ + ikx;
-        h(xy, 0) = fft_out0_[ij].real();
+        h(xy, 0) = fft_out0_(ij, 0).real();
       }
     }
 #else
@@ -164,8 +142,8 @@ namespace waves
       {
         int ij = ikx * ny_ + iky;
         int xy = iky * nx_ + ikx;
-        dhdy(xy, 0) = fft_out1_[ij].real();
-        dhdx(xy, 0) = fft_out2_[ij].real();
+        dhdy(xy, 0) = fft_out1_(ij, 0).real();
+        dhdx(xy, 0) = fft_out2_(ij, 0).real();
       }
     }
 #else
@@ -200,8 +178,8 @@ namespace waves
       {
         int ij = ikx * ny_ + iky;
         int xy = iky * nx_ + ikx;
-        sy(xy, 0) = fft_out3_[ij].real() * lambda_ * -1.0;
-        sx(xy, 0) = fft_out4_[ij].real() * lambda_ * -1.0;
+        sy(xy, 0) = fft_out3_(ij, 0).real() * lambda_ * -1.0;
+        sx(xy, 0) = fft_out4_(ij, 0).real() * lambda_ * -1.0;
       }
     }
 #else
@@ -233,9 +211,9 @@ namespace waves
       {
         int ij = ikx * ny_ + iky;
         int xy = iky * nx_ + ikx;
-        dsydy(xy, 0) = fft_out5_[ij].real() * lambda_ * -1.0;
-        dsxdx(xy, 0) = fft_out6_[ij].real() * lambda_ * -1.0;
-        dsxdy(xy, 0) = fft_out7_[ij].real() * lambda_ *  1.0;
+        dsydy(xy, 0) = fft_out5_(ij, 0).real() * lambda_ * -1.0;
+        dsxdx(xy, 0) = fft_out6_(ij, 0).real() * lambda_ * -1.0;
+        dsxdy(xy, 0) = fft_out7_(ij, 0).real() * lambda_ *  1.0;
       }
     }
 #else
@@ -493,23 +471,23 @@ namespace waves
         complex hiok = hi * ook;
 
         // height (amplitude)
-        fft_h_[idx] = h;
+        fft_h_(idx, 0) = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        fft_h_ikx_[idx] = hi * kx;
-        fft_h_iky_[idx] = hi * ky;
+        fft_h_ikx_(idx, 0) = hi * kx;
+        fft_h_iky_(idx, 0) = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
         {          
-          fft_sx_[idx]    = czero;
-          fft_sy_[idx]    = czero;
-          fft_h_kxkx_[idx] = czero;
-          fft_h_kyky_[idx] = czero;
-          fft_h_kxky_[idx] = czero;
+          fft_sx_(idx, 0)     = czero;
+          fft_sy_(idx, 0)     = czero;
+          fft_h_kxkx_(idx, 0) = czero;
+          fft_h_kyky_(idx, 0) = czero;
+          fft_h_kxky_(idx, 0) = czero;
         }
         else
         {
@@ -519,11 +497,11 @@ namespace waves
           complex hkyky = hok * ky2;
           complex hkxky = hok * kx * ky;
           
-          fft_sx_[idx]    = dx;
-          fft_sy_[idx]    = dy;
-          fft_h_kxkx_[idx] = hkxkx;
-          fft_h_kyky_[idx] = hkyky;
-          fft_h_kxky_[idx] = hkxky;
+          fft_sx_(idx, 0)     = dx;
+          fft_sy_(idx, 0)     = dy;
+          fft_h_kxkx_(idx, 0) = hkxkx;
+          fft_h_kyky_(idx, 0) = hkyky;
+          fft_h_kxky_(idx, 0) = hkxky;
         }
       }
     }
@@ -702,23 +680,23 @@ namespace waves
         complex hiok = hi * ook;
 
         // height (amplitude)
-        fft_h_[idx] = h;
+        fft_h_(idx, 0) = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        fft_h_ikx_[idx] = hi * kx;
-        fft_h_iky_[idx] = hi * ky;
+        fft_h_ikx_(idx, 0) = hi * kx;
+        fft_h_iky_(idx, 0) = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
         {          
-          fft_sx_[idx]     = czero;
-          fft_sy_[idx]     = czero;
-          fft_h_kxkx_[idx] = czero;
-          fft_h_kyky_[idx] = czero;
-          fft_h_kxky_[idx] = czero;
+          fft_sx_(idx, 0)     = czero;
+          fft_sy_(idx, 0)     = czero;
+          fft_h_kxkx_(idx, 0) = czero;
+          fft_h_kyky_(idx, 0) = czero;
+          fft_h_kxky_(idx, 0) = czero;
         }
         else
         {
@@ -728,11 +706,11 @@ namespace waves
           complex hkyky = hok * ky2;
           complex hkxky = hok * kx * ky;
           
-          fft_sx_[idx]     = dx;
-          fft_sy_[idx]     = dy;
-          fft_h_kxkx_[idx] = hkxkx;
-          fft_h_kyky_[idx] = hkyky;
-          fft_h_kxky_[idx] = hkxky;
+          fft_sx_(idx, 0)     = dx;
+          fft_sy_(idx, 0)     = dy;
+          fft_h_kxkx_(idx, 0) = hkxkx;
+          fft_h_kyky_(idx, 0) = hkyky;
+          fft_h_kxky_(idx, 0) = hkxky;
         }
       }
     }
@@ -999,23 +977,23 @@ namespace waves
         complex hiok = hi * ook;
 
         // height (amplitude)
-        fft_h_[idx] = h;
+        fft_h_(idx, 0) = h;
 
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
 
-        fft_h_ikx_[idx] = hi * kx;
-        fft_h_iky_[idx] = hi * ky;
+        fft_h_ikx_(idx, 0) = hi * kx;
+        fft_h_iky_(idx, 0) = hi * ky;
 
         // displacement and derivatives
         if (std::abs(k) < 1.0E-8)
         {          
-          fft_sx_[idx]     = czero;
-          fft_sy_[idx]     = czero;
-          fft_h_kxkx_[idx] = czero;
-          fft_h_kyky_[idx] = czero;
-          fft_h_kxky_[idx] = czero;
+          fft_sx_(idx, 0)     = czero;
+          fft_sy_(idx, 0)     = czero;
+          fft_h_kxkx_(idx, 0) = czero;
+          fft_h_kyky_(idx, 0) = czero;
+          fft_h_kxky_(idx, 0) = czero;
         }
         else
         {
@@ -1025,11 +1003,11 @@ namespace waves
           complex hkyky = hok * ky2;
           complex hkxky = hok * kx * ky;
           
-          fft_sx_[idx]     = dx;
-          fft_sy_[idx]     = dy;
-          fft_h_kxkx_[idx] = hkxkx;
-          fft_h_kyky_[idx] = hkyky;
-          fft_h_kxky_[idx] = hkxky;
+          fft_sx_(idx, 0)     = dx;
+          fft_sy_(idx, 0)     = dy;
+          fft_h_kxkx_(idx, 0) = hkxkx;
+          fft_h_kyky_(idx, 0) = hkyky;
+          fft_h_kxky_(idx, 0) = hkxky;
         }
       }
     }
@@ -1041,14 +1019,14 @@ namespace waves
     size_t n2 = nx_ * ny_;
 
     // initialise storage for Fourier coefficients
-    fft_h_      = Eigen::VectorXcd::Zero(n2);
-    fft_h_ikx_  = Eigen::VectorXcd::Zero(n2);
-    fft_h_iky_  = Eigen::VectorXcd::Zero(n2);
-    fft_sx_     = Eigen::VectorXcd::Zero(n2);
-    fft_sy_     = Eigen::VectorXcd::Zero(n2);
-    fft_h_kxkx_ = Eigen::VectorXcd::Zero(n2);
-    fft_h_kyky_ = Eigen::VectorXcd::Zero(n2);
-    fft_h_kxky_ = Eigen::VectorXcd::Zero(n2);
+    fft_h_      = Eigen::VectorXcd::Zero(n2, 1);
+    fft_h_ikx_  = Eigen::VectorXcd::Zero(n2, 1);
+    fft_h_iky_  = Eigen::VectorXcd::Zero(n2, 1);
+    fft_sx_     = Eigen::VectorXcd::Zero(n2, 1);
+    fft_sy_     = Eigen::VectorXcd::Zero(n2, 1);
+    fft_h_kxkx_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_h_kyky_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_h_kxky_ = Eigen::VectorXcd::Zero(n2, 1);
   }
 
   //////////////////////////////////////////////////
@@ -1081,16 +1059,16 @@ namespace waves
     size_t n2 = nx_ * ny_;
 
     // elevation
-    fft_out0_ = Eigen::VectorXcd::Zero(n2);
-    fft_out1_ = Eigen::VectorXcd::Zero(n2);
-    fft_out2_ = Eigen::VectorXcd::Zero(n2);
+    fft_out0_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_out1_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_out2_ = Eigen::VectorXcd::Zero(n2, 1);
 
     // xy-displacements
-    fft_out3_ = Eigen::VectorXcd::Zero(n2);
-    fft_out4_ = Eigen::VectorXcd::Zero(n2);
-    fft_out5_ = Eigen::VectorXcd::Zero(n2);
-    fft_out6_ = Eigen::VectorXcd::Zero(n2);
-    fft_out7_ = Eigen::VectorXcd::Zero(n2);
+    fft_out3_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_out4_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_out5_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_out6_ = Eigen::VectorXcd::Zero(n2, 1);
+    fft_out7_ = Eigen::VectorXcd::Zero(n2, 1);
 
     // elevation
     fft_plan0_ = fftw_plan_dft_2d(nx_, ny_,

--- a/gz-waves/src/WaveSimulationFFT2Impl.hh
+++ b/gz-waves/src/WaveSimulationFFT2Impl.hh
@@ -111,13 +111,6 @@ namespace waves
     void CreateFFTWPlans();
     void DestroyFFTWPlans();
 
-    bool use_vectorised_{false};
-
-    double gravity_{9.81};
-
-    /// \brief Horizontal displacement scaling factor. Zero for no displacement
-    double lambda_{0.0};
-
     Eigen::VectorXcd fft_h_;       // FFT0 - height
     Eigen::VectorXcd fft_h_ikx_;   // FFT1 - d height / dx
     Eigen::VectorXcd fft_h_iky_;   // FFT1 - d height / dy
@@ -126,15 +119,6 @@ namespace waves
     Eigen::VectorXcd fft_h_kxkx_;  // FFT5 - d displacement x / dx
     Eigen::VectorXcd fft_h_kyky_;  // FFT6 - d displacement y / dy
     Eigen::VectorXcd fft_h_kxky_;  // FFT7 - d displacement x / dy = d displacement y / dx
-
-    // Eigen::VectorXcd fft_in0_;
-    // Eigen::VectorXcd fft_in1_;
-    // Eigen::VectorXcd fft_in2_;
-    // Eigen::VectorXcd fft_in3_;
-    // Eigen::VectorXcd fft_in4_;
-    // Eigen::VectorXcd fft_in5_;
-    // Eigen::VectorXcd fft_in6_;
-    // Eigen::VectorXcd fft_in7_;
 
     Eigen::VectorXcd fft_out0_;
     Eigen::VectorXcd fft_out1_;
@@ -148,7 +132,16 @@ namespace waves
     fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
     fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
 
-    // parameters
+    /// \brief Flag to select whether to use vectorised calculations. 
+    bool use_vectorised_{false};
+
+    /// \brief Gravity acceleration [m/s^2]
+    double gravity_{9.81};
+
+    /// \brief Horizontal displacement scaling factor. Zero for no displacement
+    double lambda_{0.0};
+
+    // grid parameters
     double  lx_{1.0};
     double  ly_{1.0};
     int     nx_{2};
@@ -202,7 +195,7 @@ namespace waves
     Eigen::VectorXd kx_math_;
     Eigen::VectorXd ky_math_;
 
-    // set to 1 to use a symmetric spreading function (=> standing waves)
+    /// \brief Set to 1 to use a symmetric spreading function (standing waves).
     bool use_symmetric_spreading_fn_{false};
 
     /// \todo consolidate different storage structures when checked correct

--- a/gz-waves/src/WaveSimulationFFT2Impl.hh
+++ b/gz-waves/src/WaveSimulationFFT2Impl.hh
@@ -91,6 +91,9 @@ namespace waves
     /// \brief Calculate the time-independent Fourier amplitudes
     void ComputeCurrentAmplitudes(double time);
     
+    void ComputeBaseAmplitudesNonVectorised();
+    void ComputeCurrentAmplitudesNonVectorised(double time);
+
     void ComputeBaseAmplitudesVectorised();
     void ComputeCurrentAmplitudesVectorised(double time);
 

--- a/gz-waves/src/WaveSimulationFFT2Impl.hh
+++ b/gz-waves/src/WaveSimulationFFT2Impl.hh
@@ -48,6 +48,8 @@ namespace waves
   class WaveSimulationFFT2Impl
   {
   public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    
     /// \brief Destructor 
     ~WaveSimulationFFT2Impl();
 

--- a/gz-waves/src/WaveSimulationFFT2Impl.hh
+++ b/gz-waves/src/WaveSimulationFFT2Impl.hh
@@ -91,6 +91,9 @@ namespace waves
     /// \brief Calculate the time-independent Fourier amplitudes
     void ComputeCurrentAmplitudes(double time);
     
+    void ComputeBaseAmplitudesVectorised();
+    void ComputeCurrentAmplitudesVectorised(double time);
+
     /// \brief Reference implementation of base amplitude calculation
     void ComputeBaseAmplitudesReference();
 
@@ -98,6 +101,8 @@ namespace waves
     void ComputeCurrentAmplitudesReference(double time);
 
     bool use_vectorised_{false};
+
+    double gravity_{9.81};
 
     /// \brief Horizontal displacement scaling factor. Zero for no displacement
     double lambda_;
@@ -216,11 +221,14 @@ namespace waves
     Eigen::MatrixXd omega_k_ref_;
 
     static double ECKVOmniDirectionalSpectrum(
-        double k, double u10, double cap_omega_c=0.84);
+        double k, double u10, double cap_omega_c=0.84,
+        double gravity=9.81);
     static double ECKVSpreadingFunction(
-        double k, double phi, double u10, double cap_omega_c=0.84);
+        double k, double phi, double u10, double cap_omega_c=0.84,
+        double gravity=9.81);
     static double Cos2SSpreadingFunction(
-        double s_param, double phi, double u10, double cap_omega_c=0.84);
+        double s_param, double phi, double u10, double cap_omega_c=0.84,
+        double gravity=9.81);
 
     /// \brief For testing
     friend class TestFixtureWaveSimulationFFT2;

--- a/gz-waves/src/WaveSimulationFFT2Impl.hh
+++ b/gz-waves/src/WaveSimulationFFT2Impl.hh
@@ -16,13 +16,13 @@
 #ifndef GZ_WAVES_WAVESIMULATIONFFT2_IMPL_HH_
 #define GZ_WAVES_WAVESIMULATIONFFT2_IMPL_HH_
 
-#include "gz/waves/WaveSimulation.hh"
+#include <complex>
 
 #include <Eigen/Dense>
 
 #include <fftw3.h>
 
-#include <complex>
+#include "gz/waves/WaveSimulation.hh"
 
 using Eigen::MatrixXcd;
 using Eigen::MatrixXd;
@@ -40,6 +40,11 @@ namespace waves
   typedef std::complex<fftw_data_type> complex;
 
   /// \brief Implementation of a FFT based wave simulation model
+  ///
+  /// \note The FFT wave simulation mixes storage ordering which
+  ///       must be made consistent and should be column major
+  ///       which is the Eigen default..
+  ///
   class WaveSimulationFFT2Impl
   {
   public:
@@ -47,168 +52,168 @@ namespace waves
     ~WaveSimulationFFT2Impl();
 
     /// \brief Construct a wave simulation model
-    WaveSimulationFFT2Impl(double _lx, double _ly, int _nx, int _ny);
+    WaveSimulationFFT2Impl(double lx, double ly, int nx, int ny);
 
-    void SetUseVectorised(bool _value);
+    void SetUseVectorised(bool value);
 
     /// \brief Set the components of the wind velocity (U10) in [m/s]
-    void SetWindVelocity(double _ux, double _uy);
+    void SetWindVelocity(double ux, double uy);
 
     /// \brief Set the current time in seconds
-    void SetTime(double _value);
+    void SetTime(double value);
 
     /// \brief Set the horizontal displacement scaling factor
-    void SetLambda(double _value);
+    void SetLambda(double value);
 
     /// \brief Calculate the sea surface elevation
     void ComputeElevation(
-      Eigen::Ref<Eigen::MatrixXd> _h);
+      Eigen::Ref<Eigen::MatrixXd> h);
 
     /// \brief Calculate the derivative of the elevation wrt x and y
     void ComputeElevationDerivatives(
-      Eigen::Ref<Eigen::MatrixXd> _dhdx,
-      Eigen::Ref<Eigen::MatrixXd> _dhdy);
+      Eigen::Ref<Eigen::MatrixXd> dhdx,
+      Eigen::Ref<Eigen::MatrixXd> dhdy);
 
     /// \brief Calculate the sea surface horizontal displacements
     void ComputeDisplacements(
-      Eigen::Ref<Eigen::MatrixXd> _sx,
-      Eigen::Ref<Eigen::MatrixXd> _sy);
+      Eigen::Ref<Eigen::MatrixXd> sx,
+      Eigen::Ref<Eigen::MatrixXd> sy);
 
     /// \brief Calculate the derivative of the horizontal displacements wrt x and y
     void ComputeDisplacementsDerivatives(
-      Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-      Eigen::Ref<Eigen::MatrixXd> _dsydy,
-      Eigen::Ref<Eigen::MatrixXd> _dsxdy);
+      Eigen::Ref<Eigen::MatrixXd> dsxdx,
+      Eigen::Ref<Eigen::MatrixXd> dsydy,
+      Eigen::Ref<Eigen::MatrixXd> dsxdy);
 
     /// \brief Calculate the base (time-independent) Fourier amplitudes
     void ComputeBaseAmplitudes();
 
     /// \brief Calculate the time-independent Fourier amplitudes
-    void ComputeCurrentAmplitudes(double _time);
+    void ComputeCurrentAmplitudes(double time);
     
     /// \brief Reference implementation of base amplitude calculation
     void ComputeBaseAmplitudesReference();
 
     /// \brief Reference implementation of time-dependent amplitude calculation
-    void ComputeCurrentAmplitudesReference(double _time);
+    void ComputeCurrentAmplitudesReference(double time);
 
     bool use_vectorised{false};
 
     /// \brief Horizontal displacement scaling factor. Zero for no displacement
-    double lambda;
+    double lambda_;
 
-    Eigen::VectorXcd fft_h;       // FFT0 - height
-    Eigen::VectorXcd fft_h_ikx;   // FFT1 - d height / dx
-    Eigen::VectorXcd fft_h_iky;   // FFT1 - d height / dy
-    Eigen::VectorXcd fft_sx;      // FFT3 - displacement x
-    Eigen::VectorXcd fft_sy;      // FFT4 - displacement y
-    Eigen::VectorXcd fft_h_kxkx;  // FFT5 - d displacement x / dx
-    Eigen::VectorXcd fft_h_kyky;  // FFT6 - d displacement y / dy
-    Eigen::VectorXcd fft_h_kxky;  // FFT7 - d displacement x / dy = d displacement y / dx
+    Eigen::VectorXcd fft_h_;       // FFT0 - height
+    Eigen::VectorXcd fft_h_ikx_;   // FFT1 - d height / dx
+    Eigen::VectorXcd fft_h_iky_;   // FFT1 - d height / dy
+    Eigen::VectorXcd fft_sx_;      // FFT3 - displacement x
+    Eigen::VectorXcd fft_sy_;      // FFT4 - displacement y
+    Eigen::VectorXcd fft_h_kxkx_;  // FFT5 - d displacement x / dx
+    Eigen::VectorXcd fft_h_kyky_;  // FFT6 - d displacement y / dy
+    Eigen::VectorXcd fft_h_kxky_;  // FFT7 - d displacement x / dy = d displacement y / dx
 
-    fftw_complex* fft_in0;
-    fftw_complex* fft_in1;
-    fftw_complex* fft_in2;
-    fftw_complex* fft_in3;
-    fftw_complex* fft_in4;
-    fftw_complex* fft_in5;
-    fftw_complex* fft_in6;
-    fftw_complex* fft_in7;
+    fftw_complex* fft_in0_;
+    fftw_complex* fft_in1_;
+    fftw_complex* fft_in2_;
+    fftw_complex* fft_in3_;
+    fftw_complex* fft_in4_;
+    fftw_complex* fft_in5_;
+    fftw_complex* fft_in6_;
+    fftw_complex* fft_in7_;
 
-    fftw_complex* fft_out0;
-    fftw_complex* fft_out1;
-    fftw_complex* fft_out2;
-    fftw_complex* fft_out3;
-    fftw_complex* fft_out4;
-    fftw_complex* fft_out5;
-    fftw_complex* fft_out6;
-    fftw_complex* fft_out7;
+    fftw_complex* fft_out0_;
+    fftw_complex* fft_out1_;
+    fftw_complex* fft_out2_;
+    fftw_complex* fft_out3_;
+    fftw_complex* fft_out4_;
+    fftw_complex* fft_out5_;
+    fftw_complex* fft_out6_;
+    fftw_complex* fft_out7_;
 
-    fftw_plan fft_plan0, fft_plan1, fft_plan2;
-    fftw_plan fft_plan3, fft_plan4, fft_plan5, fft_plan6, fft_plan7;
+    fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
+    fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
 
     // parameters
-    double  lx{1.0};
-    double  ly{1.0};
-    int     nx{2};
-    int     ny{2};
+    double  lx_{1.0};
+    double  ly_{1.0};
+    int     nx_{2};
+    int     ny_{2};
 
     /// \brief Wind speed at 10m above mean sea level [m]
-    double  u10{5.0};
+    double  u10_{5.0};
 
     /// \brief Direction of u10. Counter clockwise angle from x-axis [rad]
-    double  phi10{0.0};
+    double  phi10_{0.0};
 
     /// \brief Spreading parameter for the cosine-2S model
-    double  s_param{5.0};
+    double  s_param_{5.0};
 
     /// \brief Parameter controlling the maturity of the sea state.
-    double  cap_omega_c{0.84};
+    double  cap_omega_c_{0.84};
 
     // derived quantities
 
     // sample spacing [m]
-    double  delta_x{this->lx / this->nx};
-    double  delta_y{this->ly / this->ny};
+    double  delta_x_{lx_ / nx_};
+    double  delta_y_{ly_ / ny_};
 
     // fundamental wavelength [m]
-    double  lambda_x_f{this->lx};
-    double  lambda_y_f{this->ly};
+    double  lambda_x_f_{lx_};
+    double  lambda_y_f_{ly_};
 
     // nyquist wavelength [m]
-    double  lambda_x_ny{2.0 * this->delta_x};
-    double  lambda_y_ny{2.0 * this->delta_y};
+    double  lambda_x_ny_{2.0 * delta_x_};
+    double  lambda_y_ny_{2.0 * delta_y_};
 
     // fundamental spatial frequency [1/m]
-    double  nu_x_f{1.0 / this->lx};
-    double  nu_y_f{1.0 / this->ly};
+    double  nu_x_f_{1.0 / lx_};
+    double  nu_y_f_{1.0 / ly_};
 
     // nyquist spatial frequency [1/m]
-    double  nu_x_ny{1.0 / (2.0 * this->delta_x)};
-    double  nu_y_ny{1.0 / (2.0 * this->delta_y)};
+    double  nu_x_ny_{1.0 / (2.0 * delta_x_)};
+    double  nu_y_ny_{1.0 / (2.0 * delta_y_)};
 
     // fundamental angular spatial frequency [rad/m]
-    double  kx_f{2.0 * M_PI / this->lx};
-    double  ky_f{2.0 * M_PI / this->ly};
+    double  kx_f_{2.0 * M_PI / lx_};
+    double  ky_f_{2.0 * M_PI / ly_};
 
     // nyquist angular spatial frequency [rad/m]
-    double  kx_ny{this->kx_f * this->nx / 2.0};
-    double  ky_ny{this->ky_f * this->ny / 2.0};
+    double  kx_ny_{kx_f_ * nx_ / 2.0};
+    double  ky_ny_{ky_f_ * ny_ / 2.0};
 
     // angular spatial frequencies in fft and math order
-    Eigen::VectorXd kx_fft{Eigen::VectorXd::Zero(this->nx)};
-    Eigen::VectorXd ky_fft{Eigen::VectorXd::Zero(this->ny)};
-    Eigen::VectorXd kx_math{Eigen::VectorXd::Zero(this->nx)};
-    Eigen::VectorXd ky_math{Eigen::VectorXd::Zero(this->ny)};
+    Eigen::VectorXd kx_fft_{Eigen::VectorXd::Zero(nx_)};
+    Eigen::VectorXd ky_fft_{Eigen::VectorXd::Zero(ny_)};
+    Eigen::VectorXd kx_math_{Eigen::VectorXd::Zero(nx_)};
+    Eigen::VectorXd ky_math_{Eigen::VectorXd::Zero(ny_)};
 
     // set to 1 to use a symmetric spreading function (=> standing waves)
-    bool use_symmetric_spreading_fn{false};
+    bool use_symmetric_spreading_fn_{false};
 
     //////////////////////////////////////////////////
     /// \note: use flattened array storage for optimised version
 
     // square-root of two-sided discrete elevation variance spectrum
-    Eigen::VectorXd cap_psi_2s_root{Eigen::VectorXd::Zero(this->nx * this->ny)};
+    Eigen::VectorXd cap_psi_2s_root_{Eigen::VectorXd::Zero(nx_ * ny_)};
 
     // iid random normals for real and imaginary parts of the amplitudes
-    Eigen::VectorXd rho{Eigen::VectorXd::Zero(this->nx * this->ny)};
-    Eigen::VectorXd sigma{Eigen::VectorXd::Zero(this->nx * this->ny)};
+    Eigen::VectorXd rho_{Eigen::VectorXd::Zero(nx_ * ny_)};
+    Eigen::VectorXd sigma_{Eigen::VectorXd::Zero(nx_ * ny_)};
 
     // angular temporal frequency
-    Eigen::VectorXd omega_k{Eigen::VectorXd::Zero(this->nx * this->ny)};
+    Eigen::VectorXd omega_k_{Eigen::VectorXd::Zero(nx_ * ny_)};
 
     //////////////////////////////////////////////////
     /// \note: use 2d array storage for reference version, resized if required
 
     // square-root of two-sided discrete elevation variance spectrum
-    Eigen::MatrixXd cap_psi_2s_root_ref;
+    Eigen::MatrixXd cap_psi_2s_root_ref_;
 
     // iid random normals for real and imaginary parts of the amplitudes
-    Eigen::MatrixXd rho_ref;
-    Eigen::MatrixXd sigma_ref;
+    Eigen::MatrixXd rho_ref_;
+    Eigen::MatrixXd sigma_ref_;
 
     // angular temporal frequency
-    Eigen::MatrixXd omega_k_ref;
+    Eigen::MatrixXd omega_k_ref_;
 
     static double ECKVOmniDirectionalSpectrum(
         double k, double u10, double cap_omega_c=0.84);

--- a/gz-waves/src/WaveSimulationFFT2Impl.hh
+++ b/gz-waves/src/WaveSimulationFFT2Impl.hh
@@ -29,6 +29,23 @@ using Eigen::MatrixXd;
 using Eigen::VectorXcd;
 using Eigen::VectorXd;
 
+namespace Eigen
+{ 
+  typedef Eigen::Matrix<
+    std::complex<double>,
+    Eigen::Dynamic,
+    Eigen::Dynamic,
+    Eigen::RowMajor
+  > MatrixXcdRowMajor;
+
+  typedef Eigen::Matrix<
+    double,
+    Eigen::Dynamic,
+    Eigen::Dynamic,
+    Eigen::RowMajor
+  > MatrixXdRowMajor;
+}
+
 namespace gz
 {
 namespace waves
@@ -111,23 +128,29 @@ namespace waves
     void CreateFFTWPlans();
     void DestroyFFTWPlans();
 
-    Eigen::VectorXcd fft_h_;       // FFT0 - height
-    Eigen::VectorXcd fft_h_ikx_;   // FFT1 - d height / dx
-    Eigen::VectorXcd fft_h_iky_;   // FFT1 - d height / dy
-    Eigen::VectorXcd fft_sx_;      // FFT3 - displacement x
-    Eigen::VectorXcd fft_sy_;      // FFT4 - displacement y
-    Eigen::VectorXcd fft_h_kxkx_;  // FFT5 - d displacement x / dx
-    Eigen::VectorXcd fft_h_kyky_;  // FFT6 - d displacement y / dy
-    Eigen::VectorXcd fft_h_kxky_;  // FFT7 - d displacement x / dy = d displacement y / dx
+    /// \note FFTW expects the multi-dimensional arrays to be in row-major
+    ///       format. Eigen::MatrixXcd is column-major, so here we
+    ///       explicity set the storage type.
+    ///
+    /// https://www.fftw.org/fftw3_doc/Row_002dmajor-Format.html 
+    ///
+    Eigen::MatrixXcdRowMajor fft_h_;       // FFT0 - height
+    Eigen::MatrixXcdRowMajor fft_h_ikx_;   // FFT1 - d height / dx
+    Eigen::MatrixXcdRowMajor fft_h_iky_;   // FFT1 - d height / dy
+    Eigen::MatrixXcdRowMajor fft_sx_;      // FFT3 - displacement x
+    Eigen::MatrixXcdRowMajor fft_sy_;      // FFT4 - displacement y
+    Eigen::MatrixXcdRowMajor fft_h_kxkx_;  // FFT5 - d displacement x / dx
+    Eigen::MatrixXcdRowMajor fft_h_kyky_;  // FFT6 - d displacement y / dy
+    Eigen::MatrixXcdRowMajor fft_h_kxky_;  // FFT7 - d displacement x / dy
 
-    Eigen::VectorXcd fft_out0_;
-    Eigen::VectorXcd fft_out1_;
-    Eigen::VectorXcd fft_out2_;
-    Eigen::VectorXcd fft_out3_;
-    Eigen::VectorXcd fft_out4_;
-    Eigen::VectorXcd fft_out5_;
-    Eigen::VectorXcd fft_out6_;
-    Eigen::VectorXcd fft_out7_;
+    Eigen::MatrixXcdRowMajor fft_out0_;
+    Eigen::MatrixXcdRowMajor fft_out1_;
+    Eigen::MatrixXcdRowMajor fft_out2_;
+    Eigen::MatrixXcdRowMajor fft_out3_;
+    Eigen::MatrixXcdRowMajor fft_out4_;
+    Eigen::MatrixXcdRowMajor fft_out5_;
+    Eigen::MatrixXcdRowMajor fft_out6_;
+    Eigen::MatrixXcdRowMajor fft_out7_;
 
     fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
     fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;

--- a/gz-waves/src/WaveSimulationFFT2Impl.hh
+++ b/gz-waves/src/WaveSimulationFFT2Impl.hh
@@ -111,7 +111,6 @@ namespace waves
     void CreateFFTWPlans();
     void DestroyFFTWPlans();
 
-
     bool use_vectorised_{false};
 
     double gravity_{9.81};
@@ -128,23 +127,23 @@ namespace waves
     Eigen::VectorXcd fft_h_kyky_;  // FFT6 - d displacement y / dy
     Eigen::VectorXcd fft_h_kxky_;  // FFT7 - d displacement x / dy = d displacement y / dx
 
-    fftw_complex* fft_in0_;
-    fftw_complex* fft_in1_;
-    fftw_complex* fft_in2_;
-    fftw_complex* fft_in3_;
-    fftw_complex* fft_in4_;
-    fftw_complex* fft_in5_;
-    fftw_complex* fft_in6_;
-    fftw_complex* fft_in7_;
+    // Eigen::VectorXcd fft_in0_;
+    // Eigen::VectorXcd fft_in1_;
+    // Eigen::VectorXcd fft_in2_;
+    // Eigen::VectorXcd fft_in3_;
+    // Eigen::VectorXcd fft_in4_;
+    // Eigen::VectorXcd fft_in5_;
+    // Eigen::VectorXcd fft_in6_;
+    // Eigen::VectorXcd fft_in7_;
 
-    fftw_complex* fft_out0_;
-    fftw_complex* fft_out1_;
-    fftw_complex* fft_out2_;
-    fftw_complex* fft_out3_;
-    fftw_complex* fft_out4_;
-    fftw_complex* fft_out5_;
-    fftw_complex* fft_out6_;
-    fftw_complex* fft_out7_;
+    Eigen::VectorXcd fft_out0_;
+    Eigen::VectorXcd fft_out1_;
+    Eigen::VectorXcd fft_out2_;
+    Eigen::VectorXcd fft_out3_;
+    Eigen::VectorXcd fft_out4_;
+    Eigen::VectorXcd fft_out5_;
+    Eigen::VectorXcd fft_out6_;
+    Eigen::VectorXcd fft_out7_;
 
     fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
     fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
@@ -207,7 +206,7 @@ namespace waves
     bool use_symmetric_spreading_fn_{false};
 
     /// \todo consolidate different storage structures when checked correct
-     
+
     //////////////////////////////////////////////////
     /// \note: flattened array storage for non-vectorised version
 

--- a/gz-waves/src/WaveSimulationFFT2Impl.hh
+++ b/gz-waves/src/WaveSimulationFFT2Impl.hh
@@ -97,7 +97,7 @@ namespace waves
     /// \brief Reference implementation of time-dependent amplitude calculation
     void ComputeCurrentAmplitudesReference(double time);
 
-    bool use_vectorised{false};
+    bool use_vectorised_{false};
 
     /// \brief Horizontal displacement scaling factor. Zero for no displacement
     double lambda_;

--- a/gz-waves/src/WaveSimulationFFT2_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT2_TEST.cc
@@ -72,10 +72,10 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
 
   // check array dimensions
-  EXPECT_EQ(model.kx_fft.size(), this->nx);
-  EXPECT_EQ(model.ky_fft.size(), this->ny);
-  EXPECT_EQ(model.kx_math.size(), this->nx);
-  EXPECT_EQ(model.ky_math.size(), this->ny);
+  EXPECT_EQ(model.kx_fft_.size(), this->nx);
+  EXPECT_EQ(model.ky_fft_.size(), this->ny);
+  EXPECT_EQ(model.kx_math_.size(), this->nx);
+  EXPECT_EQ(model.ky_math_.size(), this->ny);
 
   std::vector<double> ikx_math = {
     -8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0,
@@ -95,23 +95,23 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
   // check kx math-ordering
   for (int i=0; i<this->nx; ++i)
   {
-    ASSERT_DOUBLE_EQ(model.kx_math[i] / model.kx_f, ikx_math[i]);
+    ASSERT_DOUBLE_EQ(model.kx_math_[i] / model.kx_f_, ikx_math[i]);
   }
   // check ky math-ordering
   for (int i=0; i<this->ny; ++i)
   {
-    ASSERT_DOUBLE_EQ(model.ky_math[i] / model.ky_f, iky_math[i]);
+    ASSERT_DOUBLE_EQ(model.ky_math_[i] / model.ky_f_, iky_math[i]);
   }
 
   // check kx fft-ordering
   for (int i=0; i<this->nx; ++i)
   {
-    ASSERT_DOUBLE_EQ(model.kx_fft[i] / model.kx_f, ikx_fft[i]);
+    ASSERT_DOUBLE_EQ(model.kx_fft_[i] / model.kx_f_, ikx_fft[i]);
   }
   // check ky fft-ordering
   for (int i=0; i<this->ny; ++i)
   {
-    ASSERT_DOUBLE_EQ(model.ky_fft[i] / model.ky_f, iky_fft[i]);
+    ASSERT_DOUBLE_EQ(model.ky_fft_[i] / model.ky_f_, iky_fft[i]);
   }
 }
 
@@ -142,8 +142,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
       //   << "\n";
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h[idx];
-      complex hc = model.fft_h[cdx];
+      complex h  = model.fft_h_[idx];
+      complex hc = model.fft_h_[cdx];
 
       // real part symmetric
       ASSERT_DOUBLE_EQ(h.real(), hc.real());
@@ -174,8 +174,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
         cdx += (this->ny - iky);
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h[idx];
-      complex hc = model.fft_h[cdx];
+      complex h  = model.fft_h_[idx];
+      complex hc = model.fft_h_[cdx];
 
       // real part symmetric
       ASSERT_DOUBLE_EQ(h.real(), hc.real());
@@ -205,7 +205,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h[i]);
+    sum_h2 += norm(model.fft_h_[i]);
   }
 
   ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -230,7 +230,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h[i]);
+    sum_h2 += norm(model.fft_h_[i]);
   }
 
   ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -283,8 +283,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
         cdx += (this->ny - iky);
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h[idx];
-      complex hc = model.fft_h[cdx];
+      complex h  = model.fft_h_[idx];
+      complex hc = model.fft_h_[cdx];
 
       // real part symmetric
       ASSERT_DOUBLE_EQ(h.real(), hc.real());
@@ -315,8 +315,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
         cdx += (this->ny - iky);
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h[idx];
-      complex hc = model.fft_h[cdx];
+      complex h  = model.fft_h_[idx];
+      complex hc = model.fft_h_[cdx];
 
       // real part symmetric
       ASSERT_DOUBLE_EQ(h.real(), hc.real());
@@ -346,7 +346,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h[i]);
+    sum_h2 += norm(model.fft_h_[i]);
   }
 
   ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -371,7 +371,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h[i]);
+    sum_h2 += norm(model.fft_h_[i]);
   }
 
   ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);

--- a/gz-waves/src/WaveSimulationFFT2_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT2_TEST.cc
@@ -58,9 +58,9 @@ public:
   }
 
   // put in any custom data members that you need 
-  double lx = 100.0;
+  double lx = 200.0;
   double ly = 100.0;
-  int    nx = 8;
+  int    nx = 16;
   int    ny = 8;
 };
 
@@ -73,21 +73,33 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
 
   // check array dimensions
   EXPECT_EQ(model.kx_fft.size(), this->nx);
-  EXPECT_EQ(model.ky_fft.size(), this->nx);
+  EXPECT_EQ(model.ky_fft.size(), this->ny);
   EXPECT_EQ(model.kx_math.size(), this->nx);
-  EXPECT_EQ(model.ky_math.size(), this->nx);
+  EXPECT_EQ(model.ky_math.size(), this->ny);
 
-  std::vector<double> ikx_math =
-      {-4.0, -3.0, -2.0, -1.0,  0.0,  1.0,  2.0,  3.0};
-  std::vector<double> iky_math = ikx_math;
-  std::vector<double> ikx_fft =
-      { 0.0,  1.0,  2.0,  3.0, -4.0, -3.0, -2.0, -1.0};
-  std::vector<double> iky_fft = ikx_fft;
+  std::vector<double> ikx_math = {
+    -8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0,
+     0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0
+  };
+  std::vector<double> iky_math = {
+    -4.0, -3.0, -2.0, -1.0,  0.0,  1.0,  2.0,  3.0
+  };
+  std::vector<double> ikx_fft = {
+     0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,
+    -8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0
+  };
+  std::vector<double> iky_fft = {
+    0.0,  1.0,  2.0,  3.0, -4.0, -3.0, -2.0, -1.0
+  };
 
   // check kx math-ordering
   for (int i=0; i<this->nx; ++i)
   {
     ASSERT_DOUBLE_EQ(model.kx_math[i] / model.kx_f, ikx_math[i]);
+  }
+  // check ky math-ordering
+  for (int i=0; i<this->ny; ++i)
+  {
     ASSERT_DOUBLE_EQ(model.ky_math[i] / model.ky_f, iky_math[i]);
   }
 
@@ -95,37 +107,39 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
   for (int i=0; i<this->nx; ++i)
   {
     ASSERT_DOUBLE_EQ(model.kx_fft[i] / model.kx_f, ikx_fft[i]);
+  }
+  // check ky fft-ordering
+  for (int i=0; i<this->ny; ++i)
+  {
     ASSERT_DOUBLE_EQ(model.ky_fft[i] / model.ky_f, iky_fft[i]);
   }
 }
 
 //////////////////////////////////////////////////
 // Reference version checks
-
 TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
 {
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(0.0);
 
-  for (int ikx=0; ikx<this->nx; ++ikx)
+  for (int ikx=0, idx=0; ikx<this->nx; ++ikx)
   {
-    for (int iky=0; iky<this->nx; ++iky)
+    for (int iky=0; iky<this->ny; ++iky, ++idx)
     {
-      // index for flattened array
-      int idx = ikx * this->nx + iky;
-
       // index for conjugate
       int cdx = 0;
-      if (ikx == 0)
-        cdx += ikx * this->nx;
-      else
-        cdx += (this->nx - ikx) * this->nx;
+      if (ikx != 0)
+        cdx += (this->nx - ikx) * this->ny;
 
-      if (iky == 0)
-        cdx += iky;
-      else
-        cdx += (this->nx - iky);
+      if (iky != 0)
+        cdx += (this->ny - iky);
+
+      // std::cerr << "iky: " << iky
+      //   << ", ikx: " << ikx
+      //   << ", idx: " << idx
+      //   << ", cdx: " << cdx
+      //   << "\n";
 
       // look up amplitude and conjugate
       complex h  = model.fft_h[idx];
@@ -147,24 +161,17 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(11.2);
 
-  for (int ikx=0; ikx<this->nx; ++ikx)
+  for (int ikx=0, idx=0; ikx<this->nx; ++ikx)
   {
-    for (int iky=0; iky<this->nx; ++iky)
+    for (int iky=0; iky<this->ny; ++iky, ++idx)
     {
-      // index for flattened array
-      int idx = ikx * this->nx + iky;
-
       // index for conjugate
       int cdx = 0;
-      if (ikx == 0)
-        cdx += ikx * this->nx;
-      else
-        cdx += (this->nx - ikx) * this->nx;
+      if (ikx != 0)
+        cdx += (this->nx - ikx) * this->ny;
 
-      if (iky == 0)
-        cdx += iky;
-      else
-        cdx += (this->nx - iky);
+      if (iky != 0)
+        cdx += (this->ny - iky);
 
       // look up amplitude and conjugate
       complex h  = model.fft_h[idx];
@@ -182,57 +189,57 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(0.0);
 
-  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeElevation(z);
 
-  EXPECT_EQ(z.size(), N2);
+  EXPECT_EQ(z.size(), n2);
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
     sum_h2 += norm(model.fft_h[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * N2);
+  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(25.3);
 
-  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeElevation(z);
 
-  EXPECT_EQ(z.size(), N2);
+  EXPECT_EQ(z.size(), n2);
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
     sum_h2 += norm(model.fft_h[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * N2);
+  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
 
@@ -241,14 +248,14 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(10.0);
 
-  Eigen::MatrixXd sx = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd sy = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd sx = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd sy = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeDisplacements(sx, sy);
 
-  EXPECT_EQ(sx.size(), N2);
-  EXPECT_EQ(sy.size(), N2);
+  EXPECT_EQ(sx.size(), n2);
+  EXPECT_EQ(sy.size(), n2);
 
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     ASSERT_DOUBLE_EQ(sx(i, 0), 0.0);
     ASSERT_DOUBLE_EQ(sy(i, 0), 0.0);
@@ -257,31 +264,23 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference
 
 //////////////////////////////////////////////////
 // Optimised version checks
-
 TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
 {
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (int ikx=0; ikx<this->nx; ++ikx)
+  for (int ikx=0, idx=0; ikx<this->nx; ++ikx)
   {
-    for (int iky=0; iky<this->nx; ++iky)
+    for (int iky=0; iky<this->ny; ++iky, ++idx)
     {
-      // index for flattened array
-      int idx = ikx * this->nx + iky;
-
       // index for conjugate
       int cdx = 0;
-      if (ikx == 0)
-        cdx += ikx * this->nx;
-      else
-        cdx += (this->nx - ikx) * this->nx;
+      if (ikx != 0)
+        cdx += (this->nx - ikx) * this->ny;
 
-      if (iky == 0)
-        cdx += iky;
-      else
-        cdx += (this->nx - iky);
+      if (iky != 0)
+        cdx += (this->ny - iky);
 
       // look up amplitude and conjugate
       complex h  = model.fft_h[idx];
@@ -303,24 +302,17 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(11.2);
 
-  for (int ikx=0; ikx<this->nx; ++ikx)
+  for (int ikx=0, idx=0; ikx<this->nx; ++ikx)
   {
-    for (int iky=0; iky<this->nx; ++iky)
+    for (int iky=0; iky<this->ny; ++iky, ++idx)
     {
-      // index for flattened array
-      int idx = ikx * this->nx + iky;
-
       // index for conjugate
       int cdx = 0;
-      if (ikx == 0)
-        cdx += ikx * this->nx;
-      else
-        cdx += (this->nx - ikx) * this->nx;
+      if (ikx != 0)
+        cdx += (this->nx - ikx) * this->ny;
 
-      if (iky == 0)
-        cdx += iky;
-      else
-        cdx += (this->nx - iky);
+      if (iky != 0)
+        cdx += (this->ny - iky);
 
       // look up amplitude and conjugate
       complex h  = model.fft_h[idx];
@@ -338,57 +330,57 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeElevation(z);
 
-  EXPECT_EQ(z.size(), N2);
+  EXPECT_EQ(z.size(), n2);
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
     sum_h2 += norm(model.fft_h[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * N2);
+  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(25.3);
 
-  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeElevation(z);
 
-  EXPECT_EQ(z.size(), N2);
+  EXPECT_EQ(z.size(), n2);
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
     sum_h2 += norm(model.fft_h[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * N2);
+  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->nx;
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
 
@@ -397,14 +389,14 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(10.0);
 
-  Eigen::MatrixXd sx = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd sy = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd sx = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd sy = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeDisplacements(sx, sy);
 
-  EXPECT_EQ(sx.size(), N2);
-  EXPECT_EQ(sy.size(), N2);
+  EXPECT_EQ(sx.size(), n2);
+  EXPECT_EQ(sy.size(), n2);
 
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     ASSERT_DOUBLE_EQ(sx(i, 0), 0.0);
     ASSERT_DOUBLE_EQ(sy(i, 0), 0.0);
@@ -416,26 +408,26 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
 
 TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeZero)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(0.0);
 
-  Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeElevation(z);
 
-  EXPECT_EQ(ref_z.size(), N2);
-  EXPECT_EQ(z.size(), N2);
+  EXPECT_EQ(ref_z.size(), n2);
+  EXPECT_EQ(z.size(), n2);
 
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     ASSERT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
   }
@@ -444,26 +436,26 @@ TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeZero)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeNonZero)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(31.7);
 
-  Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(31.7);
 
-  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd z = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeElevation(z);
 
-  EXPECT_EQ(ref_z.size(), N2);
-  EXPECT_EQ(z.size(), N2);
+  EXPECT_EQ(ref_z.size(), n2);
+  EXPECT_EQ(z.size(), n2);
 
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     ASSERT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
   }
@@ -472,30 +464,30 @@ TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeNonZero)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
 
-  Eigen::MatrixXd ref_sx = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd ref_sy = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd ref_sx = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd ref_sy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeDisplacements(ref_sx, ref_sy);
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
 
-  Eigen::MatrixXd sx = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd sy = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd sx = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd sy = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeDisplacements(sx, sy);
 
-  EXPECT_EQ(ref_sx.size(), N2);
-  EXPECT_EQ(ref_sy.size(), N2);
-  EXPECT_EQ(sx.size(), N2);
-  EXPECT_EQ(sy.size(), N2);
+  EXPECT_EQ(ref_sx.size(), n2);
+  EXPECT_EQ(ref_sy.size(), n2);
+  EXPECT_EQ(sx.size(), n2);
+  EXPECT_EQ(sy.size(), n2);
 
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     ASSERT_DOUBLE_EQ(sx(i, 0), ref_sx(i, 0));
     ASSERT_DOUBLE_EQ(sy(i, 0), ref_sy(i, 0));
@@ -505,30 +497,30 @@ TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HeightDerivatives)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
 
-  Eigen::MatrixXd ref_dhdx = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd ref_dhdy = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd ref_dhdx = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd ref_dhdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevationDerivatives(ref_dhdx, ref_dhdy);
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
 
-  Eigen::MatrixXd dhdx = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd dhdy = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd dhdx = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd dhdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevationDerivatives(dhdx, dhdy);
 
-  EXPECT_EQ(ref_dhdx.size(), N2);
-  EXPECT_EQ(ref_dhdy.size(), N2);
-  EXPECT_EQ(dhdx.size(), N2);
-  EXPECT_EQ(dhdy.size(), N2);
+  EXPECT_EQ(ref_dhdx.size(), n2);
+  EXPECT_EQ(ref_dhdy.size(), n2);
+  EXPECT_EQ(dhdx.size(), n2);
+  EXPECT_EQ(dhdy.size(), n2);
 
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     ASSERT_DOUBLE_EQ(dhdx(i, 0), ref_dhdx(i, 0));
     ASSERT_DOUBLE_EQ(dhdy(i, 0), ref_dhdy(i, 0));
@@ -538,34 +530,34 @@ TEST_F(TestFixtureWaveSimulationFFT2, HeightDerivatives)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, DisplacementDerivatives)
 {
-  int N2 = this->nx * this->nx;
+  int n2 = this->nx * this->ny;
 
   WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
 
-  Eigen::MatrixXd ref_dsxdx = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd ref_dsydy = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd ref_dsxdy = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd ref_dsxdx = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd ref_dsydy = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd ref_dsxdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeDisplacementsDerivatives(ref_dsxdx, ref_dsydy, ref_dsxdy);
 
   WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
 
-  Eigen::MatrixXd dsxdx = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd dsydy = Eigen::MatrixXd::Zero(N2, 1);
-  Eigen::MatrixXd dsxdy = Eigen::MatrixXd::Zero(N2, 1);
+  Eigen::MatrixXd dsxdx = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd dsydy = Eigen::MatrixXd::Zero(n2, 1);
+  Eigen::MatrixXd dsxdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeDisplacementsDerivatives(dsxdx, dsydy, dsxdy);
 
-  EXPECT_EQ(ref_dsxdx.size(), N2);
-  EXPECT_EQ(ref_dsydy.size(), N2);
-  EXPECT_EQ(ref_dsxdy.size(), N2);
-  EXPECT_EQ(dsxdx.size(), N2);
-  EXPECT_EQ(dsydy.size(), N2);
-  EXPECT_EQ(dsxdy.size(), N2);
+  EXPECT_EQ(ref_dsxdx.size(), n2);
+  EXPECT_EQ(ref_dsydy.size(), n2);
+  EXPECT_EQ(ref_dsxdy.size(), n2);
+  EXPECT_EQ(dsxdx.size(), n2);
+  EXPECT_EQ(dsydy.size(), n2);
+  EXPECT_EQ(dsxdy.size(), n2);
 
-  for (int i=0; i<N2; ++i)
+  for (int i=0; i<n2; ++i)
   {
     ASSERT_DOUBLE_EQ(dsxdx(i, 0), ref_dsxdx(i, 0));
     ASSERT_DOUBLE_EQ(dsydy(i, 0), ref_dsydy(i, 0));
@@ -577,19 +569,27 @@ TEST_F(TestFixtureWaveSimulationFFT2, DisplacementDerivatives)
 // check we're the indexing / stride rules used in the FFT routines
 TEST_F(TestFixtureWaveSimulationFFT2, Indexing)
 {
-  int Nx = 3;
-  int Ny = 4;
+  int nxx = 4;
+  int nyy = 3;
 
-  std::vector<std::vector<double>> a1(Nx, std::vector<double>(Ny, 0.0));
+  // column major storage
+  std::vector<std::vector<double>> a1(nyy, std::vector<double>(nxx, 0.0));
   
-  for (int ikx = 0, idx = 0; ikx < Nx; ++ikx)
+  for (int iky = 0, idx = 0; iky < nyy; ++iky)
   {
-    for (int iky = 0; iky < Ny; ++iky, ++idx)
+    for (int ikx = 0; ikx < nxx; ++ikx, ++idx)
     {
-      a1[ikx][iky] = idx;
+      a1[iky][ikx] = idx;
     }
   }
 
+  // column major storage - fastest index over rows
+  // 
+  //  M = 0   4   8 
+  //      1   5   9
+  //      2   6  10
+  //      3   7  11
+  // 
   std::vector<std::vector<double>> a2 = {
     { 0, 1, 2, 3},
     { 4, 5, 6, 7},
@@ -600,21 +600,21 @@ TEST_F(TestFixtureWaveSimulationFFT2, Indexing)
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
   };
 
-  EXPECT_EQ(a1.size(), Nx);
-  EXPECT_EQ(a1[0].size(), Ny);
+  EXPECT_EQ(a1.size(), nyy);
+  EXPECT_EQ(a1[0].size(), nxx);
 
-  EXPECT_EQ(a2.size(), Nx);
-  EXPECT_EQ(a2[0].size(), Ny);
+  EXPECT_EQ(a2.size(), nyy);
+  EXPECT_EQ(a2[0].size(), nxx);
 
-  EXPECT_EQ(a3.size(), Nx * Ny);
+  EXPECT_EQ(a3.size(), nyy * nxx);
 
-  for (int ikx = 0; ikx < Nx; ++ikx)
+  for (int iky = 0; iky < nyy; ++iky)
   {
-    for (int iky = 0; iky < Ny; ++iky)
+    for (int ikx = 0; ikx < nxx; ++ikx)
     {
-      int idx = ikx * Ny + iky;
-      EXPECT_EQ(a1[ikx][iky], a2[ikx][iky]);
-      EXPECT_EQ(a3[idx], a2[ikx][iky]);
+      int idx = iky * nxx + ikx;
+      EXPECT_EQ(a1[iky][ikx], a2[iky][ikx]);
+      EXPECT_EQ(a3[idx], a2[iky][ikx]);
     }
   }
 

--- a/gz-waves/src/WaveSimulationFFT2_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT2_TEST.cc
@@ -406,7 +406,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
 //////////////////////////////////////////////////
 // Cross-check optimised version against reference 
 
-TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT2, ElevationTimeZero)
 {
   int n2 = nx_ * ny_;
 
@@ -434,7 +434,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT2, ElevationTimeNonZero)
 {
   int n2 = nx_ * ny_;
 
@@ -495,7 +495,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, HeightDerivatives)
+TEST_F(TestFixtureWaveSimulationFFT2, ElevationDerivatives)
 {
   int n2 = nx_ * ny_;
 

--- a/gz-waves/src/WaveSimulationFFT2_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT2_TEST.cc
@@ -238,7 +238,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
     }
   }
 
-  EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
+  EXPECT_NEAR(sum_z2, sum_h2 * n2, 1.0E-14);
 }
 
 //////////////////////////////////////////////////
@@ -396,7 +396,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
     }
   }
 
-  EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
+  EXPECT_NEAR(sum_z2, sum_h2 * n2, 1.0E-14);
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/WaveSimulationFFT2_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT2_TEST.cc
@@ -140,8 +140,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
       //   << "\n";
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_[idx];
-      complex hc = model.fft_h_[cdx];
+      complex h  = model.fft_h_(idx, 0);
+      complex hc = model.fft_h_(cdx, 0);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
@@ -172,8 +172,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
         cdx += (ny_ - iky);
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_[idx];
-      complex hc = model.fft_h_[cdx];
+      complex h  = model.fft_h_(idx, 0);
+      complex hc = model.fft_h_(cdx, 0);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
@@ -203,7 +203,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_[i]);
+    sum_h2 += norm(model.fft_h_(i, 0));
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -228,7 +228,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_[i]);
+    sum_h2 += norm(model.fft_h_(i, 0));
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -281,8 +281,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
         cdx += (ny_ - iky);
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_[idx];
-      complex hc = model.fft_h_[cdx];
+      complex h  = model.fft_h_(idx, 0);
+      complex hc = model.fft_h_(cdx, 0);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
@@ -313,8 +313,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
         cdx += (ny_ - iky);
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_[idx];
-      complex hc = model.fft_h_[cdx];
+      complex h  = model.fft_h_(idx, 0);
+      complex hc = model.fft_h_(cdx, 0);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
@@ -344,7 +344,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_[i]);
+    sum_h2 += norm(model.fft_h_(i, 0));
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -369,7 +369,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_[i]);
+    sum_h2 += norm(model.fft_h_(i, 0));
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -644,11 +644,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeZero)
         cdx += (ny_ - iky);
 
       // look up amplitude and conjugate
-      complex h1  = model1.fft_h_[idx];
-      complex hc1 = model1.fft_h_[cdx];
+      complex h1  = model1.fft_h_(idx, 0);
+      complex hc1 = model1.fft_h_(cdx, 0);
 
-      complex h2  = model2.fft_h_[idx];
-      complex hc2 = model2.fft_h_[cdx];
+      complex h2  = model2.fft_h_(idx, 0);
+      complex hc2 = model2.fft_h_(cdx, 0);
 
       // consistency: real part symmetric
       EXPECT_DOUBLE_EQ(h2.real(), hc2.real());
@@ -691,11 +691,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeNonZero)
         cdx += (ny_ - iky);
 
       // look up amplitude and conjugate
-      complex h1  = model1.fft_h_[idx];
-      complex hc1 = model1.fft_h_[cdx];
+      complex h1  = model1.fft_h_(idx, 0);
+      complex hc1 = model1.fft_h_(cdx, 0);
 
-      complex h2  = model2.fft_h_[idx];
-      complex hc2 = model2.fft_h_[cdx];
+      complex h2  = model2.fft_h_(idx, 0);
+      complex hc2 = model2.fft_h_(cdx, 0);
 
       // consistency: real part symmetric
       EXPECT_DOUBLE_EQ(h2.real(), hc2.real());
@@ -734,7 +734,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeZero)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_[i]);
+    sum_h2 += norm(model.fft_h_(i, 0));
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -760,7 +760,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeNonZero)
   for (int i=0; i<n2; ++i)
   {
     sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_[i]);
+    sum_h2 += norm(model.fft_h_(i, 0));
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);

--- a/gz-waves/src/WaveSimulationFFT2_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT2_TEST.cc
@@ -58,10 +58,10 @@ public:
   }
 
   // put in any custom data members that you need 
-  double lx = 200.0;
-  double ly = 100.0;
-  int    nx = 16;
-  int    ny = 8;
+  double lx_ = 200.0;
+  double ly_ = 100.0;
+  int    nx_ = 16;
+  int    ny_ = 8;
 };
 
 //////////////////////////////////////////////////
@@ -69,13 +69,13 @@ public:
  
 TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
 {
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
 
   // check array dimensions
-  EXPECT_EQ(model.kx_fft_.size(), this->nx);
-  EXPECT_EQ(model.ky_fft_.size(), this->ny);
-  EXPECT_EQ(model.kx_math_.size(), this->nx);
-  EXPECT_EQ(model.ky_math_.size(), this->ny);
+  EXPECT_EQ(model.kx_fft_.size(), nx_);
+  EXPECT_EQ(model.ky_fft_.size(), ny_);
+  EXPECT_EQ(model.kx_math_.size(), nx_);
+  EXPECT_EQ(model.ky_math_.size(), ny_);
 
   std::vector<double> ikx_math = {
     -8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0,
@@ -93,23 +93,23 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
   };
 
   // check kx math-ordering
-  for (int i=0; i<this->nx; ++i)
+  for (int i=0; i<nx_; ++i)
   {
     ASSERT_DOUBLE_EQ(model.kx_math_[i] / model.kx_f_, ikx_math[i]);
   }
   // check ky math-ordering
-  for (int i=0; i<this->ny; ++i)
+  for (int i=0; i<ny_; ++i)
   {
     ASSERT_DOUBLE_EQ(model.ky_math_[i] / model.ky_f_, iky_math[i]);
   }
 
   // check kx fft-ordering
-  for (int i=0; i<this->nx; ++i)
+  for (int i=0; i<nx_; ++i)
   {
     ASSERT_DOUBLE_EQ(model.kx_fft_[i] / model.kx_f_, ikx_fft[i]);
   }
   // check ky fft-ordering
-  for (int i=0; i<this->ny; ++i)
+  for (int i=0; i<ny_; ++i)
   {
     ASSERT_DOUBLE_EQ(model.ky_fft_[i] / model.ky_f_, iky_fft[i]);
   }
@@ -119,21 +119,21 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
 // Reference version checks
 TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
 {
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(0.0);
 
-  for (int ikx=0, idx=0; ikx<this->nx; ++ikx)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    for (int iky=0; iky<this->ny; ++iky, ++idx)
+    for (int iky=0; iky<ny_; ++iky, ++idx)
     {
       // index for conjugate
       int cdx = 0;
       if (ikx != 0)
-        cdx += (this->nx - ikx) * this->ny;
+        cdx += (nx_ - ikx) * ny_;
 
       if (iky != 0)
-        cdx += (this->ny - iky);
+        cdx += (ny_ - iky);
 
       // std::cerr << "iky: " << iky
       //   << ", ikx: " << ikx
@@ -157,21 +157,21 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
 {
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(11.2);
 
-  for (int ikx=0, idx=0; ikx<this->nx; ++ikx)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    for (int iky=0; iky<this->ny; ++iky, ++idx)
+    for (int iky=0; iky<ny_; ++iky, ++idx)
     {
       // index for conjugate
       int cdx = 0;
       if (ikx != 0)
-        cdx += (this->nx - ikx) * this->ny;
+        cdx += (nx_ - ikx) * ny_;
 
       if (iky != 0)
-        cdx += (this->ny - iky);
+        cdx += (ny_ - iky);
 
       // look up amplitude and conjugate
       complex h  = model.fft_h_[idx];
@@ -189,9 +189,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(0.0);
 
@@ -214,9 +214,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(25.3);
 
@@ -239,9 +239,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
 
   // displacements should be zero when lamda = 0
   model.SetLambda(0.0);
@@ -266,21 +266,21 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference
 // Optimised version checks
 TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
 {
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (int ikx=0, idx=0; ikx<this->nx; ++ikx)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    for (int iky=0; iky<this->ny; ++iky, ++idx)
+    for (int iky=0; iky<ny_; ++iky, ++idx)
     {
       // index for conjugate
       int cdx = 0;
       if (ikx != 0)
-        cdx += (this->nx - ikx) * this->ny;
+        cdx += (nx_ - ikx) * ny_;
 
       if (iky != 0)
-        cdx += (this->ny - iky);
+        cdx += (ny_ - iky);
 
       // look up amplitude and conjugate
       complex h  = model.fft_h_[idx];
@@ -298,21 +298,21 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
 {
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(11.2);
 
-  for (int ikx=0, idx=0; ikx<this->nx; ++ikx)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    for (int iky=0; iky<this->ny; ++iky, ++idx)
+    for (int iky=0; iky<ny_; ++iky, ++idx)
     {
       // index for conjugate
       int cdx = 0;
       if (ikx != 0)
-        cdx += (this->nx - ikx) * this->ny;
+        cdx += (nx_ - ikx) * ny_;
 
       if (iky != 0)
-        cdx += (this->ny - iky);
+        cdx += (ny_ - iky);
 
       // look up amplitude and conjugate
       complex h  = model.fft_h_[idx];
@@ -330,9 +330,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
@@ -355,9 +355,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(25.3);
 
@@ -380,9 +380,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
 {
-  int n2 = this->nx * this->nx;
+  int n2 = nx_ * nx_;
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
 
   // displacements should be zero when lamda = 0
   model.SetLambda(0.0);
@@ -408,16 +408,16 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
 
 TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeZero)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(0.0);
 
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
@@ -436,16 +436,16 @@ TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeZero)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeNonZero)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(31.7);
 
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(31.7);
 
@@ -464,9 +464,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, HeightTimeNonZero)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
 
@@ -474,7 +474,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
   Eigen::MatrixXd ref_sy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeDisplacements(ref_sx, ref_sy);
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
 
@@ -497,9 +497,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, HeightDerivatives)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
 
@@ -507,7 +507,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, HeightDerivatives)
   Eigen::MatrixXd ref_dhdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevationDerivatives(ref_dhdx, ref_dhdy);
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
 
@@ -530,9 +530,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, HeightDerivatives)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, DisplacementDerivatives)
 {
-  int n2 = this->nx * this->ny;
+  int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
 
@@ -541,7 +541,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, DisplacementDerivatives)
   Eigen::MatrixXd ref_dsxdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeDisplacementsDerivatives(ref_dsxdx, ref_dsydy, ref_dsxdy);
 
-  WaveSimulationFFT2Impl model(this->lx, this->ly, this->nx, this->ny);
+  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
 

--- a/gz-waves/src/WaveSimulationFFT2_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT2_TEST.cc
@@ -93,23 +93,23 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
   // check kx math-ordering
   for (int i=0; i<nx_; ++i)
   {
-    ASSERT_DOUBLE_EQ(model.kx_math_[i] / model.kx_f_, ikx_math[i]);
+    EXPECT_DOUBLE_EQ(model.kx_math_[i] / model.kx_f_, ikx_math[i]);
   }
   // check ky math-ordering
   for (int i=0; i<ny_; ++i)
   {
-    ASSERT_DOUBLE_EQ(model.ky_math_[i] / model.ky_f_, iky_math[i]);
+    EXPECT_DOUBLE_EQ(model.ky_math_[i] / model.ky_f_, iky_math[i]);
   }
 
   // check kx fft-ordering
   for (int i=0; i<nx_; ++i)
   {
-    ASSERT_DOUBLE_EQ(model.kx_fft_[i] / model.kx_f_, ikx_fft[i]);
+    EXPECT_DOUBLE_EQ(model.kx_fft_[i] / model.kx_f_, ikx_fft[i]);
   }
   // check ky fft-ordering
   for (int i=0; i<ny_; ++i)
   {
-    ASSERT_DOUBLE_EQ(model.ky_fft_[i] / model.ky_f_, iky_fft[i]);
+    EXPECT_DOUBLE_EQ(model.ky_fft_[i] / model.ky_f_, iky_fft[i]);
   }
 }
 
@@ -144,10 +144,10 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
       complex hc = model.fft_h_[cdx];
 
       // real part symmetric
-      ASSERT_DOUBLE_EQ(h.real(), hc.real());
+      EXPECT_DOUBLE_EQ(h.real(), hc.real());
       
       // imaginary part anti-symmetric
-      ASSERT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
+      EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
   }
 }
@@ -176,10 +176,10 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
       complex hc = model.fft_h_[cdx];
 
       // real part symmetric
-      ASSERT_DOUBLE_EQ(h.real(), hc.real());
+      EXPECT_DOUBLE_EQ(h.real(), hc.real());
       
       // imaginary part anti-symmetric
-      ASSERT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
+      EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
   }
 }
@@ -206,7 +206,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
     sum_h2 += norm(model.fft_h_[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
+  EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
@@ -231,7 +231,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
     sum_h2 += norm(model.fft_h_[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
+  EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
@@ -255,8 +255,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(sx(i, 0), 0.0);
-    ASSERT_DOUBLE_EQ(sy(i, 0), 0.0);
+    EXPECT_DOUBLE_EQ(sx(i, 0), 0.0);
+    EXPECT_DOUBLE_EQ(sy(i, 0), 0.0);
   }
 }
 
@@ -285,10 +285,10 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
       complex hc = model.fft_h_[cdx];
 
       // real part symmetric
-      ASSERT_DOUBLE_EQ(h.real(), hc.real());
+      EXPECT_DOUBLE_EQ(h.real(), hc.real());
       
       // imaginary part anti-symmetric
-      ASSERT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
+      EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
   }
 }
@@ -317,10 +317,10 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
       complex hc = model.fft_h_[cdx];
 
       // real part symmetric
-      ASSERT_DOUBLE_EQ(h.real(), hc.real());
+      EXPECT_DOUBLE_EQ(h.real(), hc.real());
       
       // imaginary part anti-symmetric
-      ASSERT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
+      EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
   }
 }
@@ -347,7 +347,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
     sum_h2 += norm(model.fft_h_[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
+  EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
@@ -372,7 +372,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
     sum_h2 += norm(model.fft_h_[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
+  EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
@@ -396,8 +396,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(sx(i, 0), 0.0);
-    ASSERT_DOUBLE_EQ(sy(i, 0), 0.0);
+    EXPECT_DOUBLE_EQ(sx(i, 0), 0.0);
+    EXPECT_DOUBLE_EQ(sy(i, 0), 0.0);
   }
 }
 
@@ -426,7 +426,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ElevationTimeZero)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
+    EXPECT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
   }
 }
 
@@ -454,7 +454,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ElevationTimeNonZero)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
+    EXPECT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
   }
 }
 
@@ -486,8 +486,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(sx(i, 0), ref_sx(i, 0));
-    ASSERT_DOUBLE_EQ(sy(i, 0), ref_sy(i, 0));
+    EXPECT_DOUBLE_EQ(sx(i, 0), ref_sx(i, 0));
+    EXPECT_DOUBLE_EQ(sy(i, 0), ref_sy(i, 0));
   }
 }
 
@@ -519,8 +519,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, ElevationDerivatives)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(dhdx(i, 0), ref_dhdx(i, 0));
-    ASSERT_DOUBLE_EQ(dhdy(i, 0), ref_dhdy(i, 0));
+    EXPECT_DOUBLE_EQ(dhdx(i, 0), ref_dhdx(i, 0));
+    EXPECT_DOUBLE_EQ(dhdy(i, 0), ref_dhdy(i, 0));
   }
 }
 
@@ -556,9 +556,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, DisplacementDerivatives)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(dsxdx(i, 0), ref_dsxdx(i, 0));
-    ASSERT_DOUBLE_EQ(dsydy(i, 0), ref_dsydy(i, 0));
-    ASSERT_DOUBLE_EQ(dsxdy(i, 0), ref_dsxdy(i, 0));
+    EXPECT_DOUBLE_EQ(dsxdx(i, 0), ref_dsxdx(i, 0));
+    EXPECT_DOUBLE_EQ(dsydy(i, 0), ref_dsydy(i, 0));
+    EXPECT_DOUBLE_EQ(dsxdy(i, 0), ref_dsxdy(i, 0));
   }
 }
 
@@ -651,16 +651,16 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeZero)
       complex hc2 = model2.fft_h_[cdx];
 
       // consistency: real part symmetric
-      ASSERT_DOUBLE_EQ(h2.real(), hc2.real());
+      EXPECT_DOUBLE_EQ(h2.real(), hc2.real());
       
       // consistency: imaginary part anti-symmetric
-      ASSERT_DOUBLE_EQ(h2.imag(), -1.0 * hc2.imag());
+      EXPECT_DOUBLE_EQ(h2.imag(), -1.0 * hc2.imag());
 
       // cross-check: real part
-      ASSERT_DOUBLE_EQ(h2.real(), h1.real());
+      EXPECT_DOUBLE_EQ(h2.real(), h1.real());
       
       // cross-check: imaginary part
-      ASSERT_DOUBLE_EQ(h2.imag(), h1.imag());
+      EXPECT_DOUBLE_EQ(h2.imag(), h1.imag());
     }
   }
 }
@@ -698,16 +698,18 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeNonZero)
       complex hc2 = model2.fft_h_[cdx];
 
       // consistency: real part symmetric
-      ASSERT_DOUBLE_EQ(h2.real(), hc2.real());
+      EXPECT_DOUBLE_EQ(h2.real(), hc2.real());
       
       // consistency: imaginary part anti-symmetric
-      ASSERT_DOUBLE_EQ(h2.imag(), -1.0 * hc2.imag());
+      EXPECT_DOUBLE_EQ(h2.imag(), -1.0 * hc2.imag());
 
       // cross-check: real part
-      ASSERT_DOUBLE_EQ(h2.real(), h1.real());
+      // EXPECT_DOUBLE_EQ(h2.real(), h1.real());
+      EXPECT_NEAR(h2.real(), h1.real(), 1.0E-14);
       
       // cross-check: imaginary part
-      ASSERT_DOUBLE_EQ(h2.imag(), h1.imag());
+      // EXPECT_DOUBLE_EQ(h2.imag(), h1.imag());
+      EXPECT_NEAR(h2.imag(), h1.imag(), 1.0E-14);
     }
   }
 }
@@ -735,7 +737,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeZero)
     sum_h2 += norm(model.fft_h_[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
+  EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
@@ -761,7 +763,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeNonZero)
     sum_h2 += norm(model.fft_h_[i]);
   }
 
-  ASSERT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
+  EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
 //////////////////////////////////////////////////
@@ -786,8 +788,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHorizontalDisplacementsLambdaZer
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(sx(i, 0), 0.0);
-    ASSERT_DOUBLE_EQ(sy(i, 0), 0.0);
+    EXPECT_DOUBLE_EQ(sx(i, 0), 0.0);
+    EXPECT_DOUBLE_EQ(sy(i, 0), 0.0);
   }
 }
 
@@ -817,7 +819,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeZero)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
+    // EXPECT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
+    EXPECT_NEAR(z(i, 0), ref_z(i, 0), 1.0E-14);
   }
 }
 //////////////////////////////////////////////////
@@ -846,7 +849,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeNonZero)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
+    // EXPECT_DOUBLE_EQ(z(i, 0), ref_z(i, 0));
+    EXPECT_NEAR(z(i, 0), ref_z(i, 0), 1.0E-14);
   }
 }
 
@@ -880,8 +884,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedDisplacement)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(sx(i, 0), ref_sx(i, 0));
-    ASSERT_DOUBLE_EQ(sy(i, 0), ref_sy(i, 0));
+    // EXPECT_DOUBLE_EQ(sx(i, 0), ref_sx(i, 0));
+    EXPECT_NEAR(sx(i, 0), ref_sx(i, 0), 1.0E-14);
+
+    // EXPECT_DOUBLE_EQ(sy(i, 0), ref_sy(i, 0));
+    EXPECT_NEAR(sy(i, 0), ref_sy(i, 0), 1.0E-14);
   }
 }
 
@@ -915,8 +922,8 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationDerivatives)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(dhdx(i, 0), ref_dhdx(i, 0));
-    ASSERT_DOUBLE_EQ(dhdy(i, 0), ref_dhdy(i, 0));
+    EXPECT_DOUBLE_EQ(dhdx(i, 0), ref_dhdx(i, 0));
+    EXPECT_DOUBLE_EQ(dhdy(i, 0), ref_dhdy(i, 0));
   }
 }
 
@@ -954,9 +961,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedDisplacementDerivatives)
 
   for (int i=0; i<n2; ++i)
   {
-    ASSERT_DOUBLE_EQ(dsxdx(i, 0), ref_dsxdx(i, 0));
-    ASSERT_DOUBLE_EQ(dsydy(i, 0), ref_dsydy(i, 0));
-    ASSERT_DOUBLE_EQ(dsxdy(i, 0), ref_dsxdy(i, 0));
+    EXPECT_DOUBLE_EQ(dsxdx(i, 0), ref_dsxdx(i, 0));
+    EXPECT_DOUBLE_EQ(dsydy(i, 0), ref_dsydy(i, 0));
+    EXPECT_DOUBLE_EQ(dsxdy(i, 0), ref_dsxdy(i, 0));
   }
 }
 

--- a/gz-waves/src/WaveSimulationFFT2_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT2_TEST.cc
@@ -121,27 +121,22 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(0.0);
 
-  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
+  for (int ikx=0; ikx<nx_; ++ikx)
   {
-    for (int iky=0; iky<ny_; ++iky, ++idx)
+    for (int iky=0; iky<ny_; ++iky)
     {
       // index for conjugate
-      int cdx = 0;
+      int ckx = 0;
       if (ikx != 0)
-        cdx += (nx_ - ikx) * ny_;
+        ckx = nx_ - ikx;
 
+      int cky = 0;
       if (iky != 0)
-        cdx += (ny_ - iky);
-
-      // std::cerr << "iky: " << iky
-      //   << ", ikx: " << ikx
-      //   << ", idx: " << idx
-      //   << ", cdx: " << cdx
-      //   << "\n";
+        cky = ny_ - iky;
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_(idx, 0);
-      complex hc = model.fft_h_(cdx, 0);
+      complex h  = model.fft_h_(ikx, iky);
+      complex hc = model.fft_h_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
@@ -165,15 +160,22 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
     {
       // index for conjugate
       int cdx = 0;
+      int ckx = 0;
       if (ikx != 0)
-        cdx += (nx_ - ikx) * ny_;
-
+      {
+        ckx = nx_ - ikx;
+        cdx += ckx * ny_;
+      }
+      int cky = 0;
       if (iky != 0)
-        cdx += (ny_ - iky);
+      {
+        cky = ny_ - iky;
+        cdx += cky;
+      }
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_(idx, 0);
-      complex hc = model.fft_h_(cdx, 0);
+      complex h  = model.fft_h_(ikx, iky);
+      complex hc = model.fft_h_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
@@ -200,12 +202,14 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<n2; ++i)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_(i, 0));
+    for (int iky=0; iky<ny_; ++iky, ++idx)
+    {
+      sum_z2 += z(idx, 0) * z(idx, 0);
+      sum_h2 += norm(model.fft_h_(ikx, iky));
+    }
   }
-
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
 }
 
@@ -225,10 +229,13 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<n2; ++i)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_(i, 0));
+    for (int iky=0; iky<ny_; ++iky, ++idx)
+    {
+      sum_z2 += z(idx, 0) * z(idx, 0);
+      sum_h2 += norm(model.fft_h_(ikx, iky));
+    }
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -268,21 +275,25 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
+  for (int ikx=0; ikx<nx_; ++ikx)
   {
-    for (int iky=0; iky<ny_; ++iky, ++idx)
+    for (int iky=0; iky<ny_; ++iky)
     {
       // index for conjugate
-      int cdx = 0;
+      int ckx = 0;
       if (ikx != 0)
-        cdx += (nx_ - ikx) * ny_;
-
+      {
+        ckx = nx_ - ikx;
+      }
+      int cky = 0;
       if (iky != 0)
-        cdx += (ny_ - iky);
+      {
+        cky = ny_ - iky;
+      }
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_(idx, 0);
-      complex hc = model.fft_h_(cdx, 0);
+      complex h  = model.fft_h_(ikx, iky);
+      complex hc = model.fft_h_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
@@ -306,15 +317,22 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
     {
       // index for conjugate
       int cdx = 0;
+      int ckx = 0;
       if (ikx != 0)
-        cdx += (nx_ - ikx) * ny_;
-
+      {
+        ckx = nx_ - ikx;
+        cdx += ckx * ny_;
+      }
+      int cky = 0;
       if (iky != 0)
-        cdx += (ny_ - iky);
+      {
+        cky = ny_ - iky;
+        cdx += cky;
+      }
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_(idx, 0);
-      complex hc = model.fft_h_(cdx, 0);
+      complex h  = model.fft_h_(ikx, iky);
+      complex hc = model.fft_h_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
@@ -341,10 +359,13 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<n2; ++i)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_(i, 0));
+    for (int iky=0; iky<ny_; ++iky, ++idx)
+    {
+      sum_z2 += z(idx, 0) * z(idx, 0);
+      sum_h2 += norm(model.fft_h_(ikx, iky));
+    }
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -366,10 +387,13 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<n2; ++i)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_(i, 0));
+    for (int iky=0; iky<ny_; ++iky, ++idx)
+    {
+      sum_z2 += z(idx, 0) * z(idx, 0);
+      sum_h2 += norm(model.fft_h_(ikx, iky));
+    }
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -637,18 +661,25 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeZero)
     {
       // index for conjugate
       int cdx = 0;
+      int ckx = 0;
       if (ikx != 0)
-        cdx += (nx_ - ikx) * ny_;
-
+      {
+        ckx = nx_ - ikx;
+        cdx += ckx * ny_;
+      }
+      int cky = 0;
       if (iky != 0)
-        cdx += (ny_ - iky);
+      {
+        cky = ny_ - iky;
+        cdx += cky;
+      }
 
       // look up amplitude and conjugate
-      complex h1  = model1.fft_h_(idx, 0);
-      complex hc1 = model1.fft_h_(cdx, 0);
+      complex h1  = model1.fft_h_(ikx, iky);
+      complex hc1 = model1.fft_h_(ckx, cky);
 
-      complex h2  = model2.fft_h_(idx, 0);
-      complex hc2 = model2.fft_h_(cdx, 0);
+      complex h2  = model2.fft_h_(ikx, iky);
+      complex hc2 = model2.fft_h_(ckx, cky);
 
       // consistency: real part symmetric
       EXPECT_DOUBLE_EQ(h2.real(), hc2.real());
@@ -684,18 +715,25 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeNonZero)
     {
       // index for conjugate
       int cdx = 0;
+      int ckx = 0;
       if (ikx != 0)
-        cdx += (nx_ - ikx) * ny_;
-
+      {
+        ckx = nx_ - ikx;
+        cdx += ckx * ny_;
+      }
+      int cky = 0;
       if (iky != 0)
-        cdx += (ny_ - iky);
+      {
+        cky = ny_ - iky;
+        cdx += cky;
+      }
 
       // look up amplitude and conjugate
-      complex h1  = model1.fft_h_(idx, 0);
-      complex hc1 = model1.fft_h_(cdx, 0);
+      complex h1  = model1.fft_h_(ikx, iky);
+      complex hc1 = model1.fft_h_(ckx, cky);
 
-      complex h2  = model2.fft_h_(idx, 0);
-      complex hc2 = model2.fft_h_(cdx, 0);
+      complex h2  = model2.fft_h_(ikx, iky);
+      complex hc2 = model2.fft_h_(ckx, cky);
 
       // consistency: real part symmetric
       EXPECT_DOUBLE_EQ(h2.real(), hc2.real());
@@ -731,10 +769,13 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeZero)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<n2; ++i)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_(i, 0));
+    for (int iky=0; iky<ny_; ++iky, ++idx)
+    {
+      sum_z2 += z(idx, 0) * z(idx, 0);
+      sum_h2 += norm(model.fft_h_(ikx, iky));
+    }
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -757,10 +798,13 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeNonZero)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (int i=0; i<n2; ++i)
+  for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
-    sum_z2 += z(i, 0) * z(i, 0);
-    sum_h2 += norm(model.fft_h_(i, 0));
+    for (int iky=0; iky<ny_; ++iky, ++idx)
+    {
+      sum_z2 += z(idx, 0) * z(idx, 0);
+      sum_h2 += norm(model.fft_h_(ikx, iky));
+    }
   }
 
   EXPECT_DOUBLE_EQ(sum_z2, sum_h2 * n2);
@@ -823,6 +867,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeZero)
     EXPECT_NEAR(z(i, 0), ref_z(i, 0), 1.0E-14);
   }
 }
+
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeNonZero)
 {

--- a/gz-waves/src/WaveSimulationSinusoid.cc
+++ b/gz-waves/src/WaveSimulationSinusoid.cc
@@ -70,6 +70,8 @@ namespace waves
   class WaveSimulationSinusoid::Impl
   {
   public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     ~Impl();
 
     Impl(double lx, double ly, int nx, int ny);

--- a/gz-waves/src/WaveSimulationSinusoid.cc
+++ b/gz-waves/src/WaveSimulationSinusoid.cc
@@ -72,61 +72,61 @@ namespace waves
   public:
     ~Impl();
 
-    Impl(double _lx, double _ly, int _nx, int _ny);
+    Impl(double lx, double ly, int nx, int ny);
 
-    void SetUseVectorised(bool _value);
+    void SetUseVectorised(bool value);
 
-    void SetDirection(double _dir_x, double _dir_y);
+    void SetDirection(double dir_x, double dir_y);
 
-    void SetAmplitude(double _value);
+    void SetAmplitude(double value);
 
-    void SetPeriod(double _value);
+    void SetPeriod(double value);
 
-    void SetWindVelocity(double _ux, double _uy);
+    void SetWindVelocity(double ux, double uy);
 
-    void SetTime(double _value);
+    void SetTime(double value);
 
     void ComputeElevation(
-        Eigen::Ref<Eigen::MatrixXd> _h);
+        Eigen::Ref<Eigen::MatrixXd> h);
 
     void ComputeElevationDerivatives(
-        Eigen::Ref<Eigen::MatrixXd> _dhdx,
-        Eigen::Ref<Eigen::MatrixXd> _dhdy);
+        Eigen::Ref<Eigen::MatrixXd> dhdx,
+        Eigen::Ref<Eigen::MatrixXd> dhdy);
 
     void ComputeDisplacements(
-        Eigen::Ref<Eigen::MatrixXd> _sx,
-        Eigen::Ref<Eigen::MatrixXd> _sy);
+        Eigen::Ref<Eigen::MatrixXd> sx,
+        Eigen::Ref<Eigen::MatrixXd> sy);
 
     void ComputeDisplacementsDerivatives(
-        Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-        Eigen::Ref<Eigen::MatrixXd> _dsydy,
-        Eigen::Ref<Eigen::MatrixXd> _dsxdy);
+        Eigen::Ref<Eigen::MatrixXd> dsxdx,
+        Eigen::Ref<Eigen::MatrixXd> dsydy,
+        Eigen::Ref<Eigen::MatrixXd> dsxdy);
 
     void ComputeDisplacementsAndDerivatives(
-        Eigen::Ref<Eigen::MatrixXd> _h,
-        Eigen::Ref<Eigen::MatrixXd> _sx,
-        Eigen::Ref<Eigen::MatrixXd> _sy,
-        Eigen::Ref<Eigen::MatrixXd> _dhdx,
-        Eigen::Ref<Eigen::MatrixXd> _dhdy,
-        Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-        Eigen::Ref<Eigen::MatrixXd> _dsydy,
-        Eigen::Ref<Eigen::MatrixXd> _dsxdy);
+        Eigen::Ref<Eigen::MatrixXd> h,
+        Eigen::Ref<Eigen::MatrixXd> sx,
+        Eigen::Ref<Eigen::MatrixXd> sy,
+        Eigen::Ref<Eigen::MatrixXd> dhdx,
+        Eigen::Ref<Eigen::MatrixXd> dhdy,
+        Eigen::Ref<Eigen::MatrixXd> dsxdx,
+        Eigen::Ref<Eigen::MatrixXd> dsydy,
+        Eigen::Ref<Eigen::MatrixXd> dsxdy);
   
-    bool use_vectorised{true};
+    bool use_vectorised_{true};
 
-    int nx{2};
-    int ny{2};
-    double lx{1.0};
-    double ly{1.0};
-    double wave_angle{0.0};
-    double amplitude{1.0};
-    double period{1.0};
-    double time{0.0};
+    int nx_{2};
+    int ny_{2};
+    double lx_{1.0};
+    double ly_{1.0};
+    double wave_angle_{0.0};
+    double amplitude_{1.0};
+    double period_{1.0};
+    double time_{0.0};
     
-    Eigen::VectorXd x_v;
-    Eigen::VectorXd y_v;
-    Eigen::MatrixXd x_grid;
-    Eigen::MatrixXd y_grid;
+    Eigen::VectorXd x_;
+    Eigen::VectorXd y_;
+    Eigen::MatrixXd x_grid_;
+    Eigen::MatrixXd y_grid_;
   };
 
   //////////////////////////////////////////////////
@@ -136,55 +136,55 @@ namespace waves
 
   //////////////////////////////////////////////////
   WaveSimulationSinusoid::Impl::Impl(
-      double _lx, double _ly, int _nx, int _ny) :
-    nx(_nx),
-    ny(_ny),
-    lx(_lx),
-    ly(_ly)
+      double lx, double ly, int nx, int ny) :
+    nx_(nx),
+    ny_(ny),
+    lx_(lx),
+    ly_(ly)
   {
     // grid spacing
-    double dx = this->lx / this->nx;
-    double dy = this->ly / this->ny;
+    double dx = lx_ / nx_;
+    double dy = ly_ / ny_;
 
     // x and y coordinates
-    double lx_min = - this->lx / 2.0;
-    double lx_max =   this->lx / 2.0;
-    double ly_min = - this->ly / 2.0;
-    double ly_max =   this->ly / 2.0;
+    double lx_min = - lx_ / 2.0;
+    double lx_max =   lx_ / 2.0;
+    double ly_min = - ly_ / 2.0;
+    double ly_max =   ly_ / 2.0;
 
     // linspaced is on closed interval (unlike Python which is open to right)
-    this->x_v = Eigen::VectorXd::LinSpaced(nx, lx_min, lx_max - dx);
-    this->y_v = Eigen::VectorXd::LinSpaced(ny, ly_min, ly_max - dy);
+    x_ = Eigen::VectorXd::LinSpaced(nx_, lx_min, lx_max - dx);
+    y_ = Eigen::VectorXd::LinSpaced(ny_, ly_min, ly_max - dy);
 
     // broadcast to matrices (aka meshgrid)
-    this->x_grid = Eigen::MatrixXd::Zero(this->nx, this->ny);
-    this->y_grid = Eigen::MatrixXd::Zero(this->nx, this->ny);
-    this->x_grid.colwise() += this->x_v;
-    this->y_grid.rowwise() += this->y_v.transpose();
+    x_grid_ = Eigen::MatrixXd::Zero(nx_, ny_);
+    y_grid_ = Eigen::MatrixXd::Zero(nx_, ny_);
+    x_grid_.colwise() += x_;
+    y_grid_.rowwise() += y_.transpose();
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::Impl::SetUseVectorised(bool _value)
+  void WaveSimulationSinusoid::Impl::SetUseVectorised(bool value)
   {
-    this->use_vectorised = _value;
+    use_vectorised_ = value;
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::Impl::SetDirection(double _dir_x, double _dir_y)
+  void WaveSimulationSinusoid::Impl::SetDirection(double dir_x, double dir_y)
   {
-    this->wave_angle = std::atan2(_dir_y, _dir_x);
+    wave_angle_ = std::atan2(dir_y, dir_x);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::Impl::SetAmplitude(double _value)
+  void WaveSimulationSinusoid::Impl::SetAmplitude(double value)
   {
-    this->amplitude = _value;
+    amplitude_ = value;
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::Impl::SetPeriod(double _value)
+  void WaveSimulationSinusoid::Impl::SetPeriod(double value)
   {
-    this->period = _value;
+    period_ = value;
   }
 
   //////////////////////////////////////////////////
@@ -194,46 +194,46 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::Impl::SetTime(double _value)
+  void WaveSimulationSinusoid::Impl::SetTime(double value)
   {
-    this->time = _value;
+    time_ = value;
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::Impl::ComputeElevation(
-    Eigen::Ref<Eigen::MatrixXd> _heights)
+    Eigen::Ref<Eigen::MatrixXd> h)
   {
     // derived wave properties
-    double w = 2.0 * M_PI / this->period;
-    double wt = w * this->time;
+    double w = 2.0 * M_PI / period_;
+    double wt = w * time_;
     double k = Physics::DeepWaterDispersionToWavenumber(w);
-    double cd = std::cos(this->wave_angle);
-    double sd = std::sin(this->wave_angle);
+    double cd = std::cos(wave_angle_);
+    double sd = std::sin(wave_angle_);
 
-    if (this->use_vectorised)
+    if (use_vectorised_)
     {
-      Eigen::MatrixXd a = k * (this->x_grid.array() * cd
-          + this->y_grid.array() * sd) - wt;
+      Eigen::MatrixXd a = k * (x_grid_.array() * cd
+          + y_grid_.array() * sd) - wt;
       Eigen::MatrixXd ca = Eigen::cos(a.array());
-      Eigen::MatrixXd h = this->amplitude * ca.array();
-      _heights = h.reshaped();
+      Eigen::MatrixXd h1 = amplitude_ * ca.array();
+      h = h1.reshaped();
     }
     else
     {
-      double dx = this->lx / this->nx;
-      double dy = this->ly / this->ny;
-      double lx_min = - this->lx / 2.0;
-      double ly_min = - this->ly / 2.0;
-      for (size_t iy=0, idx=0; iy<this->ny; ++iy)
+      double dx = lx_ / nx_;
+      double dy = ly_ / ny_;
+      double lx_min = - lx_ / 2.0;
+      double ly_min = - ly_ / 2.0;
+      for (size_t iy=0, idx=0; iy<ny_; ++iy)
       {
         double y = iy * dy + ly_min;
-        for (size_t ix=0; ix<this->nx; ++ix, ++idx)
+        for (size_t ix=0; ix<nx_; ++ix, ++idx)
         {
           double x = ix * dx + lx_min;
           double a  = k * (x * cd + y * sd) - wt;
           double ca = std::cos(a);
-          double h = this->amplitude * ca;
-          _heights(idx, 0) = h;
+          double h1 = amplitude_ * ca;
+          h(idx, 0) = h1;
         }
       }
     }
@@ -241,46 +241,46 @@ namespace waves
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::Impl::ComputeElevationDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy)
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
     // derived wave properties
-    double w = 2.0 * M_PI / this->period;
-    double wt = w * this->time;
+    double w = 2.0 * M_PI / period_;
+    double wt = w * time_;
     double k = Physics::DeepWaterDispersionToWavenumber(w);
-    double cd = std::cos(this->wave_angle);
-    double sd = std::sin(this->wave_angle);
+    double cd = std::cos(wave_angle_);
+    double sd = std::sin(wave_angle_);
     double dadx = k * cd;
     double dady = k * sd;
 
-    if (this->use_vectorised)
+    if (use_vectorised_)
     {
-      Eigen::MatrixXd a = k * (this->x_grid.array() * cd
-          + this->y_grid.array() * sd) - wt;
+      Eigen::MatrixXd a = k * (x_grid_.array() * cd
+          + y_grid_.array() * sd) - wt;
       Eigen::MatrixXd sa = Eigen::sin(a.array());
-      Eigen::MatrixXd dhdx = - dadx * this->amplitude * sa.array();
-      Eigen::MatrixXd dhdy = - dady * this->amplitude * sa.array();
-      _dhdx = dhdx.reshaped();
-      _dhdy = dhdy.reshaped();
+      Eigen::MatrixXd dhdx1 = - dadx * amplitude_ * sa.array();
+      Eigen::MatrixXd dhdy1 = - dady * amplitude_ * sa.array();
+      dhdx = dhdx1.reshaped();
+      dhdy = dhdy1.reshaped();
     }
     else
     {
-      double dx = this->lx / this->nx;
-      double dy = this->ly / this->ny;
-      double lx_min = - this->lx / 2.0;
-      double ly_min = - this->ly / 2.0;
-      for (size_t iy=0, idx=0; iy<this->ny; ++iy)
+      double dx = lx_ / nx_;
+      double dy = ly_ / ny_;
+      double lx_min = - lx_ / 2.0;
+      double ly_min = - ly_ / 2.0;
+      for (size_t iy=0, idx=0; iy<ny_; ++iy)
       {
         double y = iy * dy + ly_min;
-        for (size_t ix=0; ix<this->nx; ++ix, ++idx)
+        for (size_t ix=0; ix<nx_; ++ix, ++idx)
         {
           double x = ix * dx + lx_min;
           double a  = k * (x * cd + y * sd) - wt;
           double sa = std::sin(a);
-          double dhdx = - dadx * this->amplitude * sa;
-          double dhdy = - dady * this->amplitude * sa;
-          _dhdx(idx, 0) = dhdx;
-          _dhdy(idx, 0) = dhdy;
+          double dhdx1 = - dadx * amplitude_ * sa;
+          double dhdy1 = - dady * amplitude_ * sa;
+          dhdx(idx, 0) = dhdx1;
+          dhdy(idx, 0) = dhdy1;
         }
       }
     }
@@ -288,75 +288,75 @@ namespace waves
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::Impl::ComputeDisplacements(
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy)
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy)
   {
     // No xy-displacement
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::Impl::ComputeDisplacementsDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
     // No xy-displacement
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::Impl::ComputeDisplacementsAndDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _h,
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy,
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> h,
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy,
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
     // derived wave properties
-    double w = 2.0 * M_PI / this->period;
-    double wt = w * this->time;
+    double w = 2.0 * M_PI / period_;
+    double wt = w * time_;
     double k = Physics::DeepWaterDispersionToWavenumber(w);
-    double cd = std::cos(this->wave_angle);
-    double sd = std::sin(this->wave_angle);
+    double cd = std::cos(wave_angle_);
+    double sd = std::sin(wave_angle_);
     double dadx = k * cd;
     double dady = k * sd;
 
-    if (this->use_vectorised)
+    if (use_vectorised_)
     {
-      Eigen::MatrixXd a = k * (this->x_grid.array() * cd
-          + this->y_grid.array() * sd) - wt;
+      Eigen::MatrixXd a = k * (x_grid_.array() * cd
+          + y_grid_.array() * sd) - wt;
       Eigen::MatrixXd ca = Eigen::cos(a.array());
       Eigen::MatrixXd sa = Eigen::sin(a.array());
-      Eigen::MatrixXd h = this->amplitude * ca.array();
-      Eigen::MatrixXd dhdx = - dadx * this->amplitude * sa.array();
-      Eigen::MatrixXd dhdy = - dady * this->amplitude * sa.array();
-      _h = h.reshaped();
-      _dhdx = dhdx.reshaped();
-      _dhdy = dhdy.reshaped();
+      Eigen::MatrixXd h1 = amplitude_ * ca.array();
+      Eigen::MatrixXd dhdx1 = - dadx * amplitude_ * sa.array();
+      Eigen::MatrixXd dhdy1 = - dady * amplitude_ * sa.array();
+      h = h1.reshaped();
+      dhdx = dhdx1.reshaped();
+      dhdy = dhdy1.reshaped();
     }
     else
     {
-      double dx = this->lx / this->nx;
-      double dy = this->ly / this->ny;
-      double lx_min = - this->lx / 2.0;
-      double ly_min = - this->ly / 2.0;
-      for (size_t iy=0, idx=0; iy<this->ny; ++iy)
+      double dx = lx_ / nx_;
+      double dy = ly_ / ny_;
+      double lx_min = - lx_ / 2.0;
+      double ly_min = - ly_ / 2.0;
+      for (size_t iy=0, idx=0; iy<ny_; ++iy)
       {
         double y = iy * dy + ly_min;
-        for (size_t ix=0; ix<this->nx; ++ix, ++idx)
+        for (size_t ix=0; ix<nx_; ++ix, ++idx)
         {
           double x = ix * dx + lx_min;
           double a  = k * (x * cd + y * sd) - wt;
           double ca = std::cos(a);
           double sa = std::sin(a);
-          double h = this->amplitude * ca;
-          double dhdx = - dadx * this->amplitude * sa;
-          double dhdy = - dady * this->amplitude * sa;
-          _h(idx, 0) = h;
-          _dhdx(idx, 0) = dhdx;
-          _dhdy(idx, 0) = dhdy;
+          double h1 = amplitude_ * ca;
+          double dhdx1 = - dadx * amplitude_ * sa;
+          double dhdy1 = - dady * amplitude_ * sa;
+          h(idx, 0) = h1;
+          dhdx(idx, 0) = dhdx1;
+          dhdy(idx, 0) = dhdy1;
         }
       }
     }
@@ -370,96 +370,96 @@ namespace waves
 
   //////////////////////////////////////////////////
   WaveSimulationSinusoid::WaveSimulationSinusoid(
-      double _lx, double _ly, int _nx, int _ny) :
-    impl(new WaveSimulationSinusoid::Impl(_lx, _ly, _nx, _ny))
+      double lx, double ly, int nx, int ny) :
+    impl_(new WaveSimulationSinusoid::Impl(lx, ly, nx, ny))
   {
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::SetUseVectorised(bool _value)
+  void WaveSimulationSinusoid::SetUseVectorised(bool value)
   {
-    impl->SetUseVectorised(_value);
+    impl_->SetUseVectorised(value);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::SetDirection(double _dir_x, double _dir_y)
+  void WaveSimulationSinusoid::SetDirection(double dir_x, double dir_y)
   {
-    impl->SetDirection(_dir_x, _dir_y);
+    impl_->SetDirection(dir_x, dir_y);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::SetAmplitude(double _value)
+  void WaveSimulationSinusoid::SetAmplitude(double value)
   {
-    impl->SetAmplitude(_value);
+    impl_->SetAmplitude(value);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::SetPeriod(double _value)
+  void WaveSimulationSinusoid::SetPeriod(double value)
   {
-    impl->SetPeriod(_value);
+    impl_->SetPeriod(value);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::SetWindVelocity(double _ux, double _uy)
+  void WaveSimulationSinusoid::SetWindVelocity(double ux, double uy)
   {
-    impl->SetWindVelocity(_ux, _uy);
+    impl_->SetWindVelocity(ux, uy);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::SetTime(double _value)
+  void WaveSimulationSinusoid::SetTime(double value)
   {
-    impl->SetTime(_value);
+    impl_->SetTime(value);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::ComputeElevation(
-    Eigen::Ref<Eigen::MatrixXd> _h)
+    Eigen::Ref<Eigen::MatrixXd> h)
   {
-    impl->ComputeElevation(_h);
+    impl_->ComputeElevation(h);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::ComputeElevationDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy)
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
-    impl->ComputeElevationDerivatives(_dhdx, _dhdy);
+    impl_->ComputeElevationDerivatives(dhdx, dhdy);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::ComputeDisplacements(
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy)
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy)
   {
-    impl->ComputeDisplacements(_sx, _sy);
+    impl_->ComputeDisplacements(sx, sy);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::ComputeDisplacementsDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    impl->ComputeDisplacementsDerivatives(_dsxdx, _dsydy, _dsxdy);
+    impl_->ComputeDisplacementsDerivatives(dsxdx, dsydy, dsxdy);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::ComputeDisplacementsAndDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _h,
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy,
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> h,
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy,
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    // impl->ComputeDisplacementsAndDerivatives(
-    //     _h, _sx, _sy, _dhdx, _dhdy, _dsxdx, _dsydy, _dsxdy);
+    // impl_->ComputeDisplacementsAndDerivatives(
+    //     h, sx, sy, dhdx, dhdy, dsxdx, dsydy, dsxdy);
 
     /// \todo undo flip of dhdx <---> dhdy once render plugin fixed
-    impl->ComputeDisplacementsAndDerivatives(
-        _h, _sx, _sy, _dhdy, _dhdx, _dsxdx, _dsydy, _dsxdy);
+    impl_->ComputeDisplacementsAndDerivatives(
+        h, sx, sy, dhdy, dhdx, dsxdx, dsydy, dsxdy);
   }
 }
 }

--- a/gz-waves/src/WaveSimulationTrochoid.cc
+++ b/gz-waves/src/WaveSimulationTrochoid.cc
@@ -32,13 +32,13 @@ namespace waves
     ~WaveSimulationTrochoidImpl();
 
     WaveSimulationTrochoidImpl(
-        int _N,
-        double _L,
-        std::shared_ptr<WaveParameters> _params);
+        int N,
+        double L,
+        std::shared_ptr<WaveParameters> params);
 
-    void SetWindVelocity(double _ux, double _uy);
+    void SetWindVelocity(double ux, double uy);
 
-    void SetTime(double _time);
+    void SetTime(double time);
 
     void ComputeElevation(
         Eigen::Ref<Eigen::MatrixXd> _heights);
@@ -56,12 +56,12 @@ namespace waves
         Eigen::Ref<Eigen::MatrixXd> _dsydy,
         Eigen::Ref<Eigen::MatrixXd> _dsxdy);
   
-    int N;
-    int N2;
-    int NOver2;
-    double L;
-    double time;
-    std::shared_ptr<WaveParameters> params;
+    int N_;
+    int N2_;
+    int NOver2_;
+    double L_;
+    double time_;
+    std::shared_ptr<WaveParameters> params_;
   };
 
   //////////////////////////////////////////////////
@@ -71,45 +71,45 @@ namespace waves
 
   //////////////////////////////////////////////////
   WaveSimulationTrochoidImpl::WaveSimulationTrochoidImpl(
-    int _N,
-    double _L,
-    std::shared_ptr<WaveParameters> _params) :
-    N(_N),
-    N2(_N * _N),
-    NOver2(_N / 2),
-    L(_L),
-    params(_params)
+    int N,
+    double L,
+    std::shared_ptr<WaveParameters> params) :
+    N_(N),
+    N2_(N * N),
+    NOver2_(N / 2),
+    L_(L),
+    params_(params)
   {
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationTrochoidImpl::SetWindVelocity(double _ux, double _uy)
+  void WaveSimulationTrochoidImpl::SetWindVelocity(double ux, double uy)
   {
     // @TODO NO IMPLEMENTATION
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationTrochoidImpl::SetTime(double _time)
+  void WaveSimulationTrochoidImpl::SetTime(double time)
   {
     // @TODO NO IMPLEMENTATION
-    this->time = _time;
+    this->time_ = time;
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoidImpl::ComputeElevation(
-    Eigen::Ref<Eigen::MatrixXd> _heights)
+    Eigen::Ref<Eigen::MatrixXd> h)
   {
     // Multiple wave params
-    const auto  number     = this->params->Number();
-    const auto& amplitude  = this->params->Amplitude_V();
-    const auto& wavenumber = this->params->Wavenumber_V();
-    const auto& omega      = this->params->AngularFrequency_V();
-    const auto& phase      = this->params->Phase_V();
-    const auto& q          = this->params->Steepness_V();
-    const auto& direction  = this->params->Direction_V();
+    const auto  number     = this->params_->Number();
+    const auto& amplitude  = this->params_->Amplitude_V();
+    const auto& wavenumber = this->params_->Wavenumber_V();
+    const auto& omega      = this->params_->AngularFrequency_V();
+    const auto& phase      = this->params_->Phase_V();
+    const auto& q          = this->params_->Steepness_V();
+    const auto& direction  = this->params_->Direction_V();
 
     // Multiple wave update 
-    _heights = Eigen::MatrixXd::Zero(this->N2, 0);
+    h = Eigen::MatrixXd::Zero(this->N2_, 0);
     for (size_t i=0; i<number; ++i)
     {        
       const auto& amplitude_i = amplitude[i];
@@ -119,27 +119,27 @@ namespace waves
       const auto& direction_i = direction[i];
       const auto& q_i = q[i];
 
-      for (size_t iy=0; iy<this->N; ++iy)
+      for (size_t iy=0; iy<this->N_; ++iy)
       {
-        for (size_t ix=0; ix<this->N; ++ix)
+        for (size_t ix=0; ix<this->N_; ++ix)
         {
           // Col major index
-          size_t idx = iy * this->N + ix;
+          size_t idx = iy * this->N_ + ix;
 
           // Regular grid
-          double vx = ix * this->L / this->N - this->L / 2.0;
-          double vy = iy * this->L / this->N - this->L / 2.0;
+          double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;
+          double vy = iy * this->L_ / this->N_ - this->L_ / 2.0;
 
           // Multiple waves
           double ddotx = direction_i.X() * vx + direction_i.Y() * vy;
-          double angle  = ddotx * wavenumber_i - omega_i * time + phase_i;
+          double angle  = ddotx * wavenumber_i - omega_i * time_ + phase_i;
           // double s = std::sin(angle);
           double c = std::cos(angle);
           // double sx = - direction_i.X() * q_i * amplitude_i * s;
           // double sy = - direction_i.Y() * q_i * amplitude_i * s;
-          double h = amplitude_i * c;
+          double h1 = amplitude_i * c;
 
-          _heights(idx, 0) += h;
+          h(idx, 0) += h1;
         }
       }
     }
@@ -147,29 +147,29 @@ namespace waves
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoidImpl::ComputeElevationDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy)
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
     // @TODO NO IMPLEMENTATION
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoidImpl::ComputeDisplacements(
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy)
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy)
   {
     // Multiple wave params
-    const auto  number     = this->params->Number();
-    const auto& amplitude  = this->params->Amplitude_V();
-    const auto& wavenumber = this->params->Wavenumber_V();
-    const auto& omega      = this->params->AngularFrequency_V();
-    const auto& phase      = this->params->Phase_V();
-    const auto& q          = this->params->Steepness_V();
-    const auto& direction  = this->params->Direction_V();
+    const auto  number     = this->params_->Number();
+    const auto& amplitude  = this->params_->Amplitude_V();
+    const auto& wavenumber = this->params_->Wavenumber_V();
+    const auto& omega      = this->params_->AngularFrequency_V();
+    const auto& phase      = this->params_->Phase_V();
+    const auto& q          = this->params_->Steepness_V();
+    const auto& direction  = this->params_->Direction_V();
 
     // Multiple wave update
-    _sx = Eigen::MatrixXd::Zero(this->N2, 0);
-    _sy = Eigen::MatrixXd::Zero(this->N2, 0);
+    sx = Eigen::MatrixXd::Zero(this->N2_, 0);
+    sy = Eigen::MatrixXd::Zero(this->N2_, 0);
     for (size_t i=0; i<number; ++i)
     {        
       const auto& amplitude_i = amplitude[i];
@@ -179,28 +179,28 @@ namespace waves
       const auto& direction_i = direction[i];
       const auto& q_i = q[i];
 
-      for (size_t iy=0; iy<this->N; ++iy)
+      for (size_t iy=0; iy<this->N_; ++iy)
       {
-        for (size_t ix=0; ix<this->N; ++ix)
+        for (size_t ix=0; ix<this->N_; ++ix)
         {
           // Col major index
-          size_t idx = iy * this->N + ix;
+          size_t idx = iy * this->N_ + ix;
 
           // Regular grid
-          double vx = ix * this->L / this->N - this->L / 2.0;
-          double vy = iy * this->L / this->N - this->L / 2.0;
+          double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;
+          double vy = iy * this->L_ / this->N_ - this->L_ / 2.0;
 
           // Multiple waves
           double ddotx = direction_i.X() * vx + direction_i.Y() * vy;
-          double angle  = ddotx * wavenumber_i - omega_i * time + phase_i;
+          double angle  = ddotx * wavenumber_i - omega_i * time_ + phase_i;
           double s = std::sin(angle);
           // double c = std::cos(angle);
-          double sx = - direction_i.X() * q_i * amplitude_i * s;
-          double sy = - direction_i.Y() * q_i * amplitude_i * s;
+          double sx1 = - direction_i.X() * q_i * amplitude_i * s;
+          double sy1 = - direction_i.Y() * q_i * amplitude_i * s;
           // double h = amplitude_i * c;
 
-          _sx(idx, 0) += sx;
-          _sy(idx, 0) += sy;
+          sx(idx, 0) += sx1;
+          sy(idx, 0) += sy1;
         }
       }
     }
@@ -208,9 +208,9 @@ namespace waves
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoidImpl::ComputeDisplacementsDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
     // @TODO NO IMPLEMENTATION
   }
@@ -222,72 +222,72 @@ namespace waves
 
   //////////////////////////////////////////////////
   WaveSimulationTrochoid::WaveSimulationTrochoid(
-    int _N,
-    double _L,
-    std::shared_ptr<WaveParameters> _params) :
-    impl(new WaveSimulationTrochoidImpl(_N, _L, _params))
+    int N,
+    double L,
+    std::shared_ptr<WaveParameters> params) :
+    impl_(new WaveSimulationTrochoidImpl(N, L, params))
   {
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationTrochoid::SetWindVelocity(double _ux, double _uy)
+  void WaveSimulationTrochoid::SetWindVelocity(double ux, double uy)
   {
-    impl->SetWindVelocity(_ux, _uy);
+    impl_->SetWindVelocity(ux, uy);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationTrochoid::SetTime(double _time)
+  void WaveSimulationTrochoid::SetTime(double time)
   {
-    impl->SetTime(_time);
+    impl_->SetTime(time);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoid::ComputeElevation(
-    Eigen::Ref<Eigen::MatrixXd> _h)
+    Eigen::Ref<Eigen::MatrixXd> h)
   {
-    impl->ComputeElevation(_h);
+    impl_->ComputeElevation(h);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoid::ComputeElevationDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy)
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
-    impl->ComputeElevationDerivatives(_dhdx, _dhdy);
+    impl_->ComputeElevationDerivatives(dhdx, dhdy);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoid::ComputeDisplacements(
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy)
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy)
   {
-    impl->ComputeDisplacements(_sx, _sy);
+    impl_->ComputeDisplacements(sx, sy);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoid::ComputeDisplacementsDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    impl->ComputeDisplacementsDerivatives(_dsxdx, _dsydy, _dsxdy);
+    impl_->ComputeDisplacementsDerivatives(dsxdx, dsydy, dsxdy);
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoid::ComputeDisplacementsAndDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> _h,
-    Eigen::Ref<Eigen::MatrixXd> _sx,
-    Eigen::Ref<Eigen::MatrixXd> _sy,
-    Eigen::Ref<Eigen::MatrixXd> _dhdx,
-    Eigen::Ref<Eigen::MatrixXd> _dhdy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> _dsydy,
-    Eigen::Ref<Eigen::MatrixXd> _dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> h,
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy,
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    impl->ComputeElevation(_h);
-    impl->ComputeElevationDerivatives(_dhdx, _dhdy);
-    impl->ComputeDisplacements(_sx, _sy);
-    impl->ComputeDisplacementsDerivatives(_dsxdx, _dsydy, _dsxdy);
+    impl_->ComputeElevation(h);
+    impl_->ComputeElevationDerivatives(dhdx, dhdy);
+    impl_->ComputeDisplacements(sx, sy);
+    impl_->ComputeDisplacementsDerivatives(dsxdx, dsydy, dsxdy);
   }
 }
 }

--- a/gz-waves/src/WaveSimulation_TEST.cc
+++ b/gz-waves/src/WaveSimulation_TEST.cc
@@ -102,21 +102,21 @@ protected:
   }
 
   // simulation parameters
-  const double gravity{9.81};
+  const double gravity_{9.81};
 
   // grid dimensions
-  const int nx{8};
-  const int ny{4};
-  const double lx{10.0};
-  const double ly{5.0};
+  const int nx_{8};
+  const int ny_{4};
+  const double lx_{10.0};
+  const double ly_{5.0};
 
   // wave parameters
-  const double amplitude{2.0};
-  const double period{10.0};
+  const double amplitude_{2.0};
+  const double period_{10.0};
 
   // derived parameters
-  const double w{2.0 * M_PI / period};
-  const double k{w * w / gravity};
+  const double w_{2.0 * M_PI / period_};
+  const double k_{w_ * w_ / gravity_};
 };
 
 //////////////////////////////////////////////////
@@ -126,31 +126,31 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestHeightsDirX)
 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
-      new WaveSimulationSinusoid(lx, ly, nx, ny));
+      new WaveSimulationSinusoid(lx_, ly_, nx_, ny_));
   wave_sim->SetDirection(1.0, 0.0);
-  wave_sim->SetAmplitude(amplitude);
-  wave_sim->SetPeriod(period);
+  wave_sim->SetAmplitude(amplitude_);
+  wave_sim->SetPeriod(period_);
   wave_sim->SetTime(time);
 
   // Grid spacing and offset
-  double lx_min = - lx / 2.0;
-  double ly_min = - ly / 2.0;
-  double dx = lx / nx;
-  double dy = ly / ny;
+  double lx_min = - lx_ / 2.0;
+  double ly_min = - ly_ / 2.0;
+  double dx = lx_ / nx_;
+  double dy = ly_ / ny_;
 
   // Verify heights
-  Eigen::VectorXd h = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd h = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->ComputeElevation(h);
 
-  for (size_t iy=0, idx=0; iy<ny; ++iy)
+  for (size_t iy=0, idx=0; iy<ny_; ++iy)
   {
     double y = iy * dy + ly_min;
-    for (size_t ix=0; ix<nx; ++ix, ++idx)
+    for (size_t ix=0; ix<nx_; ++ix, ++idx)
     {
       double x = ix * dx + lx_min;
-      double a = k * x - w * time;
+      double a = k_ * x - w_ * time;
       double c = std::cos(a);
-      double h_test = amplitude * c;
+      double h_test = amplitude_ * c;
       
       EXPECT_DOUBLE_EQ(h(idx), h_test);
     }
@@ -164,35 +164,35 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestHeightsDirXY)
 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
-      new WaveSimulationSinusoid(lx, ly, nx, ny));
+      new WaveSimulationSinusoid(lx_, ly_, nx_, ny_));
   wave_sim->SetDirection(2.0, -1.0);
-  wave_sim->SetAmplitude(amplitude);
-  wave_sim->SetPeriod(period);
+  wave_sim->SetAmplitude(amplitude_);
+  wave_sim->SetPeriod(period_);
   wave_sim->SetTime(time);
 
   // Grid spacing and offset
-  double lx_min = - lx / 2.0;
-  double ly_min = - ly / 2.0;
-  double dx = lx / nx;
-  double dy = ly / ny;
-  double wt = w * time;
+  double lx_min = - lx_ / 2.0;
+  double ly_min = - ly_ / 2.0;
+  double dx = lx_ / nx_;
+  double dy = ly_ / ny_;
+  double wt = w_ * time;
   double theta = std::atan2(-1.0, 2.0);
   double cd = std::cos(theta);
   double sd = std::sin(theta);
 
   // Verify heights
-  Eigen::VectorXd h = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd h = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->ComputeElevation(h);
 
-  for (size_t iy=0, idx=0; iy<ny; ++iy)
+  for (size_t iy=0, idx=0; iy<ny_; ++iy)
   {
     double y = iy * dy + ly_min;
-    for (size_t ix=0; ix<nx; ++ix, ++idx)
+    for (size_t ix=0; ix<nx_; ++ix, ++idx)
     {
       double x = ix * dx + lx_min;
-      double a = k * (x * cd + y * sd) - wt;
+      double a = k_ * (x * cd + y * sd) - wt;
       double c = std::cos(a);
-      double h_test = amplitude * c;
+      double h_test = amplitude_ * c;
       
       EXPECT_DOUBLE_EQ(h(idx), h_test);
     }
@@ -204,20 +204,20 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestDisplacementsDirX)
 {
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
-      new WaveSimulationSinusoid(lx, ly, nx, ny));
+      new WaveSimulationSinusoid(lx_, ly_, nx_, ny_));
   wave_sim->SetDirection(1.0, 0.0);
-  wave_sim->SetAmplitude(amplitude);
-  wave_sim->SetPeriod(period);
+  wave_sim->SetAmplitude(amplitude_);
+  wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
 
   // Verify displacements (expect zero for sinusoid waves)
-  Eigen::VectorXd sx = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd sy = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd sx = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd sy = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->ComputeDisplacements(sx, sy);
 
-  for (size_t iy=0, idx=0; iy<ny; ++iy)
+  for (size_t iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx; ++ix, ++idx)
+    for (size_t ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(sx(idx), 0.0);
       EXPECT_DOUBLE_EQ(sy(idx), 0.0);
@@ -231,40 +231,40 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedGrid)
   // check the behaviour of Eigen meshgrid
 
   // grid spacing
-  double dx = this->lx / this->nx;
-  double dy = this->ly / this->ny;
+  double dx = lx_ / nx_;
+  double dy = ly_ / ny_;
 
   // create coordinate grids
-  double lx_min = - lx / 2.0;
-  double lx_max =   lx / 2.0;
-  double ly_min = - ly / 2.0;
-  double ly_max =   ly / 2.0;
+  double lx_min = - lx_ / 2.0;
+  double lx_max =   lx_ / 2.0;
+  double ly_min = - ly_ / 2.0;
+  double ly_max =   ly_ / 2.0;
 
   // linspaced is on closed interval (unlike Python which is open to right)
-  Eigen::VectorXd x_v = Eigen::VectorXd::LinSpaced(nx, lx_min, lx_max - dx);
-  Eigen::VectorXd y_v = Eigen::VectorXd::LinSpaced(ny, ly_min, ly_max - dy);
+  Eigen::VectorXd x_v = Eigen::VectorXd::LinSpaced(nx_, lx_min, lx_max - dx);
+  Eigen::VectorXd y_v = Eigen::VectorXd::LinSpaced(ny_, ly_min, ly_max - dy);
 
   // broadcast to matrices (aka meshgrid)
-  Eigen::MatrixXd x_grid = Eigen::MatrixXd::Zero(this->nx, this->ny);
-  Eigen::MatrixXd y_grid = Eigen::MatrixXd::Zero(this->nx, this->ny);
+  Eigen::MatrixXd x_grid = Eigen::MatrixXd::Zero(nx_, ny_);
+  Eigen::MatrixXd y_grid = Eigen::MatrixXd::Zero(nx_, ny_);
   x_grid.colwise() += x_v;
   y_grid.rowwise() += y_v.transpose();
 
-  for (size_t ix=0; ix<nx; ++ix)
+  for (size_t ix=0; ix<nx_; ++ix)
   {
     double x_test = ix * dx + lx_min;
     EXPECT_DOUBLE_EQ(x_v(ix), x_test);
   }
 
-  for (size_t iy=0; iy<ny; ++iy)
+  for (size_t iy=0; iy<ny_; ++iy)
   {
     double y_test = iy * dy + ly_min;
     EXPECT_DOUBLE_EQ(y_v(iy), y_test);
   }
 
-  for (size_t ix=0; ix<nx; ++ix)
+  for (size_t ix=0; ix<nx_; ++ix)
   {
-    for (size_t iy=0; iy<ny; ++iy)
+    for (size_t iy=0; iy<ny_; ++iy)
     {
       double x_test = ix * dx + lx_min;
       double y_test = iy * dy + ly_min;
@@ -280,25 +280,25 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightsDirX)
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
-      new WaveSimulationSinusoid(lx, ly, nx, ny));
+      new WaveSimulationSinusoid(lx_, ly_, nx_, ny_));
   wave_sim->SetDirection(1.0, 0.0);
-  wave_sim->SetAmplitude(amplitude);
-  wave_sim->SetPeriod(period);
+  wave_sim->SetAmplitude(amplitude_);
+  wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
   // vectorised
-  Eigen::VectorXd h1 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd h1 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(true);
   wave_sim->ComputeElevation(h1);
  
   // non-vectorised
-  Eigen::VectorXd h2 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd h2 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeElevation(h2);
 
-  for (size_t iy=0, idx=0; iy<ny; ++iy)
+  for (size_t iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx; ++ix, ++idx)
+    for (size_t ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(h1(idx), h2(idx));
     }
@@ -310,25 +310,25 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightsDirXY)
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
-      new WaveSimulationSinusoid(lx, ly, nx, ny));
+      new WaveSimulationSinusoid(lx_, ly_, nx_, ny_));
   wave_sim->SetDirection(2.0, -1.0);
-  wave_sim->SetAmplitude(amplitude);
-  wave_sim->SetPeriod(period);
+  wave_sim->SetAmplitude(amplitude_);
+  wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
   // vectorised
-  Eigen::VectorXd h1 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd h1 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(true);
   wave_sim->ComputeElevation(h1);
  
   // non-vectorised
-  Eigen::VectorXd h2 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd h2 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeElevation(h2);
 
-  for (size_t iy=0, idx=0; iy<ny; ++iy)
+  for (size_t iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx; ++ix, ++idx)
+    for (size_t ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(h1(idx), h2(idx));
     }
@@ -340,27 +340,27 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedDisplacments)
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
-      new WaveSimulationSinusoid(lx, ly, nx, ny));
+      new WaveSimulationSinusoid(lx_, ly_, nx_, ny_));
   wave_sim->SetDirection(2.0, -1.0);
-  wave_sim->SetAmplitude(amplitude);
-  wave_sim->SetPeriod(period);
+  wave_sim->SetAmplitude(amplitude_);
+  wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
   // vectorised
-  Eigen::VectorXd sx1 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd sy1 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd sx1 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd sy1 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(true);
   wave_sim->ComputeDisplacements(sx1, sy1);
  
   // non-vectorised
-  Eigen::VectorXd sx2 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd sy2 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd sx2 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd sy2 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeDisplacements(sx2, sy2);
 
-  for (size_t iy=0, idx=0; iy<ny; ++iy)
+  for (size_t iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx; ++ix, ++idx)
+    for (size_t ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(sx1(idx), sx2(idx));
       EXPECT_DOUBLE_EQ(sy1(idx), sy2(idx));
@@ -373,27 +373,27 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightDerivatives)
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
-      new WaveSimulationSinusoid(lx, ly, nx, ny));
+      new WaveSimulationSinusoid(lx_, ly_, nx_, ny_));
   wave_sim->SetDirection(2.0, -1.0);
-  wave_sim->SetAmplitude(amplitude);
-  wave_sim->SetPeriod(period);
+  wave_sim->SetAmplitude(amplitude_);
+  wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
   // vectorised
-  Eigen::VectorXd dhdx1 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dhdy1 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd dhdx1 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dhdy1 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(true);
   wave_sim->ComputeElevationDerivatives(dhdx1, dhdy1);
  
   // non-vectorised
-  Eigen::VectorXd dhdx2 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dhdy2 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd dhdx2 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dhdy2 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeElevationDerivatives(dhdx2, dhdy2);
 
-  for (size_t iy=0, idx=0; iy<ny; ++iy)
+  for (size_t iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx; ++ix, ++idx)
+    for (size_t ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(dhdx1(idx), dhdx2(idx));
       EXPECT_DOUBLE_EQ(dhdy1(idx), dhdy2(idx));
@@ -407,41 +407,41 @@ TEST_F(WaveSimulationSinusoidTestSuite,
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
-      new WaveSimulationSinusoid(lx, ly, nx, ny));
+      new WaveSimulationSinusoid(lx_, ly_, nx_, ny_));
   wave_sim->SetDirection(2.0, -1.0);
-  wave_sim->SetAmplitude(amplitude);
-  wave_sim->SetPeriod(period);
+  wave_sim->SetAmplitude(amplitude_);
+  wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
   // vectorised
-  Eigen::VectorXd h1 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd sx1 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd sy1 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dhdx1 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dhdy1 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dsxdx1 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dsydy1 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dsxdy1 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd h1 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd sx1 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd sy1 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dhdx1 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dhdy1 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dsxdx1 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dsydy1 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dsxdy1 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(true);
   wave_sim->ComputeDisplacementsAndDerivatives(
     h1, sx1, sy1, dhdx1, dhdy1, dsxdx1, dsydy1, dsxdy1);
  
   // non-vectorised
-  Eigen::VectorXd h2 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd sx2 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd sy2 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dhdx2 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dhdy2 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dsxdx2 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dsydy2 = Eigen::VectorXd::Zero(nx * ny);
-  Eigen::VectorXd dsxdy2 = Eigen::VectorXd::Zero(nx * ny);
+  Eigen::VectorXd h2 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd sx2 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd sy2 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dhdx2 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dhdy2 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dsxdx2 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dsydy2 = Eigen::VectorXd::Zero(nx_ * ny_);
+  Eigen::VectorXd dsxdy2 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeDisplacementsAndDerivatives(
     h2, sx2, sy2, dhdx2, dhdy2, dsxdx2, dsydy2, dsxdy2);
 
-  for (size_t iy=0, idx=0; iy<ny; ++iy)
+  for (size_t iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx; ++ix, ++idx)
+    for (size_t ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(h1(idx), h2(idx));
       EXPECT_DOUBLE_EQ(sx1(idx), sx2(idx));

--- a/gz-waves/src/WaveSpectrum.cc
+++ b/gz-waves/src/WaveSpectrum.cc
@@ -33,34 +33,30 @@ PiersonMoskowitzWaveSpectrum::~PiersonMoskowitzWaveSpectrum()
 
 //////////////////////////////////////////////////
 PiersonMoskowitzWaveSpectrum::PiersonMoskowitzWaveSpectrum(
-    double _u19, double _gravity) :
+    double u19, double gravity) :
   OmniDirectionalWaveSpectrum(),
-  _u19(_u19),
-  _gravity(_gravity)
+  u19_(u19),
+  gravity_(gravity)
 {
 }
 
 //////////////////////////////////////////////////
-double PiersonMoskowitzWaveSpectrum::Evaluate(double _k) const
+double PiersonMoskowitzWaveSpectrum::Evaluate(double k) const
 {
-  if (std::abs(_k) < 1.0E-8 || std::abs(this->_u19) < 1.0E-8)
+  if (std::abs(k) < 1.0E-8 || std::abs(u19_) < 1.0E-8)
   {
     return 0.0;
   }
-
-  // aliases
-  double g = this->_gravity;
-  double u = this->_u19;
 
   // constants
   const double alpha = 0.0081;
   const double beta = 0.74;
 
   // intermediates
-  double g2 = g * g;
-  double k2 = _k * _k;
-  double k3 = _k * k2;
-  double u2 = u * u;
+  double g2 = gravity_ * gravity_;
+  double k2 = k * k;
+  double k3 = k * k2;
+  double u2 = u19_ * u19_;
   double u4 = u2 * u2;
 
   double cap_s = alpha / 2.0 / k3 * std::exp(-beta * g2 / k2 / u4);
@@ -69,67 +65,63 @@ double PiersonMoskowitzWaveSpectrum::Evaluate(double _k) const
 
 //////////////////////////////////////////////////
 void PiersonMoskowitzWaveSpectrum::Evaluate(
-    Eigen::Ref<Eigen::MatrixXd> _spectrum,
-    const Eigen::Ref<const Eigen::MatrixXd> &_k) const
+    Eigen::Ref<Eigen::MatrixXd> spectrum,
+    const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
-  auto rows =  _spectrum.rows();
-  auto cols =  _spectrum.cols();
+  auto rows =  spectrum.rows();
+  auto cols =  spectrum.cols();
 
-  if (std::abs(this->_u19) < 1.0E-8)
+  if (std::abs(u19_) < 1.0E-8)
   {
-    _spectrum.setZero();
+    spectrum.setZero();
   }
 
   // array k has no zero elements
-  Eigen::MatrixXd k = (_k.array() == 0).select(
-      Eigen::MatrixXd::Ones(rows, cols), _k);
-
-  // aliases
-  double g = this->_gravity;
-  double u = this->_u19;
+  Eigen::MatrixXd k1 = (k.array() == 0).select(
+      Eigen::MatrixXd::Ones(rows, cols), k);
 
   // constants
   const double alpha = 0.0081;
   const double beta = 0.74;
 
   // intermediates
-  double g2 = g * g;
-  double u2 = u * u;
+  double g2 = gravity_ * gravity_;
+  double u2 = u19_ * u19_;
   double u4 = u2 * u2;
-  Eigen::MatrixXd k2 = Eigen::pow(k.array(), 2.0);
-  Eigen::MatrixXd k3 = Eigen::pow(k.array(), 3.0);
+  Eigen::MatrixXd k2 = Eigen::pow(k1.array(), 2.0);
+  Eigen::MatrixXd k3 = Eigen::pow(k1.array(), 3.0);
 
   // evaluate for k
   Eigen::MatrixXd cap_s = alpha / 2.0 / k3.array()
       * Eigen::exp(-beta * g2 / k2.array() / u4);
 
   // apply filter
-  _spectrum = (_k.array() == 0).select(
+  spectrum = (k.array() == 0).select(
       Eigen::MatrixXd::Zero(rows, cols), cap_s);
 }
 
 //////////////////////////////////////////////////
 double PiersonMoskowitzWaveSpectrum::Gravity() const
 {
-  return this->_gravity;
+  return gravity_;
 }
 
 //////////////////////////////////////////////////
-void PiersonMoskowitzWaveSpectrum::SetGravity(double _value)
+void PiersonMoskowitzWaveSpectrum::SetGravity(double value)
 {
-  this->_gravity = _value;
+  gravity_ = value;
 }
 
 //////////////////////////////////////////////////
 double PiersonMoskowitzWaveSpectrum::U19() const
 {
-  return this->_u19;
+  return u19_;
 }
 
 //////////////////////////////////////////////////
-void PiersonMoskowitzWaveSpectrum::SetU19(double _value)
+void PiersonMoskowitzWaveSpectrum::SetU19(double value)
 {
-  this->_u19 = _value;
+  u19_ = value;
 }
 
 //////////////////////////////////////////////////
@@ -140,28 +132,21 @@ ECKVWaveSpectrum::~ECKVWaveSpectrum()
 
 //////////////////////////////////////////////////
 ECKVWaveSpectrum::ECKVWaveSpectrum(
-    double _u10, double _cap_omega_c, double _gravity) :
+    double u10, double cap_omega_c, double gravity) :
   OmniDirectionalWaveSpectrum(),
-  _u10(_u10),
-  _cap_omega_c(_cap_omega_c),
-  _gravity(_gravity)
+  u10_(u10),
+  cap_omega_c_(cap_omega_c),
+  gravity_(gravity)
 {
 }
 
 //////////////////////////////////////////////////
-double ECKVWaveSpectrum::Evaluate(double _k) const
+double ECKVWaveSpectrum::Evaluate(double k) const
 {
-  if (std::abs(_k) < 1.0E-8 || std::abs(this->_u10) < 1.0E-8)
+  if (std::abs(k) < 1.0E-8 || std::abs(u10_) < 1.0E-8)
   {
     return 0.0;
   }
-
-  double k = _k;
-
-  // aliases
-  double g = this->_gravity;
-  double u10 = this->_u10;
-  double cap_omega_c = this->_cap_omega_c;
 
   // constants
   const double alpha = 0.0081;
@@ -173,21 +158,21 @@ double ECKVWaveSpectrum::Evaluate(double _k) const
   const double cm = 0.23;
 
   // intermediates
-  double u_star = std::sqrt(cd_10n) * u10;
+  double u_star = std::sqrt(cd_10n) * u10_;
   double am = 0.13 * u_star / cm;
   
   double gamma = 1.7;
-  if (cap_omega_c < 1.0)
+  if (cap_omega_c_ < 1.0)
   {
     gamma = 1.7;
   }
   else
   {
-    gamma = 1.7 + 6.0 * std::log10(cap_omega_c);
+    gamma = 1.7 + 6.0 * std::log10(cap_omega_c_);
   }
 
-  double sigma = 0.08 * (1.0 + 4.0 * std::pow(cap_omega_c, -3.0));
-  double alpha_p = 0.006 * std::pow(cap_omega_c, 0.55);
+  double sigma = 0.08 * (1.0 + 4.0 * std::pow(cap_omega_c_, -3.0));
+  double alpha_p = 0.006 * std::pow(cap_omega_c_, 0.55);
 
   double alpha_m; 
   if (u_star <= cm)
@@ -199,11 +184,11 @@ double ECKVWaveSpectrum::Evaluate(double _k) const
     alpha_m = 0.01 * (1.0 + 3.0 * std::log(u_star / cm));
   }
 
-  double ko = g / u10 / u10;
-  double kp = ko * cap_omega_c * cap_omega_c;
+  double ko = gravity_ / u10_ / u10_;
+  double kp = ko * cap_omega_c_ * cap_omega_c_;
 
-  double cp = std::sqrt(g / kp);
-  double c  = std::sqrt((g / k) * (1.0 + std::pow(k / km, 2.0)));
+  double cp = std::sqrt(gravity_ / kp);
+  double c  = std::sqrt((gravity_ / k) * (1.0 + std::pow(k / km, 2.0)));
 
   double l_pm = std::exp(-1.25 * std::pow(kp / k, 2.0));
   
@@ -215,7 +200,7 @@ double ECKVWaveSpectrum::Evaluate(double _k) const
   double j_p = std::pow(gamma, cap_gamma);
   
   double f_p = l_pm * j_p * std::exp(
-      -0.3162 * cap_omega_c * (std::sqrt(k / kp) - 1.0)
+      -0.3162 * cap_omega_c_ * (std::sqrt(k / kp) - 1.0)
   );
 
   double f_m = l_pm * j_p * std::exp(
@@ -233,25 +218,20 @@ double ECKVWaveSpectrum::Evaluate(double _k) const
 
 //////////////////////////////////////////////////
 void ECKVWaveSpectrum::Evaluate(
-    Eigen::Ref<Eigen::MatrixXd> _spectrum,
-    const Eigen::Ref<const Eigen::MatrixXd> &_k) const
+    Eigen::Ref<Eigen::MatrixXd> spectrum,
+    const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
-  auto rows =  _spectrum.rows();
-  auto cols =  _spectrum.cols();
+  auto rows =  spectrum.rows();
+  auto cols =  spectrum.cols();
 
-  if (std::abs(this->_u10) < 1.0E-8)
+  if (std::abs(u10_) < 1.0E-8)
   {
-    _spectrum.setZero();
+    spectrum.setZero();
   }
 
   // array k has no zero elements
-  Eigen::MatrixXd k = (_k.array() == 0).select(
-      Eigen::MatrixXd::Ones(rows, cols), _k);
-
-  // aliases
-  double g = this->_gravity;
-  double u10 = this->_u10;
-  double cap_omega_c = this->_cap_omega_c;
+  Eigen::MatrixXd k1 = (k.array() == 0).select(
+      Eigen::MatrixXd::Ones(rows, cols), k);
 
   // constants
   const double alpha = 0.0081;
@@ -263,21 +243,21 @@ void ECKVWaveSpectrum::Evaluate(
   const double cm = 0.23;
 
   // intermediates
-  double u_star = std::sqrt(cd_10n) * u10;
+  double u_star = std::sqrt(cd_10n) * u10_;
   double am = 0.13 * u_star / cm;
   
   double gamma = 1.7;
-  if (cap_omega_c < 1.0)
+  if (cap_omega_c_ < 1.0)
   {
     gamma = 1.7;
   }
   else
   {
-    gamma = 1.7 + 6.0 * std::log10(cap_omega_c);
+    gamma = 1.7 + 6.0 * std::log10(cap_omega_c_);
   }
 
-  double sigma = 0.08 * (1.0 + 4.0 * std::pow(cap_omega_c, -3.0));
-  double alpha_p = 0.006 * std::pow(cap_omega_c, 0.55);
+  double sigma = 0.08 * (1.0 + 4.0 * std::pow(cap_omega_c_, -3.0));
+  double alpha_p = 0.006 * std::pow(cap_omega_c_, 0.55);
 
   double alpha_m; 
   if (u_star <= cm)
@@ -289,77 +269,77 @@ void ECKVWaveSpectrum::Evaluate(
     alpha_m = 0.01 * (1.0 + 3.0 * std::log(u_star / cm));
   }
 
-  double ko = g / u10 / u10;
-  double kp = ko * cap_omega_c * cap_omega_c;
-  double cp = std::sqrt(g / kp);
+  double ko = gravity_ / u10_ / u10_;
+  double kp = ko * cap_omega_c_ * cap_omega_c_;
+  double cp = std::sqrt(gravity_ / kp);
 
   Eigen::MatrixXd c  = Eigen::sqrt(
-      (g / k.array()) * (1.0 + Eigen::pow(k.array() / km, 2.0))
+      (gravity_ / k1.array()) * (1.0 + Eigen::pow(k1.array() / km, 2.0))
   );
 
   Eigen::MatrixXd l_pm = Eigen::exp(
-      -1.25 * Eigen::pow(kp / k.array(), 2.0)
+      -1.25 * Eigen::pow(kp / k1.array(), 2.0)
   );
   
   Eigen::MatrixXd cap_gamma = Eigen::exp(
       -1.0/(2.0 * std::pow(sigma, 2.0))
-      * Eigen::pow(Eigen::sqrt(k.array() / kp) - 1.0, 2.0)
+      * Eigen::pow(Eigen::sqrt(k1.array() / kp) - 1.0, 2.0)
   );
   
   Eigen::MatrixXd j_p = Eigen::pow(gamma, cap_gamma.array());
   
   Eigen::MatrixXd f_p = l_pm.array() * j_p.array() * Eigen::exp(
-      -0.3162 * cap_omega_c * (Eigen::sqrt(k.array() / kp) - 1.0)
+      -0.3162 * cap_omega_c_ * (Eigen::sqrt(k1.array() / kp) - 1.0)
   );
 
   Eigen::MatrixXd f_m = l_pm.array() * j_p.array() * Eigen::exp(
-      -0.25 * Eigen::pow(k.array() / km - 1.0, 2.0)
+      -0.25 * Eigen::pow(k1.array() / km - 1.0, 2.0)
   );
 
   Eigen::MatrixXd b_l = 0.5 * alpha_p * (cp / c.array()) * f_p.array();
   Eigen::MatrixXd b_h = 0.5 * alpha_m * (cm / c.array()) * f_m.array();
   
-  Eigen::MatrixXd k3 = Eigen::pow(k.array(), 3.0);
+  Eigen::MatrixXd k3 = Eigen::pow(k1.array(), 3.0);
   Eigen::MatrixXd cap_s = (b_l.array() + b_h.array()) / k3.array();
 
    // apply filter
-  _spectrum = (_k.array() == 0).select(
+  spectrum = (k.array() == 0).select(
       Eigen::MatrixXd::Zero(rows, cols), cap_s);
 }
 
 //////////////////////////////////////////////////
 double ECKVWaveSpectrum::Gravity() const
 {
-  return this->_gravity;
+  return gravity_;
 }
 
 //////////////////////////////////////////////////
-void ECKVWaveSpectrum::SetGravity(double _value)
+void ECKVWaveSpectrum::SetGravity(double value)
 {
-  this->_gravity = _value;
+  gravity_ = value;
 }
 
 //////////////////////////////////////////////////
 double ECKVWaveSpectrum::U10() const
 {
-  return this->_u10;
+  return u10_;
 }
 
 //////////////////////////////////////////////////
-void ECKVWaveSpectrum::SetU10(double _value)
+void ECKVWaveSpectrum::SetU10(double value)
 {
-  this->_u10 = _value;
+  u10_ = value;
 }
 
 //////////////////////////////////////////////////
 double ECKVWaveSpectrum::CapOmegaC() const
 {
-  return this->_cap_omega_c;
+  return cap_omega_c_;
 }
 
 //////////////////////////////////////////////////
-void ECKVWaveSpectrum::SetCapOmegaC(double _value)
+void ECKVWaveSpectrum::SetCapOmegaC(double value)
 {
-  this->_cap_omega_c = _value;
+  cap_omega_c_ = value;
 }
 

--- a/gz-waves/src/WaveSpectrum.cc
+++ b/gz-waves/src/WaveSpectrum.cc
@@ -76,7 +76,7 @@ void PiersonMoskowitzWaveSpectrum::Evaluate(
     spectrum.setZero();
   }
 
-  // array k has no zero elements
+  // array1 k has no zero elements
   Eigen::MatrixXd k1 = (k.array() == 0).select(
       Eigen::MatrixXd::Ones(rows, cols), k);
 
@@ -91,11 +91,11 @@ void PiersonMoskowitzWaveSpectrum::Evaluate(
   Eigen::MatrixXd k2 = Eigen::pow(k1.array(), 2.0);
   Eigen::MatrixXd k3 = Eigen::pow(k1.array(), 3.0);
 
-  // evaluate for k
+  // evaluate for k1
   Eigen::MatrixXd cap_s = alpha / 2.0 / k3.array()
       * Eigen::exp(-beta * g2 / k2.array() / u4);
 
-  // apply filter
+  // apply filter for k
   spectrum = (k.array() == 0).select(
       Eigen::MatrixXd::Zero(rows, cols), cap_s);
 }
@@ -229,7 +229,7 @@ void ECKVWaveSpectrum::Evaluate(
     spectrum.setZero();
   }
 
-  // array k has no zero elements
+  // array k1 has no zero elements
   Eigen::MatrixXd k1 = (k.array() == 0).select(
       Eigen::MatrixXd::Ones(rows, cols), k);
 

--- a/gz-waves/src/WaveSpreadingFunction_TEST.cc
+++ b/gz-waves/src/WaveSpreadingFunction_TEST.cc
@@ -210,7 +210,7 @@ TEST(WaveSpreadingFunction, Cos2sFFT2ImplRegression)
     for (int i=0; i<21; ++i)
     {
       double dtheta = theta(i) - theta_mean;
-      double phi_test = WaveSimulationFFT2Impl::Cos2SSpreadingFunction(
+      double phi_test = WaveSimulationFFT2Impl::Cos2sSpreadingFunction(
           spread, dtheta, u10, cap_omega_c);
       EXPECT_DOUBLE_EQ(phi(i), phi_test);
     }


### PR DESCRIPTION
This PR is the second part in a series of updates to the wave simulation to improve performance.

The main change is to replace the use of `ffwt_complex` arrays for storage with Eigen types. This removes copies before and after the FFT execution. The base amplitude calculation is vectorised. 

## Details

1. Extend tests to non-square grids ie. (nx != ny), both nx and ny must be a power of 2.
2. Formatting changes to google coding standards.
3. Replace gravity constant hardcoding with parameter.
4. Add vectorised version of the base amplitude calculation.
5. Add partial vectorised version of current amplitude calculation (remainder is for part 3).
6. Factor out initialisation and cleanup of FFTW storage to separate functions.
7. Use Eigen::RowMajor matrices for FFTW storage (recommended by FFTW docs).
8. Map row major to col major storage on output.
9. Add new unit test file for using Eigen with FFTW.