### PR TITLE
Waves simulation optimisation - part 3

### DIFF
--- a/.github/workflows/macos-monterey-ci.yml
+++ b/.github/workflows/macos-monterey-ci.yml
@@ -1,6 +1,6 @@
 name: macOS Monterey CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   macos-monterey-ci:

--- a/gz-waves/include/gz/waves/WaveSimulationFFT.hh
+++ b/gz-waves/include/gz/waves/WaveSimulationFFT.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef GZ_WAVES_WAVESIMULATIONFFT2_HH_
-#define GZ_WAVES_WAVESIMULATIONFFT2_HH_
+#ifndef GZ_WAVES_WAVESIMULATIONFFT_HH_
+#define GZ_WAVES_WAVESIMULATIONFFT_HH_
 
 #include <memory>
 
@@ -26,14 +26,14 @@ namespace gz
 {
 namespace waves
 {
-  class WaveSimulationFFT2Impl;
+  class WaveSimulationFFTImpl;
 
-  class WaveSimulationFFT2 : public WaveSimulation
+  class WaveSimulationFFT : public WaveSimulation
   {
     public:
-      virtual ~WaveSimulationFFT2();
+      virtual ~WaveSimulationFFT();
 
-      WaveSimulationFFT2(double lx, double ly, int nx, int ny);
+      WaveSimulationFFT(double lx, double ly, int nx, int ny);
 
       void SetUseVectorised(bool value);
 
@@ -71,7 +71,7 @@ namespace waves
           Eigen::Ref<Eigen::MatrixXd> dsxdy) override;
 
     private:
-      std::unique_ptr<WaveSimulationFFT2Impl> impl_;
+      std::unique_ptr<WaveSimulationFFTImpl> impl_;
   };
 }
 }

--- a/gz-waves/include/gz/waves/WaveSimulationFFTRef.hh
+++ b/gz-waves/include/gz/waves/WaveSimulationFFTRef.hh
@@ -1,0 +1,79 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_WAVES_WAVESIMULATIONFFT_HH_
+#define GZ_WAVES_WAVESIMULATIONFFT_HH_
+
+#include <memory>
+
+#include "WaveSimulation.hh"
+
+using Eigen::MatrixXd;
+
+namespace gz
+{
+namespace waves
+{
+  class WaveSimulationFFTRefImpl;
+
+  class WaveSimulationFFTRef : public WaveSimulation
+  {
+    public:
+      virtual ~WaveSimulationFFTRef();
+
+      WaveSimulationFFTRef(double lx, double ly, int nx, int ny);
+
+      void SetUseVectorised(bool value);
+
+      /// \brief Set lambda which controls the horizontal wave displacement.
+      void SetLambda(double lambda);
+
+      virtual void SetWindVelocity(double ux, double uy) override;
+
+      virtual void SetTime(double value) override;
+
+      virtual void ComputeElevation(
+          Eigen::Ref<Eigen::MatrixXd> h) override;
+
+      virtual void ComputeElevationDerivatives(
+          Eigen::Ref<Eigen::MatrixXd> dhdx,
+          Eigen::Ref<Eigen::MatrixXd> dhdy) override;
+
+      virtual void ComputeDisplacements(
+          Eigen::Ref<Eigen::MatrixXd> sx,
+          Eigen::Ref<Eigen::MatrixXd> sy) override;
+
+      virtual void ComputeDisplacementsDerivatives(
+          Eigen::Ref<Eigen::MatrixXd> dsxdx,
+          Eigen::Ref<Eigen::MatrixXd> dsydy,
+          Eigen::Ref<Eigen::MatrixXd> dsxdy) override;
+
+      virtual void ComputeDisplacementsAndDerivatives(
+          Eigen::Ref<Eigen::MatrixXd> h,
+          Eigen::Ref<Eigen::MatrixXd> sx,
+          Eigen::Ref<Eigen::MatrixXd> sy,
+          Eigen::Ref<Eigen::MatrixXd> dhdx,
+          Eigen::Ref<Eigen::MatrixXd> dhdy,
+          Eigen::Ref<Eigen::MatrixXd> dsxdx,
+          Eigen::Ref<Eigen::MatrixXd> dsydy,
+          Eigen::Ref<Eigen::MatrixXd> dsxdy) override;
+
+    private:
+      std::unique_ptr<WaveSimulationFFTRefImpl> impl_;
+  };
+}
+}
+
+#endif

--- a/gz-waves/include/gz/waves/WaveSimulationFFTRef.hh
+++ b/gz-waves/include/gz/waves/WaveSimulationFFTRef.hh
@@ -35,9 +35,6 @@ namespace waves
 
       WaveSimulationFFTRef(double lx, double ly, int nx, int ny);
 
-      void SetUseVectorised(bool value);
-
-      /// \brief Set lambda which controls the horizontal wave displacement.
       void SetLambda(double lambda);
 
       virtual void SetWindVelocity(double ux, double uy) override;

--- a/gz-waves/src/CMakeLists.txt
+++ b/gz-waves/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(sources
   WaveParameters.cc
   WaveSimulation.cc
   WaveSimulationFFT.cc
+  WaveSimulationFFTRef.cc
   WaveSimulationSinusoid.cc
   WaveSimulationTrochoid.cc
   WaveSpectrum.cc

--- a/gz-waves/src/CMakeLists.txt
+++ b/gz-waves/src/CMakeLists.txt
@@ -23,7 +23,7 @@ set(sources
   WavefieldSampler.cc
   WaveParameters.cc
   WaveSimulation.cc
-  WaveSimulationFFT2.cc
+  WaveSimulationFFT.cc
   WaveSimulationSinusoid.cc
   WaveSimulationTrochoid.cc
   WaveSpectrum.cc
@@ -42,7 +42,7 @@ set(gtest_sources
   TriangulatedGrid_TEST.cc
   Wavefield_TEST.cc
   WaveSimulation_TEST.cc
-  WaveSimulationFFT2_TEST.cc
+  WaveSimulationFFT_TEST.cc
   WaveSpectrum_TEST.cc
   WaveSpreadingFunction_TEST.cc
 )

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -18,7 +18,7 @@
 #include "gz/common/SubMeshWithTangents.hh"
 #include "gz/waves/Geometry.hh"
 #include "gz/waves/WaveSimulation.hh"
-#include "gz/waves/WaveSimulationFFT2.hh"
+#include "gz/waves/WaveSimulationFFT.hh"
 #include "gz/waves/WaveSimulationSinusoid.hh"
 #include "gz/waves/WaveSimulationTrochoid.hh"
 #include "gz/waves/WaveParameters.hh"
@@ -200,7 +200,7 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
   // Different types of wave simulator are supported...
   // 0 - WaveSimulationSinusoid
   // 1 - WaveSimulationTrochoid
-  // 2 - WaveSimulationFFT2
+  // 2 - WaveSimulationFFT
 
   const int wave_sim_type = 2;
   switch (wave_sim_type)
@@ -237,8 +237,8 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
     case 2:
     {
       // FFT2
-      std::unique_ptr<WaveSimulationFFT2> waveSim(
-          new WaveSimulationFFT2(_L, _L, _N, _N));
+      std::unique_ptr<WaveSimulationFFT> waveSim(
+          new WaveSimulationFFT(_L, _L, _N, _N));
       waveSim->SetLambda(1.0);   // larger lambda => steeper waves.
       mWaveSim = std::move(waveSim);
       break;
@@ -277,7 +277,7 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
   // Different types of wave simulator are supported...
   // 0 - WaveSimulationSinusoid
   // 1 - WaveSimulationTrochoid
-  // 2 - WaveSimulationFFT2
+  // 2 - WaveSimulationFFT
 
   int wave_sim_type = 0;
   if (_params->Algorithm() == "sinusoid")
@@ -324,8 +324,8 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
     case 2:
     {
       // FFT2
-      std::unique_ptr<WaveSimulationFFT2> waveSim(
-          new WaveSimulationFFT2(_L, _L, _N, _N));
+      std::unique_ptr<WaveSimulationFFT> waveSim(
+          new WaveSimulationFFT(_L, _L, _N, _N));
       
       waveSim->SetUseVectorised(false);
       // larger lambda => steeper waves.

--- a/gz-waves/src/WaveSimulationFFT.cc
+++ b/gz-waves/src/WaveSimulationFFT.cc
@@ -15,7 +15,7 @@
 
 
 // The non-vectorised time-dependent update step labelled 'non-vectorised reference version'
-// in WaveSimulationFFT2Impl.ComputeCurrentAmplitudesReference is based on the Curtis Mobley's
+// in WaveSimulationFFTImpl.ComputeCurrentAmplitudesReference is based on the Curtis Mobley's
 // IDL code cgAnimate_2D_SeaSurface.py
 
 //***************************************************************************************************
@@ -27,7 +27,7 @@
 //* of coauthorship.  Further questions can be directed to curtis.mobley@sequoiasci.com.            *
 //***************************************************************************************************
 
-#include "gz/waves/WaveSimulationFFT2.hh"
+#include "gz/waves/WaveSimulationFFT.hh"
 
 #include <complex>
 #include <random>
@@ -40,20 +40,20 @@
 
 #include "gz/waves/WaveSpectrum.hh"
 #include "gz/waves/WaveSpreadingFunction.hh"
-#include "WaveSimulationFFT2Impl.hh"
+#include "WaveSimulationFFTImpl.hh"
 
 namespace gz
 {
 namespace waves
 {
   //////////////////////////////////////////////////
-  WaveSimulationFFT2Impl::~WaveSimulationFFT2Impl()
+  WaveSimulationFFTImpl::~WaveSimulationFFTImpl()
   {
     DestroyFFTWPlans();
   }
 
   //////////////////////////////////////////////////
-  WaveSimulationFFT2Impl::WaveSimulationFFT2Impl(
+  WaveSimulationFFTImpl::WaveSimulationFFTImpl(
     double lx, double ly, int nx, int ny) :
     nx_(nx),
     ny_(ny),
@@ -66,21 +66,21 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::SetUseVectorised(bool value)
+  void WaveSimulationFFTImpl::SetUseVectorised(bool value)
   {
     use_vectorised_ = value;
     ComputeBaseAmplitudes();
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::SetLambda(double value)
+  void WaveSimulationFFTImpl::SetLambda(double value)
   {
     lambda_ = value;
     ComputeBaseAmplitudes();
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::SetWindVelocity(double ux, double uy)
+  void WaveSimulationFFTImpl::SetWindVelocity(double ux, double uy)
   {
     // Update wind velocity and recompute base amplitudes.
     u10_ = sqrt(ux*ux + uy *uy);
@@ -90,13 +90,13 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::SetTime(double time)
+  void WaveSimulationFFTImpl::SetTime(double time)
   {
     ComputeCurrentAmplitudes(time);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeElevation(
+  void WaveSimulationFFTImpl::ComputeElevation(
     Eigen::Ref<Eigen::MatrixXd> h)
   {
     // run the FFT
@@ -108,7 +108,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeElevationDerivatives(
+  void WaveSimulationFFTImpl::ComputeElevationDerivatives(
     Eigen::Ref<Eigen::MatrixXd> dhdx,
     Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
@@ -123,7 +123,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeDisplacements(
+  void WaveSimulationFFTImpl::ComputeDisplacements(
     Eigen::Ref<Eigen::MatrixXd> sx,
     Eigen::Ref<Eigen::MatrixXd> sy)
   {
@@ -138,7 +138,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeDisplacementsDerivatives(
+  void WaveSimulationFFTImpl::ComputeDisplacementsDerivatives(
     Eigen::Ref<Eigen::MatrixXd> dsxdx,
     Eigen::Ref<Eigen::MatrixXd> dsydy,
     Eigen::Ref<Eigen::MatrixXd> dsxdy)
@@ -156,7 +156,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeBaseAmplitudes()
+  void WaveSimulationFFTImpl::ComputeBaseAmplitudes()
   {
     if (use_vectorised_)
       ComputeBaseAmplitudesVectorised();
@@ -165,7 +165,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudes(double time)
+  void WaveSimulationFFTImpl::ComputeCurrentAmplitudes(double time)
   {
     if (use_vectorised_)
       ComputeCurrentAmplitudesVectorised(time);
@@ -174,7 +174,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeBaseAmplitudesNonVectorised()
+  void WaveSimulationFFTImpl::ComputeBaseAmplitudesNonVectorised()
   {
     InitFFTCoeffStorage();
     InitWaveNumbers();
@@ -221,17 +221,17 @@ namespace waves
           if (use_symmetric_spreading_fn_)
           {
             // standing waves - symmetric spreading function
-            cap_psi = WaveSimulationFFT2Impl::ECKVSpreadingFunction(
+            cap_psi = WaveSimulationFFTImpl::ECKVSpreadingFunction(
                 k, phi - phi10_, u10_, cap_omega_c_, gravity_);
           }
           else
           {
             // travelling waves - asymmetric spreading function
-            cap_psi = WaveSimulationFFT2Impl::Cos2sSpreadingFunction(
+            cap_psi = WaveSimulationFFTImpl::Cos2sSpreadingFunction(
                 s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
           }
           const double cap_s =
-              WaveSimulationFFT2Impl::ECKVOmniDirectionalSpectrum(
+              WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
                   k, u10_, cap_omega_c_, gravity_);
           cap_psi_2s_math[idx] = cap_s * cap_psi / k;
         }
@@ -295,7 +295,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesNonVectorised(
+  void WaveSimulationFFTImpl::ComputeCurrentAmplitudesNonVectorised(
       double time)
   {
     // alias
@@ -437,7 +437,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeBaseAmplitudesVectorised()
+  void WaveSimulationFFTImpl::ComputeBaseAmplitudesVectorised()
   {
     // initialise storage
     InitFFTCoeffStorage();
@@ -571,7 +571,7 @@ namespace waves
 #define VECTORISE_ZHAT_CALCS 0
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesVectorised(
+  void WaveSimulationFFTImpl::ComputeCurrentAmplitudesVectorised(
       double time)
   {
     // // time update
@@ -692,7 +692,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeBaseAmplitudesReference()
+  void WaveSimulationFFTImpl::ComputeBaseAmplitudesReference()
   {
     InitFFTCoeffStorage();
     InitWaveNumbers();
@@ -716,7 +716,7 @@ namespace waves
     // 
 
     // debug
-    gzmsg << "WaveSimulationFFT2" << "\n";
+    gzmsg << "WaveSimulationFFT" << "\n";
     gzmsg << "lx:           " << lx_ << "\n";
     gzmsg << "ly:           " << ly_ << "\n";
     gzmsg << "nx:           " << nx_ << "\n";
@@ -779,16 +779,16 @@ namespace waves
           if (use_symmetric_spreading_fn_)
           {
             // standing waves - symmetric spreading function
-            cap_psi = WaveSimulationFFT2Impl::ECKVSpreadingFunction(
+            cap_psi = WaveSimulationFFTImpl::ECKVSpreadingFunction(
                 k, phi - phi10_, u10_, cap_omega_c_, gravity_);
           }
           else
           {
             // travelling waves - asymmetric spreading function
-            cap_psi = WaveSimulationFFT2Impl::Cos2sSpreadingFunction(
+            cap_psi = WaveSimulationFFTImpl::Cos2sSpreadingFunction(
                 s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
           }
-          double cap_s = WaveSimulationFFT2Impl::ECKVOmniDirectionalSpectrum(
+          double cap_s = WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
               k, u10_, cap_omega_c_, gravity_);
           cap_psi_2s_math(ikx, iky) = cap_s * cap_psi / k;
         }
@@ -871,7 +871,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::ComputeCurrentAmplitudesReference(
+  void WaveSimulationFFTImpl::ComputeCurrentAmplitudesReference(
       double time)
   {
     // alias
@@ -986,7 +986,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::InitFFTCoeffStorage()
+  void WaveSimulationFFTImpl::InitFFTCoeffStorage()
   {
     // initialise storage for Fourier coefficients
     fft_h_      = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
@@ -1000,7 +1000,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::InitWaveNumbers()
+  void WaveSimulationFFTImpl::InitWaveNumbers()
   {
     kx_fft_  = Eigen::VectorXd::Zero(nx_);
     ky_fft_  = Eigen::VectorXd::Zero(ny_);
@@ -1049,7 +1049,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::CreateFFTWPlans()
+  void WaveSimulationFFTImpl::CreateFFTWPlans()
   {
     // elevation
     fft_out0_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
@@ -1101,7 +1101,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2Impl::DestroyFFTWPlans()
+  void WaveSimulationFFTImpl::DestroyFFTWPlans()
   {
     fftw_destroy_plan(fft_plan0_);
     fftw_destroy_plan(fft_plan1_);
@@ -1115,7 +1115,7 @@ namespace waves
 
   //////////////////////////////////////////////////
   //////////////////////////////////////////////////
-  double WaveSimulationFFT2Impl::ECKVOmniDirectionalSpectrum(
+  double WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
       double k, double u10, double cap_omega_c, double gravity)
   {
     if (std::abs(k) < 1.0E-8 || std::abs(u10) < 1.0E-8)
@@ -1209,7 +1209,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  double WaveSimulationFFT2Impl::ECKVSpreadingFunction(
+  double WaveSimulationFFTImpl::ECKVSpreadingFunction(
       double k, double phi, double u10, double cap_omega_c, double gravity)
   {
     double g = gravity;
@@ -1230,7 +1230,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  double WaveSimulationFFT2Impl::Cos2sSpreadingFunction(
+  double WaveSimulationFFTImpl::Cos2sSpreadingFunction(
       double s, double phi, double u10, double cap_omega_c, double gravity)
   {
     // Longuet-Higgins et al. 'cosine-2S' spreading function
@@ -1248,50 +1248,50 @@ namespace waves
 
   //////////////////////////////////////////////////
   //////////////////////////////////////////////////
-  WaveSimulationFFT2::~WaveSimulationFFT2()
+  WaveSimulationFFT::~WaveSimulationFFT()
   {
   }
 
   //////////////////////////////////////////////////
-  WaveSimulationFFT2::WaveSimulationFFT2(
+  WaveSimulationFFT::WaveSimulationFFT(
     double lx, double ly, int nx, int ny) :
-    impl_(new WaveSimulationFFT2Impl(lx, ly, nx, ny))
+    impl_(new WaveSimulationFFTImpl(lx, ly, nx, ny))
   {
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::SetUseVectorised(bool value)
+  void WaveSimulationFFT::SetUseVectorised(bool value)
   {
     impl_->SetUseVectorised(value);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::SetLambda(double value)
+  void WaveSimulationFFT::SetLambda(double value)
   {
     impl_->SetLambda(value);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::SetWindVelocity(double ux, double uy)
+  void WaveSimulationFFT::SetWindVelocity(double ux, double uy)
   {
     impl_->SetWindVelocity(ux, uy);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::SetTime(double value)
+  void WaveSimulationFFT::SetTime(double value)
   {
     impl_->SetTime(value);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::ComputeElevation(
+  void WaveSimulationFFT::ComputeElevation(
     Eigen::Ref<Eigen::MatrixXd> h)
   {
     impl_->ComputeElevation(h);
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::ComputeElevationDerivatives(
+  void WaveSimulationFFT::ComputeElevationDerivatives(
     Eigen::Ref<Eigen::MatrixXd> dhdx,
     Eigen::Ref<Eigen::MatrixXd> dhdy)
   {
@@ -1299,7 +1299,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::ComputeDisplacements(
+  void WaveSimulationFFT::ComputeDisplacements(
     Eigen::Ref<Eigen::MatrixXd> sx,
     Eigen::Ref<Eigen::MatrixXd> sy)
   {
@@ -1307,7 +1307,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::ComputeDisplacementsDerivatives(
+  void WaveSimulationFFT::ComputeDisplacementsDerivatives(
     Eigen::Ref<Eigen::MatrixXd> dsxdx,
     Eigen::Ref<Eigen::MatrixXd> dsydy,
     Eigen::Ref<Eigen::MatrixXd> dsxdy)
@@ -1316,7 +1316,7 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFT2::ComputeDisplacementsAndDerivatives(
+  void WaveSimulationFFT::ComputeDisplacementsAndDerivatives(
     Eigen::Ref<Eigen::MatrixXd> h,
     Eigen::Ref<Eigen::MatrixXd> sx,
     Eigen::Ref<Eigen::MatrixXd> sy,

--- a/gz-waves/src/WaveSimulationFFT.cc
+++ b/gz-waves/src/WaveSimulationFFT.cc
@@ -189,6 +189,22 @@ namespace waves
       omega_k_          = Eigen::VectorXd::Zero(n2);
     }
 
+    // spectrum and spreading functions
+    gz::waves::ECKVWaveSpectrum spectrum;
+    spectrum.SetGravity(gravity_);
+    spectrum.SetU10(u10_);
+    spectrum.SetCapOmegaC(cap_omega_c_);
+
+    // standing waves - symmetric spreading function
+    gz::waves::ECKVSpreadingFunction spreadingFn1;
+    spreadingFn1.SetGravity(gravity_);
+    spreadingFn1.SetU10(u10_);
+    spreadingFn1.SetCapOmegaC(cap_omega_c_);
+
+    // travelling waves - asymmetric spreading function
+    gz::waves::Cos2sSpreadingFunction spreadingFn2;
+    spreadingFn2.SetSpread(s_param_);
+
     // continuous two-sided elevation variance spectrum
     Eigen::VectorXd cap_psi_2s_math = Eigen::VectorXd::Zero(nx_ * ny_);
 
@@ -221,18 +237,21 @@ namespace waves
           if (use_symmetric_spreading_fn_)
           {
             // standing waves - symmetric spreading function
-            cap_psi = WaveSimulationFFTImpl::ECKVSpreadingFunction(
-                k, phi - phi10_, u10_, cap_omega_c_, gravity_);
+            cap_psi = spreadingFn1.Evaluate(phi, phi10_, k);
+            // cap_psi = WaveSimulationFFTImpl::ECKVSpreadingFunction(
+            //     k, phi - phi10_, u10_, cap_omega_c_, gravity_);
           }
           else
           {
             // travelling waves - asymmetric spreading function
-            cap_psi = WaveSimulationFFTImpl::Cos2sSpreadingFunction(
-                s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
+            cap_psi = spreadingFn2.Evaluate(phi, phi10_, k);
+            // cap_psi = WaveSimulationFFTImpl::Cos2sSpreadingFunction(
+            //     s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
           }
-          const double cap_s =
-              WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
-                  k, u10_, cap_omega_c_, gravity_);
+          double cap_s = spectrum.Evaluate(k);
+          // double cap_s =
+          //     WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
+          //         k, u10_, cap_omega_c_, gravity_);
           cap_psi_2s_math[idx] = cap_s * cap_psi / k;
         }
       }
@@ -692,300 +711,6 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFTImpl::ComputeBaseAmplitudesReference()
-  {
-    InitFFTCoeffStorage();
-    InitWaveNumbers();
-
-    size_t n2 = nx_ * ny_;
-
-    // arrays for reference version
-    if (cap_psi_2s_root_ref_.size() == 0)
-    {
-      cap_psi_2s_root_ref_ = Eigen::MatrixXd::Zero(nx_, ny_);
-      rho_ref_             = Eigen::MatrixXd::Zero(nx_, ny_);
-      sigma_ref_           = Eigen::MatrixXd::Zero(nx_, ny_);
-      omega_k_ref_         = Eigen::MatrixXd::Zero(nx_, ny_);
-    }
-
-    // Guide to indexing conventions:  1. index, 2. math-order, 3. fft-order
-    // 
-    // 1. [ 0,  1,  2,  3,  4,  5,  6,  7]
-    // 2. [-4, -3, -2, -1,  0,  1,  2,  3]
-    // 3.                 [ 0,  1,  2,  3, -4, -3, -2, -3]
-    // 
-
-    // debug
-    gzmsg << "WaveSimulationFFT" << "\n";
-    gzmsg << "lx:           " << lx_ << "\n";
-    gzmsg << "ly:           " << ly_ << "\n";
-    gzmsg << "nx:           " << nx_ << "\n";
-    gzmsg << "ny:           " << ny_ << "\n";
-    gzmsg << "delta_x:      " << delta_x_ << "\n";
-    gzmsg << "delta_y:      " << delta_y_ << "\n";
-    gzmsg << "lambda_x_f:   " << lambda_x_f_ << "\n";
-    gzmsg << "lambda_y_f:   " << lambda_y_f_ << "\n";
-    gzmsg << "nu_x_f:       " << nu_x_f_ << "\n";
-    gzmsg << "nu_y_f:       " << nu_y_f_ << "\n";
-    gzmsg << "nu_x_nyquist: " << nu_x_nyquist_ << "\n";
-    gzmsg << "nu_y_nyquist: " << nu_y_nyquist_ << "\n";
-    gzmsg << "kx_f:         " << kx_f_ << "\n";
-    gzmsg << "ky_f:         " << ky_f_ << "\n";
-    gzmsg << "kx_nyquist:   " << kx_nyquist_ << "\n";
-    gzmsg << "ky_nyquist:   " << ky_nyquist_ << "\n";
-
-#if 0
-    {
-      std::ostringstream os;
-      os << "[ "; for (auto& v : kx_fft_) os << v << " "; os << "]\n";
-      gzmsg << "kx_fft:      " << os.str();
-    }
-    {
-      std::ostringstream os;
-      os << "[ "; for (auto& v : ky_fft_) os << v << " "; os << "]\n";
-      gzmsg << "ky_fft:      " << os.str();
-    }
-    {
-      std::ostringstream os;
-      os << "[ "; for (auto& v : kx_math_) os << v << " "; os << "]\n";
-      gzmsg << "kx_math:     " << os.str();
-    }
-    {
-      std::ostringstream os;
-      os << "[ "; for (auto& v : ky_math_) os << v << " "; os << "]\n";
-      gzmsg << "ky_math:     " << os.str();
-    }
-#endif
-
-    // continuous two-sided elevation variance spectrum
-    Eigen::MatrixXd cap_psi_2s_math = Eigen::MatrixXd::Zero(nx_, ny_);
-
-    // calculate spectrum in math-order (not vectorised)
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        double k = sqrt(kx_math_[ikx]*kx_math_[ikx]
-            + ky_math_[iky]*ky_math_[iky]);
-        double phi = atan2(ky_math_[iky], kx_math_[ikx]);
-
-        if (k == 0.0)
-        {
-          cap_psi_2s_math(ikx, iky) = 0.0;
-        }
-        else
-        {
-          double cap_psi = 0.0;
-          if (use_symmetric_spreading_fn_)
-          {
-            // standing waves - symmetric spreading function
-            cap_psi = WaveSimulationFFTImpl::ECKVSpreadingFunction(
-                k, phi - phi10_, u10_, cap_omega_c_, gravity_);
-          }
-          else
-          {
-            // travelling waves - asymmetric spreading function
-            cap_psi = WaveSimulationFFTImpl::Cos2sSpreadingFunction(
-                s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
-          }
-          double cap_s = WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
-              k, u10_, cap_omega_c_, gravity_);
-          cap_psi_2s_math(ikx, iky) = cap_s * cap_psi / k;
-        }
-      }
-    }
-
-    // debug
-#if 0
-    {
-      std::ostringstream os;
-      os << "[\n";
-      for (int ikx = 0; ikx < nx_; ++ikx)
-      {
-        os << " [ ";
-        for (auto& v : cap_psi_2s_math[ikx])
-        {
-          os << v << " ";
-        }
-        os << "]\n";
-      }
-      os << "]\n";
-
-      gzmsg << "cap_psi_2s:  " << os.str();
-    }
-#endif
-
-    // convert to fft-order
-    Eigen::MatrixXd cap_psi_2s_fft = Eigen::MatrixXd::Zero(nx_, ny_);
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      int ikx_fft = (ikx + nx_/2) % nx_;
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        int iky_fft = (iky + ny_/2) % ny_;
-        cap_psi_2s_fft(ikx_fft, iky_fft) = cap_psi_2s_math(ikx, iky);
-      }
-    }
-
-    // square-root of two-sided discrete elevation variance spectrum
-    double cap_psi_norm = 0.5;
-    double delta_kx = kx_f_;
-    double delta_ky = ky_f_;
-
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        cap_psi_2s_root_ref_(ikx, iky) =
-            cap_psi_norm * sqrt(cap_psi_2s_fft(ikx, iky) * delta_kx * delta_ky);
-      }
-    }
-
-    // iid random normals for real and imaginary parts of the amplitudes
-    auto seed = std::default_random_engine::default_seed;
-    std::default_random_engine generator(seed);
-    std::normal_distribution<double> distribution(0.0, 1.0);
-
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        rho_ref_(ikx, iky) = distribution(generator);
-        sigma_ref_(ikx, iky) = distribution(generator);
-      }
-    }
-
-    // angular temporal frequency for time-dependent (from dispersion)
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      double kx = kx_fft_[ikx];
-      double kx2 = kx*kx;
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        double ky = ky_fft_[iky];
-        double ky2 = ky*ky;
-        double k = sqrt(kx2 + ky2);
-        omega_k_ref_(ikx, iky) = sqrt(gravity_ * k);
-      }
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void WaveSimulationFFTImpl::ComputeCurrentAmplitudesReference(
-      double time)
-  {
-    // alias
-    const Eigen::Ref<const Eigen::MatrixXd>& r = rho_ref_;
-    const Eigen::Ref<const Eigen::MatrixXd>& s = sigma_ref_;
-    const Eigen::Ref<const Eigen::MatrixXd>& psi_root = cap_psi_2s_root_ref_;
-
-    // time update
-    Eigen::MatrixXd cos_omega_k = Eigen::MatrixXd::Zero(nx_, ny_);
-    Eigen::MatrixXd sin_omega_k = Eigen::MatrixXd::Zero(nx_, ny_);
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        cos_omega_k(ikx, iky) = cos(omega_k_ref_(ikx, iky) * time);
-        sin_omega_k(ikx, iky) = sin(omega_k_ref_(ikx, iky) * time);
-      }
-    }
-
-    // non-vectorised reference version
-    Eigen::MatrixXcd zhat = Eigen::MatrixXcd::Zero(nx_, ny_);
-    for (int ikx = 1; ikx < nx_; ++ikx)
-    {
-      for (int iky = 1; iky < ny_; ++iky)
-      {
-        zhat(ikx, iky) = complex(
-            + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * cos_omega_k(ikx, iky)
-            + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * sin_omega_k(ikx, iky),
-            - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * sin_omega_k(ikx, iky)
-            + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * cos_omega_k(ikx, iky));
-      }
-    }
-
-    for (int iky = 1; iky < ny_/2+1; ++iky)
-    {
-      int ikx = 0;
-      zhat(ikx, iky) = complex(
-          + ( r(ikx, iky) * psi_root(ikx, iky) + r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * cos_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) + s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * sin_omega_k(ikx, iky),
-          - ( r(ikx, iky) * psi_root(ikx, iky) - r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * sin_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) - s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * cos_omega_k(ikx, iky));
-      zhat(ikx, ny_-iky) = std::conj(zhat(ikx, iky));
-    }
-
-    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
-    {
-      int iky = 0;
-      zhat(ikx, iky) = complex(
-          + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * cos_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * sin_omega_k(ikx, iky),
-          - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * sin_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * cos_omega_k(ikx, iky));
-      zhat(nx_-ikx, iky) = std::conj(zhat(ikx, iky));
-    }
-
-    zhat(0, 0) = complex(0.0, 0.0);
-
-    // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
-    const complex iunit(0.0, 1.0);
-    const complex czero(0.0, 0.0);
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      double kx = kx_fft_[ikx];
-      double kx2 = kx*kx;
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        double ky = ky_fft_[iky];
-        double ky2 = ky*ky;
-        double k = sqrt(kx2 + ky2);
-        double ook = 1.0 / k;
-
-        complex h  = zhat(ikx, iky);
-        complex hi = h * iunit;
-        complex hok = h * ook;
-        complex hiok = hi * ook;
-
-        // height (amplitude)
-        fft_h_(ikx, iky) = h;
-
-        // height derivatives
-        complex hikx = hi * kx;
-        complex hiky = hi * ky;
-
-        fft_h_ikx_(ikx, iky) = hi * kx;
-        fft_h_iky_(ikx, iky) = hi * ky;
-
-        // displacement and derivatives
-        if (std::abs(k) < 1.0E-8)
-        {          
-          fft_sx_(ikx, iky)     = czero;
-          fft_sy_(ikx, iky)     = czero;
-          fft_h_kxkx_(ikx, iky) = czero;
-          fft_h_kyky_(ikx, iky) = czero;
-          fft_h_kxky_(ikx, iky) = czero;
-        }
-        else
-        {
-          complex dx  = - hiok * kx;
-          complex dy  = - hiok * ky;
-          complex hkxkx = hok * kx2;
-          complex hkyky = hok * ky2;
-          complex hkxky = hok * kx * ky;
-          
-          fft_sx_(ikx, iky)     = dx;
-          fft_sy_(ikx, iky)     = dy;
-          fft_h_kxkx_(ikx, iky) = hkxkx;
-          fft_h_kyky_(ikx, iky) = hkyky;
-          fft_h_kxky_(ikx, iky) = hkxky;
-        }
-      }
-    }
-  }
-
-  //////////////////////////////////////////////////
   void WaveSimulationFFTImpl::InitFFTCoeffStorage()
   {
     // initialise storage for Fourier coefficients
@@ -1111,139 +836,6 @@ namespace waves
     fftw_destroy_plan(fft_plan5_);
     fftw_destroy_plan(fft_plan6_);
     fftw_destroy_plan(fft_plan7_);
-  }
-
-  //////////////////////////////////////////////////
-  //////////////////////////////////////////////////
-  double WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
-      double k, double u10, double cap_omega_c, double gravity)
-  {
-    if (std::abs(k) < 1.0E-8 || std::abs(u10) < 1.0E-8)
-    {
-      return 0.0;
-    }
-
-    double alpha = 0.0081;
-    double beta = 1.25;
-    double g = gravity;
-    double Cd_10N = 0.00144;
-    double u_star = sqrt(Cd_10N) * u10;
-    double ao = 0.1733;
-    double ap = 4.0;
-    double km = 370.0;
-    double cm = 0.23;
-    double am = 0.13 * u_star / cm;
-    
-    double gamma = 1.7;
-    if (cap_omega_c < 1.0)
-    {
-      gamma = 1.7;
-    }
-    else
-    {
-      gamma = 1.7 + 6.0 * log10(cap_omega_c);
-    }
-
-    double sigma = 0.08 * (1.0 + 4.0 * pow(cap_omega_c, -3.0));
-    double alpha_p = 0.006 * pow(cap_omega_c, 0.55);
-
-    double alpha_m; 
-    if (u_star <= cm)
-    {
-      alpha_m = 0.01 * (1.0 + log(u_star / cm));
-    }
-    else
-    {
-      alpha_m = 0.01 * (1.0 + 3.0 * log(u_star / cm));
-    }
-
-    double ko = g / u10 / u10;
-    double kp = ko * cap_omega_c * cap_omega_c;
-
-    double cp = sqrt(g / kp);
-    double c  = sqrt((g / k) * (1.0 + pow(k / km, 2.0)));
-        
-    double L_PM = exp(-1.25 * pow(kp / k, 2.0));
-    
-    double Gamma = exp(-1.0/(2.0 * pow(sigma, 2.0)) * pow(sqrt(k / kp) - 1.0, 2.0));
-    
-    double J_p = pow(gamma, Gamma);
-    
-    double F_p = L_PM * J_p * exp(-0.3162 * cap_omega_c * (sqrt(k / kp) - 1.0));
-
-    double F_m = L_PM * J_p * exp(-0.25 * pow(k / km - 1.0, 2.0));
-
-    double B_l = 0.5 * alpha_p * (cp / c) * F_p;
-    double B_h = 0.5 * alpha_m * (cm / c) * F_m;
-    
-    double k3 = k * k * k;
-    double S = (B_l + B_h) / k3;
-
-    // debug
-    // gzmsg << "g:       " << g << "\n";
-    // gzmsg << "Omega_c: " << cap_omega_c << "\n";
-    // gzmsg << "Cd10N:   " << Cd_10N << "\n";
-    // gzmsg << "ustar:   " << u_star << "\n";
-    // gzmsg << "ao:      " << ao << "\n";
-    // gzmsg << "ap:      " << ap << "\n";
-    // gzmsg << "cm:      " << cm << "\n";
-    // gzmsg << "am:      " << am << "\n";
-    // gzmsg << "km:      " << km << "\n";
-    // gzmsg << "gamma:   " << gamma << "\n";
-    // gzmsg << "sigma:   " << sigma << "\n";
-    // gzmsg << "alphap:  " << alpha_p << "\n";
-    // gzmsg << "alpham:  " << alpha_m << "\n";
-    // gzmsg << "ko:      " << ko << "\n";
-    // gzmsg << "kp:      " << kp << "\n";
-    // gzmsg << "cp:      " << cp << "\n";
-    // gzmsg << "c:       " << c << "\n";
-    // gzmsg << "Gamma:   " << Gamma << "\n";
-    // gzmsg << "fJp:     " << J_p << "\n";
-    // gzmsg << "fLpm:    " << L_PM << "\n";
-    // gzmsg << "Fp:      " << F_p << "\n";
-    // gzmsg << "Bl:      " << B_l << "\n";
-    // gzmsg << "Fm:      " << F_m << "\n";
-    // gzmsg << "Bh:      " << B_h << "\n";
-    
-    return S;
-  }
-
-  //////////////////////////////////////////////////
-  double WaveSimulationFFTImpl::ECKVSpreadingFunction(
-      double k, double phi, double u10, double cap_omega_c, double gravity)
-  {
-    double g = gravity;
-    double Cd_10N = 0.00144;
-    double u_star = sqrt(Cd_10N) * u10;
-    double ao = 0.1733;
-    double ap = 4.0;
-    double km = 370.0;
-    double cm = 0.23;
-    double am = 0.13 * u_star / cm;
-    double ko = g / u10 / u10;
-    double kp = ko * cap_omega_c * cap_omega_c;
-    double cp = sqrt(g / kp);
-    double c  = sqrt((g / k) * (1 + pow(k / km, 2.0)));
-    double cap_phi = (1 + tanh(ao + ap * pow(c / cp, 2.5)
-        + am * pow(cm / c, 2.5)) * cos(2.0 * phi))/ 2.0 / M_PI;
-    return cap_phi;
-  }
-
-  //////////////////////////////////////////////////
-  double WaveSimulationFFTImpl::Cos2sSpreadingFunction(
-      double s, double phi, double u10, double cap_omega_c, double gravity)
-  {
-    // Longuet-Higgins et al. 'cosine-2S' spreading function
-    //
-    // Eq. (B.18) from Ocean Optics
-
-
-    // Note: s is the spreading parameter and in general
-    // will depend on k, u10, cap_omega_c
-    // s = 2
-    double cap_c_s = std::tgamma(s + 1) / std::tgamma(s + 0.5) / 2 / sqrt(M_PI);
-    double cap_phi = cap_c_s * pow(cos(phi / 2), 2 * s);
-    return cap_phi;
   }
 
   //////////////////////////////////////////////////

--- a/gz-waves/src/WaveSimulationFFT.cc
+++ b/gz-waves/src/WaveSimulationFFT.cc
@@ -238,20 +238,13 @@ namespace waves
           {
             // standing waves - symmetric spreading function
             cap_psi = spreadingFn1.Evaluate(phi, phi10_, k);
-            // cap_psi = WaveSimulationFFTImpl::ECKVSpreadingFunction(
-            //     k, phi - phi10_, u10_, cap_omega_c_, gravity_);
           }
           else
           {
             // travelling waves - asymmetric spreading function
             cap_psi = spreadingFn2.Evaluate(phi, phi10_, k);
-            // cap_psi = WaveSimulationFFTImpl::Cos2sSpreadingFunction(
-            //     s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
           }
           double cap_s = spectrum.Evaluate(k);
-          // double cap_s =
-          //     WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
-          //         k, u10_, cap_omega_c_, gravity_);
           cap_psi_2s_math[idx] = cap_s * cap_psi / k;
         }
       }

--- a/gz-waves/src/WaveSimulationFFT2Impl.hh
+++ b/gz-waves/src/WaveSimulationFFT2Impl.hh
@@ -155,6 +155,12 @@ namespace waves
     fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
     fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
 
+    // precalculated amplitudes (t=0)
+    Eigen::MatrixXd zhat0_rc_;
+    Eigen::MatrixXd zhat0_rs_;
+    Eigen::MatrixXd zhat0_ic_;
+    Eigen::MatrixXd zhat0_is_;
+
     /// \brief Flag to select whether to use vectorised calculations. 
     bool use_vectorised_{false};
 
@@ -217,6 +223,14 @@ namespace waves
     Eigen::VectorXd ky_fft_;
     Eigen::VectorXd kx_math_;
     Eigen::VectorXd ky_math_;
+    Eigen::MatrixXd kx_;
+    Eigen::MatrixXd ky_;
+    Eigen::MatrixXd kx2_;
+    Eigen::MatrixXd ky2_;
+    Eigen::MatrixXd k_;
+    Eigen::MatrixXd k_plus_;
+    Eigen::MatrixXd theta_;
+    Eigen::MatrixXd ook_;
 
     /// \brief Set to 1 to use a symmetric spreading function (standing waves).
     bool use_symmetric_spreading_fn_{false};

--- a/gz-waves/src/WaveSimulationFFTImpl.hh
+++ b/gz-waves/src/WaveSimulationFFTImpl.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef GZ_WAVES_WAVESIMULATIONFFT2_IMPL_HH_
-#define GZ_WAVES_WAVESIMULATIONFFT2_IMPL_HH_
+#ifndef GZ_WAVES_WAVESIMULATIONFFT_IMPL_HH_
+#define GZ_WAVES_WAVESIMULATIONFFT_IMPL_HH_
 
 #include <complex>
 
@@ -51,7 +51,7 @@ namespace gz
 namespace waves
 {
   //////////////////////////////////////////////////
-  // WaveSimulationFFT2Impl
+  // WaveSimulationFFTImpl
 
   typedef double fftw_data_type;
   typedef std::complex<fftw_data_type> complex;
@@ -62,16 +62,16 @@ namespace waves
   ///       must be made consistent and should be column major
   ///       which is the Eigen default..
   ///
-  class WaveSimulationFFT2Impl
+  class WaveSimulationFFTImpl
   {
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     
     /// \brief Destructor 
-    ~WaveSimulationFFT2Impl();
+    ~WaveSimulationFFTImpl();
 
     /// \brief Construct a wave simulation model
-    WaveSimulationFFT2Impl(double lx, double ly, int nx, int ny);
+    WaveSimulationFFTImpl(double lx, double ly, int nx, int ny);
 
     void SetUseVectorised(bool value);
 
@@ -287,7 +287,7 @@ namespace waves
         double gravity=9.81);
 
     /// \brief For testing
-    friend class TestFixtureWaveSimulationFFT2;
+    friend class TestFixtureWaveSimulationFFT;
   };
 }
 }

--- a/gz-waves/src/WaveSimulationFFTImpl.hh
+++ b/gz-waves/src/WaveSimulationFFTImpl.hh
@@ -116,12 +116,6 @@ namespace waves
     void ComputeBaseAmplitudesVectorised();
     void ComputeCurrentAmplitudesVectorised(double time);
 
-    /// \brief Reference implementation of base amplitude calculation
-    void ComputeBaseAmplitudesReference();
-
-    /// \brief Reference implementation of time-dependent amplitude calculation
-    void ComputeCurrentAmplitudesReference(double time);
-
     void InitFFTCoeffStorage();
     void InitWaveNumbers();
 
@@ -188,35 +182,13 @@ namespace waves
     /// \brief Parameter controlling the maturity of the sea state.
     double  cap_omega_c_{0.84};
 
-    // derived quantities
-
     // sample spacing [m]
     double  delta_x_{lx_ / nx_};
     double  delta_y_{ly_ / ny_};
 
-    // fundamental wavelength [m]
-    double  lambda_x_f_{lx_};
-    double  lambda_y_f_{ly_};
-
-    // nyquist wavelength [m]
-    double  lambda_x_nyquist_{2.0 * delta_x_};
-    double  lambda_y_nyquist_{2.0 * delta_y_};
-
-    // fundamental spatial frequency [1/m]
-    double  nu_x_f_{1.0 / lx_};
-    double  nu_y_f_{1.0 / ly_};
-
-    // nyquist spatial frequency [1/m]
-    double  nu_x_nyquist_{1.0 / (2.0 * delta_x_)};
-    double  nu_y_nyquist_{1.0 / (2.0 * delta_y_)};
-
     // fundamental angular spatial frequency [rad/m]
     double  kx_f_{2.0 * M_PI / lx_};
     double  ky_f_{2.0 * M_PI / ly_};
-
-    // nyquist angular spatial frequency [rad/m]
-    double  kx_nyquist_{kx_f_ * nx_ / 2.0};
-    double  ky_nyquist_{ky_f_ * ny_ / 2.0};
 
     // angular spatial frequencies in fft and math order
     Eigen::VectorXd kx_fft_;
@@ -262,29 +234,6 @@ namespace waves
 
     // angular temporal frequency
     Eigen::MatrixXd omega_k_vec_;
-
-    //////////////////////////////////////////////////
-    /// \note: use 2d array storage for reference version, resized if required
-
-    // square-root of two-sided discrete elevation variance spectrum
-    Eigen::MatrixXd cap_psi_2s_root_ref_;
-
-    // iid random normals for real and imaginary parts of the amplitudes
-    Eigen::MatrixXd rho_ref_;
-    Eigen::MatrixXd sigma_ref_;
-
-    // angular temporal frequency
-    Eigen::MatrixXd omega_k_ref_;
-
-    static double ECKVOmniDirectionalSpectrum(
-        double k, double u10, double cap_omega_c=0.84,
-        double gravity=9.81);
-    static double ECKVSpreadingFunction(
-        double k, double phi, double u10, double cap_omega_c=0.84,
-        double gravity=9.81);
-    static double Cos2sSpreadingFunction(
-        double s_param, double phi, double u10, double cap_omega_c=0.84,
-        double gravity=9.81);
 
     /// \brief For testing
     friend class TestFixtureWaveSimulationFFT;

--- a/gz-waves/src/WaveSimulationFFTRef.cc
+++ b/gz-waves/src/WaveSimulationFFTRef.cc
@@ -13,10 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
-// The non-vectorised time-dependent update step labelled 'non-vectorised reference version'
-// in WaveSimulationFFTImpl.ComputeCurrentAmplitudesReference is based on the Curtis Mobley's
-// IDL code cgAnimate_2D_SeaSurface.py
+// Attribution:
+// The time-dependent update step in ComputeCurrentAmplitudes is based
+// on the Curtis Mobley's IDL code cgAnimate_2D_SeaSurface.py
 
 //***************************************************************************************************
 //* This code is copyright (c) 2016 by Curtis D. Mobley.                                            *
@@ -38,8 +37,6 @@
 
 #include <gz/common.hh>
 
-#include "gz/waves/WaveSpectrum.hh"
-#include "gz/waves/WaveSpreadingFunction.hh"
 #include "WaveSimulationFFTRefImpl.hh"
 
 namespace gz
@@ -63,13 +60,6 @@ namespace waves
   {
     ComputeBaseAmplitudes();
     CreateFFTWPlans();
-  }
-
-  //////////////////////////////////////////////////
-  void WaveSimulationFFTRefImpl::SetUseVectorised(bool value)
-  {
-    use_vectorised_ = value;
-    ComputeBaseAmplitudes();
   }
 
   //////////////////////////////////////////////////
@@ -158,554 +148,18 @@ namespace waves
   //////////////////////////////////////////////////
   void WaveSimulationFFTRefImpl::ComputeBaseAmplitudes()
   {
-    if (use_vectorised_)
-      ComputeBaseAmplitudesVectorised();
-    else
-      ComputeBaseAmplitudesNonVectorised();
-  }
-
-  //////////////////////////////////////////////////
-  void WaveSimulationFFTRefImpl::ComputeCurrentAmplitudes(double time)
-  {
-    if (use_vectorised_)
-      ComputeCurrentAmplitudesVectorised(time);
-    else
-      ComputeCurrentAmplitudesNonVectorised(time);
-  }
-
-  //////////////////////////////////////////////////
-  void WaveSimulationFFTRefImpl::ComputeBaseAmplitudesNonVectorised()
-  {
-    InitFFTCoeffStorage();
-    InitWaveNumbers();
-
-    // initialise arrays
-    size_t n2 = nx_ * ny_;
-    if (cap_psi_2s_root_.size() == 0)
-    {
-      cap_psi_2s_root_  = Eigen::VectorXd::Zero(n2);
-      rho_              = Eigen::VectorXd::Zero(n2);
-      sigma_            = Eigen::VectorXd::Zero(n2);
-      omega_k_          = Eigen::VectorXd::Zero(n2);
-    }
-
-    // continuous two-sided elevation variance spectrum
-    Eigen::VectorXd cap_psi_2s_math = Eigen::VectorXd::Zero(nx_ * ny_);
-
-    // calculate spectrum in math-order (not vectorised)
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      // kx: fftfreq and ifftshift
-      const double kx = (ikx - nx_/2) * kx_f_;
-      const double kx2 = kx*kx;
-
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        // ky: fftfreq and ifftshift
-        const double ky = (iky - ny_/2) * ky_f_;
-        const double ky2 = ky*ky;
-        
-        const double k = sqrt(kx2 + ky2);
-        const double phi = atan2(ky, kx);
-
-        // index for flattened array
-        int idx = ikx * ny_ + iky;
-
-        if (k == 0.0)
-        {
-          cap_psi_2s_math[idx] = 0.0;
-        }
-        else
-        {
-          double cap_psi = 0.0;
-          if (use_symmetric_spreading_fn_)
-          {
-            // standing waves - symmetric spreading function
-            cap_psi = WaveSimulationFFTRefImpl::ECKVSpreadingFunction(
-                k, phi - phi10_, u10_, cap_omega_c_, gravity_);
-          }
-          else
-          {
-            // travelling waves - asymmetric spreading function
-            cap_psi = WaveSimulationFFTRefImpl::Cos2sSpreadingFunction(
-                s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
-          }
-          const double cap_s =
-              WaveSimulationFFTRefImpl::ECKVOmniDirectionalSpectrum(
-                  k, u10_, cap_omega_c_, gravity_);
-          cap_psi_2s_math[idx] = cap_s * cap_psi / k;
-        }
-      }
-    }
-
-    // convert to fft-order
-    Eigen::VectorXd cap_psi_2s_fft = Eigen::VectorXd::Zero(nx_ * ny_);
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      int ikx_fft = (ikx + nx_/2) % nx_;
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        int iky_fft = (iky + ny_/2) % ny_;
-
-        // index for flattened array
-        int idx = ikx * ny_ + iky;
-        int idx_fft = ikx_fft * ny_ + iky_fft;
-
-        cap_psi_2s_fft[idx_fft] = cap_psi_2s_math[idx];
-      }
-    }
-
-    // square-root of two-sided discrete elevation variance spectrum
-    double cap_psi_norm = 0.5;
-    double delta_kx = kx_f_;
-    double delta_ky = ky_f_;
-    // double c1 = cap_psi_norm * sqrt(delta_kx * delta_ky);
-
-    // iid random normals for real and imaginary parts of the amplitudes
-    auto seed = std::default_random_engine::default_seed;
-    std::default_random_engine generator(seed);
-    std::normal_distribution<double> distribution(0.0, 1.0);
-
-    for (int i = 0; i < n2; ++i)
-    {
-      // cap_psi_2s_root[i] = c1 * sqrt(cap_psi_2s_fft[i]);
-      cap_psi_2s_root_[i] =
-          cap_psi_norm * sqrt(cap_psi_2s_fft[i] * delta_kx * delta_ky);
-
-      rho_[i] = distribution(generator);
-      sigma_[i] = distribution(generator);
-    }
-
-    // angular temporal frequency for time-dependent (from dispersion)
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      double kx = kx_fft_[ikx];
-      double kx2 = kx*kx;
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        double ky = ky_fft_[iky];
-        double ky2 = ky*ky;
-        double k = sqrt(kx2 + ky2);
-
-        // index for flattened array
-        int idx = ikx * ny_ + iky;
-        omega_k_[idx] = sqrt(gravity_ * k);
-      }
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void WaveSimulationFFTRefImpl::ComputeCurrentAmplitudesNonVectorised(
-      double time)
-  {
-    // alias
-    const Eigen::Ref<const Eigen::VectorXd>& r = rho_;
-    const Eigen::Ref<const Eigen::VectorXd>& s = sigma_;
-    const Eigen::Ref<const Eigen::VectorXd>& psi_root = cap_psi_2s_root_;
-
-    // time update
-    Eigen::VectorXd cos_omega_k = Eigen::VectorXd::Zero(nx_ * ny_);
-    Eigen::VectorXd sin_omega_k = Eigen::VectorXd::Zero(nx_ * ny_);
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        // index for flattened array
-        int idx = ikx * ny_ + iky;
-
-        double omega_t = omega_k_[idx] * time;
-        cos_omega_k(idx) = cos(omega_t);
-        sin_omega_k(idx) = sin(omega_t);
-      }
-    }
-
-    // flattened index version
-    Eigen::VectorXcd zhat = Eigen::VectorXcd::Zero(nx_ * ny_);
-    for (int ikx = 1; ikx < nx_; ++ikx)
-    {
-      for (int iky = 1; iky < ny_; ++iky)
-      {
-        // index for flattened array (ikx, iky)
-        int idx = ikx * ny_ + iky;
-
-        // index for conjugate (nx_-ikx, ny_-iky)
-        int cdx = (nx_-ikx) * ny_ + (ny_-iky);
-
-        zhat[idx] = complex(
-            + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
-            + ( s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx) ) * sin_omega_k(idx),
-            - ( r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx) ) * sin_omega_k(idx)
-            + ( s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx) ) * cos_omega_k(idx));
-      }
-    }
-
-    for (int iky = 1; iky < ny_/2+1; ++iky)
-    {
-      int ikx = 0;
-
-      // index for flattened array (ikx, iky)
-      int idx = ikx * ny_ + iky;
-
-      // index for conjugate (ikx, ny_-iky)
-      int cdx = ikx * ny_ + (ny_-iky);
-
-      zhat[idx] = complex(
-          + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
-          + ( s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx) ) * sin_omega_k(idx),
-          - ( r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx) ) * sin_omega_k(idx)
-          + ( s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx) ) * cos_omega_k(idx));
-      zhat[cdx] = std::conj(zhat[idx]);
-    }
-
-    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
-    {
-      int iky = 0;
-
-      // index for flattened array (ikx, iky)
-      int idx = ikx * ny_ + iky;
-
-      // index for conjugate (nx_-ikx, iky)
-      int cdx = (nx_-ikx) * ny_ + iky;
-
-      zhat[idx] = complex(
-          + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
-          + ( s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx) ) * sin_omega_k(idx),
-          - ( r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx) ) * sin_omega_k(idx)
-          + ( s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx) ) * cos_omega_k(idx));
-      zhat[cdx] = std::conj(zhat[idx]);
-    }
-
-    zhat[0] = complex(0.0, 0.0);
-
-    // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
-    const complex iunit(0.0, 1.0);
-    const complex czero(0.0, 0.0);
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      double kx = kx_fft_[ikx];
-      double kx2 = kx*kx;
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        double ky = ky_fft_[iky];
-        double ky2 = ky*ky;
-        double k = sqrt(kx2 + ky2);
-        double ook = 1.0 / k;
-
-        // index for flattened arrays
-        int idx = ikx * ny_ + iky;
-
-        complex h  = zhat[idx];
-        complex hi = h * iunit;
-        complex hok = h * ook;
-        complex hiok = hi * ook;
-
-        // height (amplitude)
-        fft_h_(ikx, iky) = h;
-
-        // height derivatives
-        complex hikx = hi * kx;
-        complex hiky = hi * ky;
-
-        fft_h_ikx_(ikx, iky) = hi * kx;
-        fft_h_iky_(ikx, iky) = hi * ky;
-
-        // displacement and derivatives
-        if (std::abs(k) < 1.0E-8)
-        {          
-          fft_sx_(ikx, iky)     = czero;
-          fft_sy_(ikx, iky)     = czero;
-          fft_h_kxkx_(ikx, iky) = czero;
-          fft_h_kyky_(ikx, iky) = czero;
-          fft_h_kxky_(ikx, iky) = czero;
-        }
-        else
-        {
-          complex dx  = - hiok * kx;
-          complex dy  = - hiok * ky;
-          complex hkxkx = hok * kx2;
-          complex hkyky = hok * ky2;
-          complex hkxky = hok * kx * ky;
-          
-          fft_sx_(ikx, iky)     = dx;
-          fft_sy_(ikx, iky)     = dy;
-          fft_h_kxkx_(ikx, iky) = hkxkx;
-          fft_h_kyky_(ikx, iky) = hkyky;
-          fft_h_kxky_(ikx, iky) = hkxky;
-        }
-      }
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void WaveSimulationFFTRefImpl::ComputeBaseAmplitudesVectorised()
-  {
-    // initialise storage
-    InitFFTCoeffStorage();
-    InitWaveNumbers();
-
-    // initialise arrays
-    if (cap_psi_2s_root_vec_.size() == 0)
-    {
-      cap_psi_2s_root_vec_ = Eigen::MatrixXd::Zero(nx_, ny_);
-      rho_vec_             = Eigen::MatrixXd::Zero(nx_, ny_);
-      sigma_vec_           = Eigen::MatrixXd::Zero(nx_, ny_);
-      omega_k_vec_         = Eigen::MatrixXd::Zero(nx_, ny_);
-    }
-
-    // spectrum and spreading functions
-    gz::waves::ECKVWaveSpectrum spectrum;
-    spectrum.SetGravity(gravity_);
-    spectrum.SetU10(u10_);
-    spectrum.SetCapOmegaC(cap_omega_c_);
-
-    // standing waves - symmetric spreading function
-    gz::waves::ECKVSpreadingFunction spreadingFn1;
-    spreadingFn1.SetGravity(gravity_);
-    spreadingFn1.SetU10(u10_);
-    spreadingFn1.SetCapOmegaC(cap_omega_c_);
-
-    // travelling waves - asymmetric spreading function
-    gz::waves::Cos2sSpreadingFunction spreadingFn2;
-    spreadingFn2.SetSpread(s_param_);
-
-    // broadcast (fft) wavenumbers to arrays (aka meshgrid)
-    Eigen::MatrixXd kx = Eigen::MatrixXd::Zero(nx_, ny_);
-    Eigen::MatrixXd ky = Eigen::MatrixXd::Zero(nx_, ny_);
-    kx.colwise() += kx_fft_;
-    ky.rowwise() += ky_fft_.transpose();
-
-    // wavenumber and wave angle arrays
-    Eigen::MatrixXd kx2 = Eigen::pow(kx.array(), 2.0);
-    Eigen::MatrixXd ky2 = Eigen::pow(ky.array(), 2.0);
-    Eigen::MatrixXd k   = Eigen::sqrt(kx2.array() + ky2.array());
-    Eigen::MatrixXd theta = ky.binaryExpr(
-        kx, [] (double y, double x) { return std::atan2(y, x);}
-    );
-
-    // evaluate spectrum
-    Eigen::MatrixXd cap_s = Eigen::MatrixXd::Zero(nx_, ny_);
-    spectrum.Evaluate(cap_s, k);
-
-    Eigen::MatrixXd cap_psi = Eigen::MatrixXd::Zero(nx_, ny_);
-    if (use_symmetric_spreading_fn_)
-      spreadingFn1.Evaluate(cap_psi, theta, phi10_, k);
-    else
-      spreadingFn2.Evaluate(cap_psi, theta, phi10_, k);
-
-    // array k1 has no zero elements
-    Eigen::MatrixXd k1 = (k.array() == 0).select(
-        Eigen::MatrixXd::Ones(nx_, ny_), k);
-
-    // evaluate continuous two-sided elevation variance spectrum for k1 != 0
-    Eigen::MatrixXd cap_psi_2s_fft =
-        cap_s.array() * cap_psi.array() / k1.array();
-
-    // apply filter for k == 0
-    cap_psi_2s_fft = (k.array() == 0).select(
-        Eigen::MatrixXd::Zero(nx_, ny_), cap_psi_2s_fft);
-
-    // square-root of two-sided discrete elevation variance spectrum
-    double cap_psi_norm = 0.5;
-    double delta_kx = kx_f_;
-    double delta_ky = ky_f_;
-    cap_psi_2s_root_vec_ = cap_psi_norm * Eigen::sqrt(
-        cap_psi_2s_fft.array() * delta_kx * delta_ky);
-
-    /// \note vectorising the initialisation of rho and sigma will
-    ///       alter the order, and break the cross checks.
-    // iid random normals for real and imaginary parts of the amplitudes
-    auto seed = std::default_random_engine::default_seed;
-    std::default_random_engine generator(seed);
-    std::normal_distribution<double> distribution(0.0, 1.0);
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        rho_vec_(ikx, iky) = distribution(generator);
-        sigma_vec_(ikx, iky) = distribution(generator);
-      }
-    }
-
-    // angular temporal frequency for time-dependent (from dispersion)
-    omega_k_vec_ = Eigen::sqrt(gravity_ * k.array());
-
-    // calculate zhat0
-    const Eigen::Ref<const Eigen::MatrixXd>& r = rho_vec_;
-    const Eigen::Ref<const Eigen::MatrixXd>& s = sigma_vec_;
-    const Eigen::Ref<const Eigen::MatrixXd>& psi_root = cap_psi_2s_root_vec_;
-
-    zhat0_rc_ = Eigen::MatrixXd::Zero(nx_, ny_);
-    zhat0_rs_ = Eigen::MatrixXd::Zero(nx_, ny_);
-    zhat0_ic_ = Eigen::MatrixXd::Zero(nx_, ny_);
-    zhat0_is_ = Eigen::MatrixXd::Zero(nx_, ny_);
-    for (int ikx = 1; ikx < nx_; ++ikx)
-    {
-      for (int iky = 1; iky < ny_; ++iky)
-      {
-        zhat0_rc_(ikx, iky) = + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ); 
-        zhat0_rs_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ); 
-        zhat0_is_(ikx, iky) = - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) );
-        zhat0_ic_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ); 
-      }
-    }
-
-    for (int iky = 1; iky < ny_/2+1; ++iky)
-    {
-      int ikx = 0;
-      zhat0_rc_(ikx, iky) = + ( r(ikx, iky) * psi_root(ikx, iky) + r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) );
-      zhat0_rs_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) + s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) );
-      zhat0_is_(ikx, iky) = - ( r(ikx, iky) * psi_root(ikx, iky) - r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) );
-      zhat0_ic_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) - s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) );
-    }
-
-    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
-    {
-      int iky = 0;
-      zhat0_rc_(ikx, iky) = + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) );
-      zhat0_rs_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) );
-      zhat0_is_(ikx, iky) = - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) );
-      zhat0_ic_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) );
-    }
-  }
-
-#define VECTORISE_ZHAT_CALCS 0
-
-  //////////////////////////////////////////////////
-  void WaveSimulationFFTRefImpl::ComputeCurrentAmplitudesVectorised(
-      double time)
-  {
-    // // time update
-    Eigen::MatrixXd wt = omega_k_vec_.array() * time;
-    Eigen::MatrixXd cos_omega_k = Eigen::cos(wt.array());
-    Eigen::MatrixXd sin_omega_k = Eigen::sin(wt.array());
-
-    // non-vectorised reference version
-    Eigen::MatrixXcdRowMajor zhat = Eigen::MatrixXcd::Zero(nx_, ny_);
-    for (int ikx = 1; ikx < nx_; ++ikx)
-    {
-      for (int iky = 1; iky < ny_; ++iky)
-      {
-        zhat(ikx, iky) = complex(
-            + zhat0_rc_(ikx, iky) * cos_omega_k(ikx, iky)
-            + zhat0_rs_(ikx, iky) * sin_omega_k(ikx, iky),
-            + zhat0_is_(ikx, iky) * sin_omega_k(ikx, iky)
-            + zhat0_ic_(ikx, iky) * cos_omega_k(ikx, iky));
-      }
-    }
-
-    for (int iky = 1; iky < ny_/2+1; ++iky)
-    {
-      int ikx = 0;
-      zhat(ikx, iky) = complex(
-          + zhat0_rc_(ikx, iky) * cos_omega_k(ikx, iky)
-          + zhat0_rs_(ikx, iky) * sin_omega_k(ikx, iky),
-          + zhat0_is_(ikx, iky) * sin_omega_k(ikx, iky)
-          + zhat0_ic_(ikx, iky) * cos_omega_k(ikx, iky));
-      zhat(ikx, ny_-iky) = std::conj(zhat(ikx, iky));
-    }
-
-    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
-    {
-      int iky = 0;
-      zhat(ikx, iky) = complex(
-          + zhat0_rc_(ikx, iky) * cos_omega_k(ikx, iky)
-          + zhat0_rs_(ikx, iky) * sin_omega_k(ikx, iky),
-          + zhat0_is_(ikx, iky) * sin_omega_k(ikx, iky)
-          + zhat0_ic_(ikx, iky) * cos_omega_k(ikx, iky));
-      zhat(nx_-ikx, iky) = std::conj(zhat(ikx, iky));
-    }
-
-    zhat(0, 0) = complex(0.0, 0.0);
-
-    // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
-    const complex iunit(0.0, 1.0);
-    const complex czero(0.0, 0.0);
-
-/// \note array version is not faster than the loop.
-#if VECTORISE_ZHAT_CALCS
-    { // vectorised version: note: ook_ evaluates to zero when abs(k) < 1.0E-8
-      fft_h_      = zhat; //h
-      fft_h_ikx_  = zhat.array() * iunit * kx_.array(); //hikx
-      fft_h_iky_  = zhat.array() * iunit * ky_.array(); //hiky
-      fft_sx_     = zhat.array() * iunit * ook_.array() * kx_.array() * -1; //dx
-      fft_sy_     = zhat.array() * iunit * ook_.array() * ky_.array() * -1; //dy
-      fft_h_kxkx_ = zhat.array() * ook_.array() * kx2_.array(); //hkxkx
-      fft_h_kyky_ = zhat.array() * ook_.array() * ky2_.array(); //hkyky
-      fft_h_kxky_ = zhat.array() * ook_.array() * kx_.array() * ky_.array(); //hkxky
-    }
-#else
-    // loop version
-    for (int ikx = 0; ikx < nx_; ++ikx)
-    {
-      double kx = kx_fft_[ikx];
-      double kx2 = kx*kx;
-      for (int iky = 0; iky < ny_; ++iky)
-      {
-        double ky = ky_fft_[iky];
-        double ky2 = ky*ky;
-        double k = sqrt(kx2 + ky2);
-
-        // elevation
-        complex h = zhat(ikx, iky);
-        complex hi = h * iunit;
-
-        // elevation derivatives
-        complex hikx = hi * kx;
-        complex hiky = hi * ky;
-
-        fft_h_(ikx, iky) = h;
-        fft_h_ikx_(ikx, iky) = hikx;
-        fft_h_iky_(ikx, iky) = hiky;
-
-        // displacement and derivatives
-        if (std::abs(k) < 1.0E-8)
-        {          
-          fft_sx_(ikx, iky) = czero;
-          fft_sy_(ikx, iky) = czero;
-          fft_h_kxkx_(ikx, iky) = czero;
-          fft_h_kyky_(ikx, iky) = czero;
-          fft_h_kxky_(ikx, iky) = czero;
-        }
-        else
-        {
-          // displacements
-          double ook = 1.0 / k;
-          complex hok = h * ook;
-          complex hiok = hi * ook;
-          complex dx = - hiok * kx;
-          complex dy = - hiok * ky;
-
-          // displacements derivatives
-          complex hkxkx = hok * kx2;
-          complex hkyky = hok * ky2;
-          complex hkxky = hok * kx * ky;
-          
-          fft_sx_(ikx, iky) = dx;
-          fft_sy_(ikx, iky) = dy;
-          fft_h_kxkx_(ikx, iky) = hkxkx;
-          fft_h_kyky_(ikx, iky) = hkyky;
-          fft_h_kxky_(ikx, iky) = hkxky;
-        }
-      }
-    }
-#endif
-  }
-
-  //////////////////////////////////////////////////
-  void WaveSimulationFFTRefImpl::ComputeBaseAmplitudesReference()
-  {
     InitFFTCoeffStorage();
     InitWaveNumbers();
 
     size_t n2 = nx_ * ny_;
 
     // arrays for reference version
-    if (cap_psi_2s_root_ref_.size() == 0)
+    if (cap_psi_2s_root_.size() == 0)
     {
-      cap_psi_2s_root_ref_ = Eigen::MatrixXd::Zero(nx_, ny_);
-      rho_ref_             = Eigen::MatrixXd::Zero(nx_, ny_);
-      sigma_ref_           = Eigen::MatrixXd::Zero(nx_, ny_);
-      omega_k_ref_         = Eigen::MatrixXd::Zero(nx_, ny_);
+      cap_psi_2s_root_ = Eigen::MatrixXd::Zero(nx_, ny_);
+      rho_             = Eigen::MatrixXd::Zero(nx_, ny_);
+      sigma_           = Eigen::MatrixXd::Zero(nx_, ny_);
+      omega_k_         = Eigen::MatrixXd::Zero(nx_, ny_);
     }
 
     // Guide to indexing conventions:  1. index, 2. math-order, 3. fft-order
@@ -715,24 +169,48 @@ namespace waves
     // 3.                 [ 0,  1,  2,  3, -4, -3, -2, -3]
     // 
 
+    // sample spacing [m]
+    double  delta_x{lx_ / nx_};
+    double  delta_y{ly_ / ny_};
+
+    // fundamental wavelength [m]
+    double  lambda_x_f{lx_};
+    double  lambda_y_f{ly_};
+
+    // nyquist wavelength [m]
+    double  lambda_x_nyquist{2.0 * delta_x};
+    double  lambda_y_nyquist{2.0 * delta_y};
+
+    // fundamental spatial frequency [1/m]
+    double  nu_x_f{1.0 / lx_};
+    double  nu_y_f{1.0 / ly_};
+
+    // nyquist spatial frequency [1/m]
+    double  nu_x_nyquist{1.0 / (2.0 * delta_x)};
+    double  nu_y_nyquist{1.0 / (2.0 * delta_y)};
+
+    // nyquist angular spatial frequency [rad/m]
+    double  kx_nyquist{kx_f_ * nx_ / 2.0};
+    double  ky_nyquist{ky_f_ * ny_ / 2.0};
+
     // debug
     gzmsg << "WaveSimulationFFTRef" << "\n";
     gzmsg << "lx:           " << lx_ << "\n";
     gzmsg << "ly:           " << ly_ << "\n";
     gzmsg << "nx:           " << nx_ << "\n";
     gzmsg << "ny:           " << ny_ << "\n";
-    gzmsg << "delta_x:      " << delta_x_ << "\n";
-    gzmsg << "delta_y:      " << delta_y_ << "\n";
-    gzmsg << "lambda_x_f:   " << lambda_x_f_ << "\n";
-    gzmsg << "lambda_y_f:   " << lambda_y_f_ << "\n";
-    gzmsg << "nu_x_f:       " << nu_x_f_ << "\n";
-    gzmsg << "nu_y_f:       " << nu_y_f_ << "\n";
-    gzmsg << "nu_x_nyquist: " << nu_x_nyquist_ << "\n";
-    gzmsg << "nu_y_nyquist: " << nu_y_nyquist_ << "\n";
+    gzmsg << "delta_x:      " << delta_x << "\n";
+    gzmsg << "delta_y:      " << delta_y << "\n";
+    gzmsg << "lambda_x_f:   " << lambda_x_f << "\n";
+    gzmsg << "lambda_y_f:   " << lambda_y_f << "\n";
+    gzmsg << "nu_x_f:       " << nu_x_f << "\n";
+    gzmsg << "nu_y_f:       " << nu_y_f << "\n";
+    gzmsg << "nu_x_nyquist: " << nu_x_nyquist << "\n";
+    gzmsg << "nu_y_nyquist: " << nu_y_nyquist << "\n";
     gzmsg << "kx_f:         " << kx_f_ << "\n";
     gzmsg << "ky_f:         " << ky_f_ << "\n";
-    gzmsg << "kx_nyquist:   " << kx_nyquist_ << "\n";
-    gzmsg << "ky_nyquist:   " << ky_nyquist_ << "\n";
+    gzmsg << "kx_nyquist:   " << kx_nyquist << "\n";
+    gzmsg << "ky_nyquist:   " << ky_nyquist << "\n";
 
 #if 0
     {
@@ -836,7 +314,7 @@ namespace waves
     {
       for (int iky = 0; iky < ny_; ++iky)
       {
-        cap_psi_2s_root_ref_(ikx, iky) =
+        cap_psi_2s_root_(ikx, iky) =
             cap_psi_norm * sqrt(cap_psi_2s_fft(ikx, iky) * delta_kx * delta_ky);
       }
     }
@@ -850,8 +328,8 @@ namespace waves
     {
       for (int iky = 0; iky < ny_; ++iky)
       {
-        rho_ref_(ikx, iky) = distribution(generator);
-        sigma_ref_(ikx, iky) = distribution(generator);
+        rho_(ikx, iky) = distribution(generator);
+        sigma_(ikx, iky) = distribution(generator);
       }
     }
 
@@ -865,19 +343,19 @@ namespace waves
         double ky = ky_fft_[iky];
         double ky2 = ky*ky;
         double k = sqrt(kx2 + ky2);
-        omega_k_ref_(ikx, iky) = sqrt(gravity_ * k);
+        omega_k_(ikx, iky) = sqrt(gravity_ * k);
       }
     }
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationFFTRefImpl::ComputeCurrentAmplitudesReference(
+  void WaveSimulationFFTRefImpl::ComputeCurrentAmplitudes(
       double time)
   {
     // alias
-    const Eigen::Ref<const Eigen::MatrixXd>& r = rho_ref_;
-    const Eigen::Ref<const Eigen::MatrixXd>& s = sigma_ref_;
-    const Eigen::Ref<const Eigen::MatrixXd>& psi_root = cap_psi_2s_root_ref_;
+    const Eigen::Ref<const Eigen::MatrixXd>& r = rho_;
+    const Eigen::Ref<const Eigen::MatrixXd>& s = sigma_;
+    const Eigen::Ref<const Eigen::MatrixXd>& psi_root = cap_psi_2s_root_;
 
     // time update
     Eigen::MatrixXd cos_omega_k = Eigen::MatrixXd::Zero(nx_, ny_);
@@ -886,8 +364,8 @@ namespace waves
     {
       for (int iky = 0; iky < ny_; ++iky)
       {
-        cos_omega_k(ikx, iky) = cos(omega_k_ref_(ikx, iky) * time);
-        sin_omega_k(ikx, iky) = sin(omega_k_ref_(ikx, iky) * time);
+        cos_omega_k(ikx, iky) = cos(omega_k_(ikx, iky) * time);
+        sin_omega_k(ikx, iky) = sin(omega_k_(ikx, iky) * time);
       }
     }
 
@@ -1021,31 +499,6 @@ namespace waves
       ky_math_(iky) = ky;
       ky_fft_((iky + ny_/2) % ny_) = ky;
     }
-
-#if VECTORISE_ZHAT_CALCS
-    // broadcast (fft) wavenumbers to arrays (aka meshgrid)
-    kx_ = Eigen::MatrixXd::Zero(nx_, ny_);
-    ky_ = Eigen::MatrixXd::Zero(nx_, ny_);
-    kx_.colwise() += kx_fft_;
-    ky_.rowwise() += ky_fft_.transpose();
-
-    // wavenumber and wave angle arrays
-    kx2_ = Eigen::pow(kx_.array(), 2.0);
-    ky2_ = Eigen::pow(ky_.array(), 2.0);
-    k_   = Eigen::sqrt(kx2_.array() + ky2_.array());
-    theta_ = ky_.binaryExpr(
-        kx_, [] (double y, double x) { return std::atan2(y, x);}
-    );
-
-    // array k_plus_ has no elements where abs(k_plus_) < 1.0E-8
-    k_plus_ = (Eigen::abs(k_.array()) < 1.0E-8).select(
-        Eigen::MatrixXd::Ones(nx_, ny_), k_);
-
-    // set 1/k to zero when abs(k) < 1.0E-8 as the quantities it multiplies
-    // have zero as the limit as k -> 0. 
-    ook_ = (Eigen::abs(k_.array()) < 1.0E-8).select(
-        Eigen::MatrixXd::Zero(nx_, ny_), 1.0 / k_plus_.array());
-#endif
   }
 
   //////////////////////////////////////////////////
@@ -1257,12 +710,6 @@ namespace waves
     double lx, double ly, int nx, int ny) :
     impl_(new WaveSimulationFFTRefImpl(lx, ly, nx, ny))
   {
-  }
-
-  //////////////////////////////////////////////////
-  void WaveSimulationFFTRef::SetUseVectorised(bool value)
-  {
-    impl_->SetUseVectorised(value);
   }
 
   //////////////////////////////////////////////////

--- a/gz-waves/src/WaveSimulationFFTRef.cc
+++ b/gz-waves/src/WaveSimulationFFTRef.cc
@@ -1,0 +1,1335 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+// The non-vectorised time-dependent update step labelled 'non-vectorised reference version'
+// in WaveSimulationFFTImpl.ComputeCurrentAmplitudesReference is based on the Curtis Mobley's
+// IDL code cgAnimate_2D_SeaSurface.py
+
+//***************************************************************************************************
+//* This code is copyright (c) 2016 by Curtis D. Mobley.                                            *
+//* Permission is hereby given to reproduce and use this code for non-commercial academic research, *
+//* provided that the user suitably acknowledges Curtis D. Mobley in any presentations, reports,    *
+//* publications, or other works that make use of the code or its output.  Depending on the extent  *
+//* of use of the code or its outputs, suitable acknowledgement can range from a footnote to offer  *
+//* of coauthorship.  Further questions can be directed to curtis.mobley@sequoiasci.com.            *
+//***************************************************************************************************
+
+#include "gz/waves/WaveSimulationFFTRef.hh"
+
+#include <complex>
+#include <random>
+
+#include <Eigen/Dense>
+
+#include <fftw3.h>
+
+#include <gz/common.hh>
+
+#include "gz/waves/WaveSpectrum.hh"
+#include "gz/waves/WaveSpreadingFunction.hh"
+#include "WaveSimulationFFTRefImpl.hh"
+
+namespace gz
+{
+namespace waves
+{
+  //////////////////////////////////////////////////
+  WaveSimulationFFTRefImpl::~WaveSimulationFFTRefImpl()
+  {
+    DestroyFFTWPlans();
+  }
+
+  //////////////////////////////////////////////////
+  WaveSimulationFFTRefImpl::WaveSimulationFFTRefImpl(
+    double lx, double ly, int nx, int ny) :
+    nx_(nx),
+    ny_(ny),
+    lx_(lx),
+    ly_(ly),
+    lambda_(0.6)
+  {
+    ComputeBaseAmplitudes();
+    CreateFFTWPlans();
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::SetUseVectorised(bool value)
+  {
+    use_vectorised_ = value;
+    ComputeBaseAmplitudes();
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::SetLambda(double value)
+  {
+    lambda_ = value;
+    ComputeBaseAmplitudes();
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::SetWindVelocity(double ux, double uy)
+  {
+    // Update wind velocity and recompute base amplitudes.
+    u10_ = sqrt(ux*ux + uy *uy);
+    phi10_ = atan2(uy, ux);
+
+    ComputeBaseAmplitudes();
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::SetTime(double time)
+  {
+    ComputeCurrentAmplitudes(time);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeElevation(
+    Eigen::Ref<Eigen::MatrixXd> h)
+  {
+    // run the FFT
+    fftw_execute(fft_plan0_);
+
+    // change from row to column major storage
+    size_t n2 = nx_ * ny_;
+    h = fft_out0_.reshaped<Eigen::ColMajor>(n2, 1).real();
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeElevationDerivatives(
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy)
+  {
+    // run the FFTs
+    fftw_execute(fft_plan1_);
+    fftw_execute(fft_plan2_);
+
+    // change from row to column major storage
+    size_t n2 = nx_ * ny_;
+    dhdy = fft_out1_.reshaped<Eigen::ColMajor>(n2, 1).real();
+    dhdx = fft_out2_.reshaped<Eigen::ColMajor>(n2, 1).real();
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeDisplacements(
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy)
+  {
+    // run the FFTs
+    fftw_execute(fft_plan3_);
+    fftw_execute(fft_plan4_);
+
+    // change from row to column major storage
+    size_t n2 = nx_ * ny_;
+    sy = fft_out3_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ * -1.0;
+    sx = fft_out4_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ * -1.0;
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeDisplacementsDerivatives(
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
+  {
+    // run the FFTs
+    fftw_execute(fft_plan5_);
+    fftw_execute(fft_plan6_);
+    fftw_execute(fft_plan7_);
+
+    // change from row to column major storage
+    size_t n2 = nx_ * ny_;
+    dsydy = fft_out5_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ * -1.0;
+    dsxdx = fft_out6_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ * -1.0;
+    dsxdy = fft_out7_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ *  1.0;
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeBaseAmplitudes()
+  {
+    if (use_vectorised_)
+      ComputeBaseAmplitudesVectorised();
+    else
+      ComputeBaseAmplitudesNonVectorised();
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeCurrentAmplitudes(double time)
+  {
+    if (use_vectorised_)
+      ComputeCurrentAmplitudesVectorised(time);
+    else
+      ComputeCurrentAmplitudesNonVectorised(time);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeBaseAmplitudesNonVectorised()
+  {
+    InitFFTCoeffStorage();
+    InitWaveNumbers();
+
+    // initialise arrays
+    size_t n2 = nx_ * ny_;
+    if (cap_psi_2s_root_.size() == 0)
+    {
+      cap_psi_2s_root_  = Eigen::VectorXd::Zero(n2);
+      rho_              = Eigen::VectorXd::Zero(n2);
+      sigma_            = Eigen::VectorXd::Zero(n2);
+      omega_k_          = Eigen::VectorXd::Zero(n2);
+    }
+
+    // continuous two-sided elevation variance spectrum
+    Eigen::VectorXd cap_psi_2s_math = Eigen::VectorXd::Zero(nx_ * ny_);
+
+    // calculate spectrum in math-order (not vectorised)
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      // kx: fftfreq and ifftshift
+      const double kx = (ikx - nx_/2) * kx_f_;
+      const double kx2 = kx*kx;
+
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        // ky: fftfreq and ifftshift
+        const double ky = (iky - ny_/2) * ky_f_;
+        const double ky2 = ky*ky;
+        
+        const double k = sqrt(kx2 + ky2);
+        const double phi = atan2(ky, kx);
+
+        // index for flattened array
+        int idx = ikx * ny_ + iky;
+
+        if (k == 0.0)
+        {
+          cap_psi_2s_math[idx] = 0.0;
+        }
+        else
+        {
+          double cap_psi = 0.0;
+          if (use_symmetric_spreading_fn_)
+          {
+            // standing waves - symmetric spreading function
+            cap_psi = WaveSimulationFFTRefImpl::ECKVSpreadingFunction(
+                k, phi - phi10_, u10_, cap_omega_c_, gravity_);
+          }
+          else
+          {
+            // travelling waves - asymmetric spreading function
+            cap_psi = WaveSimulationFFTRefImpl::Cos2sSpreadingFunction(
+                s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
+          }
+          const double cap_s =
+              WaveSimulationFFTRefImpl::ECKVOmniDirectionalSpectrum(
+                  k, u10_, cap_omega_c_, gravity_);
+          cap_psi_2s_math[idx] = cap_s * cap_psi / k;
+        }
+      }
+    }
+
+    // convert to fft-order
+    Eigen::VectorXd cap_psi_2s_fft = Eigen::VectorXd::Zero(nx_ * ny_);
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      int ikx_fft = (ikx + nx_/2) % nx_;
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        int iky_fft = (iky + ny_/2) % ny_;
+
+        // index for flattened array
+        int idx = ikx * ny_ + iky;
+        int idx_fft = ikx_fft * ny_ + iky_fft;
+
+        cap_psi_2s_fft[idx_fft] = cap_psi_2s_math[idx];
+      }
+    }
+
+    // square-root of two-sided discrete elevation variance spectrum
+    double cap_psi_norm = 0.5;
+    double delta_kx = kx_f_;
+    double delta_ky = ky_f_;
+    // double c1 = cap_psi_norm * sqrt(delta_kx * delta_ky);
+
+    // iid random normals for real and imaginary parts of the amplitudes
+    auto seed = std::default_random_engine::default_seed;
+    std::default_random_engine generator(seed);
+    std::normal_distribution<double> distribution(0.0, 1.0);
+
+    for (int i = 0; i < n2; ++i)
+    {
+      // cap_psi_2s_root[i] = c1 * sqrt(cap_psi_2s_fft[i]);
+      cap_psi_2s_root_[i] =
+          cap_psi_norm * sqrt(cap_psi_2s_fft[i] * delta_kx * delta_ky);
+
+      rho_[i] = distribution(generator);
+      sigma_[i] = distribution(generator);
+    }
+
+    // angular temporal frequency for time-dependent (from dispersion)
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      double kx = kx_fft_[ikx];
+      double kx2 = kx*kx;
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        double ky = ky_fft_[iky];
+        double ky2 = ky*ky;
+        double k = sqrt(kx2 + ky2);
+
+        // index for flattened array
+        int idx = ikx * ny_ + iky;
+        omega_k_[idx] = sqrt(gravity_ * k);
+      }
+    }
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeCurrentAmplitudesNonVectorised(
+      double time)
+  {
+    // alias
+    const Eigen::Ref<const Eigen::VectorXd>& r = rho_;
+    const Eigen::Ref<const Eigen::VectorXd>& s = sigma_;
+    const Eigen::Ref<const Eigen::VectorXd>& psi_root = cap_psi_2s_root_;
+
+    // time update
+    Eigen::VectorXd cos_omega_k = Eigen::VectorXd::Zero(nx_ * ny_);
+    Eigen::VectorXd sin_omega_k = Eigen::VectorXd::Zero(nx_ * ny_);
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        // index for flattened array
+        int idx = ikx * ny_ + iky;
+
+        double omega_t = omega_k_[idx] * time;
+        cos_omega_k(idx) = cos(omega_t);
+        sin_omega_k(idx) = sin(omega_t);
+      }
+    }
+
+    // flattened index version
+    Eigen::VectorXcd zhat = Eigen::VectorXcd::Zero(nx_ * ny_);
+    for (int ikx = 1; ikx < nx_; ++ikx)
+    {
+      for (int iky = 1; iky < ny_; ++iky)
+      {
+        // index for flattened array (ikx, iky)
+        int idx = ikx * ny_ + iky;
+
+        // index for conjugate (nx_-ikx, ny_-iky)
+        int cdx = (nx_-ikx) * ny_ + (ny_-iky);
+
+        zhat[idx] = complex(
+            + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
+            + ( s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx) ) * sin_omega_k(idx),
+            - ( r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx) ) * sin_omega_k(idx)
+            + ( s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx) ) * cos_omega_k(idx));
+      }
+    }
+
+    for (int iky = 1; iky < ny_/2+1; ++iky)
+    {
+      int ikx = 0;
+
+      // index for flattened array (ikx, iky)
+      int idx = ikx * ny_ + iky;
+
+      // index for conjugate (ikx, ny_-iky)
+      int cdx = ikx * ny_ + (ny_-iky);
+
+      zhat[idx] = complex(
+          + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
+          + ( s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx) ) * sin_omega_k(idx),
+          - ( r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx) ) * sin_omega_k(idx)
+          + ( s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx) ) * cos_omega_k(idx));
+      zhat[cdx] = std::conj(zhat[idx]);
+    }
+
+    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
+    {
+      int iky = 0;
+
+      // index for flattened array (ikx, iky)
+      int idx = ikx * ny_ + iky;
+
+      // index for conjugate (nx_-ikx, iky)
+      int cdx = (nx_-ikx) * ny_ + iky;
+
+      zhat[idx] = complex(
+          + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_omega_k(idx)
+          + ( s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx) ) * sin_omega_k(idx),
+          - ( r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx) ) * sin_omega_k(idx)
+          + ( s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx) ) * cos_omega_k(idx));
+      zhat[cdx] = std::conj(zhat[idx]);
+    }
+
+    zhat[0] = complex(0.0, 0.0);
+
+    // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
+    const complex iunit(0.0, 1.0);
+    const complex czero(0.0, 0.0);
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      double kx = kx_fft_[ikx];
+      double kx2 = kx*kx;
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        double ky = ky_fft_[iky];
+        double ky2 = ky*ky;
+        double k = sqrt(kx2 + ky2);
+        double ook = 1.0 / k;
+
+        // index for flattened arrays
+        int idx = ikx * ny_ + iky;
+
+        complex h  = zhat[idx];
+        complex hi = h * iunit;
+        complex hok = h * ook;
+        complex hiok = hi * ook;
+
+        // height (amplitude)
+        fft_h_(ikx, iky) = h;
+
+        // height derivatives
+        complex hikx = hi * kx;
+        complex hiky = hi * ky;
+
+        fft_h_ikx_(ikx, iky) = hi * kx;
+        fft_h_iky_(ikx, iky) = hi * ky;
+
+        // displacement and derivatives
+        if (std::abs(k) < 1.0E-8)
+        {          
+          fft_sx_(ikx, iky)     = czero;
+          fft_sy_(ikx, iky)     = czero;
+          fft_h_kxkx_(ikx, iky) = czero;
+          fft_h_kyky_(ikx, iky) = czero;
+          fft_h_kxky_(ikx, iky) = czero;
+        }
+        else
+        {
+          complex dx  = - hiok * kx;
+          complex dy  = - hiok * ky;
+          complex hkxkx = hok * kx2;
+          complex hkyky = hok * ky2;
+          complex hkxky = hok * kx * ky;
+          
+          fft_sx_(ikx, iky)     = dx;
+          fft_sy_(ikx, iky)     = dy;
+          fft_h_kxkx_(ikx, iky) = hkxkx;
+          fft_h_kyky_(ikx, iky) = hkyky;
+          fft_h_kxky_(ikx, iky) = hkxky;
+        }
+      }
+    }
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeBaseAmplitudesVectorised()
+  {
+    // initialise storage
+    InitFFTCoeffStorage();
+    InitWaveNumbers();
+
+    // initialise arrays
+    if (cap_psi_2s_root_vec_.size() == 0)
+    {
+      cap_psi_2s_root_vec_ = Eigen::MatrixXd::Zero(nx_, ny_);
+      rho_vec_             = Eigen::MatrixXd::Zero(nx_, ny_);
+      sigma_vec_           = Eigen::MatrixXd::Zero(nx_, ny_);
+      omega_k_vec_         = Eigen::MatrixXd::Zero(nx_, ny_);
+    }
+
+    // spectrum and spreading functions
+    gz::waves::ECKVWaveSpectrum spectrum;
+    spectrum.SetGravity(gravity_);
+    spectrum.SetU10(u10_);
+    spectrum.SetCapOmegaC(cap_omega_c_);
+
+    // standing waves - symmetric spreading function
+    gz::waves::ECKVSpreadingFunction spreadingFn1;
+    spreadingFn1.SetGravity(gravity_);
+    spreadingFn1.SetU10(u10_);
+    spreadingFn1.SetCapOmegaC(cap_omega_c_);
+
+    // travelling waves - asymmetric spreading function
+    gz::waves::Cos2sSpreadingFunction spreadingFn2;
+    spreadingFn2.SetSpread(s_param_);
+
+    // broadcast (fft) wavenumbers to arrays (aka meshgrid)
+    Eigen::MatrixXd kx = Eigen::MatrixXd::Zero(nx_, ny_);
+    Eigen::MatrixXd ky = Eigen::MatrixXd::Zero(nx_, ny_);
+    kx.colwise() += kx_fft_;
+    ky.rowwise() += ky_fft_.transpose();
+
+    // wavenumber and wave angle arrays
+    Eigen::MatrixXd kx2 = Eigen::pow(kx.array(), 2.0);
+    Eigen::MatrixXd ky2 = Eigen::pow(ky.array(), 2.0);
+    Eigen::MatrixXd k   = Eigen::sqrt(kx2.array() + ky2.array());
+    Eigen::MatrixXd theta = ky.binaryExpr(
+        kx, [] (double y, double x) { return std::atan2(y, x);}
+    );
+
+    // evaluate spectrum
+    Eigen::MatrixXd cap_s = Eigen::MatrixXd::Zero(nx_, ny_);
+    spectrum.Evaluate(cap_s, k);
+
+    Eigen::MatrixXd cap_psi = Eigen::MatrixXd::Zero(nx_, ny_);
+    if (use_symmetric_spreading_fn_)
+      spreadingFn1.Evaluate(cap_psi, theta, phi10_, k);
+    else
+      spreadingFn2.Evaluate(cap_psi, theta, phi10_, k);
+
+    // array k1 has no zero elements
+    Eigen::MatrixXd k1 = (k.array() == 0).select(
+        Eigen::MatrixXd::Ones(nx_, ny_), k);
+
+    // evaluate continuous two-sided elevation variance spectrum for k1 != 0
+    Eigen::MatrixXd cap_psi_2s_fft =
+        cap_s.array() * cap_psi.array() / k1.array();
+
+    // apply filter for k == 0
+    cap_psi_2s_fft = (k.array() == 0).select(
+        Eigen::MatrixXd::Zero(nx_, ny_), cap_psi_2s_fft);
+
+    // square-root of two-sided discrete elevation variance spectrum
+    double cap_psi_norm = 0.5;
+    double delta_kx = kx_f_;
+    double delta_ky = ky_f_;
+    cap_psi_2s_root_vec_ = cap_psi_norm * Eigen::sqrt(
+        cap_psi_2s_fft.array() * delta_kx * delta_ky);
+
+    /// \note vectorising the initialisation of rho and sigma will
+    ///       alter the order, and break the cross checks.
+    // iid random normals for real and imaginary parts of the amplitudes
+    auto seed = std::default_random_engine::default_seed;
+    std::default_random_engine generator(seed);
+    std::normal_distribution<double> distribution(0.0, 1.0);
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        rho_vec_(ikx, iky) = distribution(generator);
+        sigma_vec_(ikx, iky) = distribution(generator);
+      }
+    }
+
+    // angular temporal frequency for time-dependent (from dispersion)
+    omega_k_vec_ = Eigen::sqrt(gravity_ * k.array());
+
+    // calculate zhat0
+    const Eigen::Ref<const Eigen::MatrixXd>& r = rho_vec_;
+    const Eigen::Ref<const Eigen::MatrixXd>& s = sigma_vec_;
+    const Eigen::Ref<const Eigen::MatrixXd>& psi_root = cap_psi_2s_root_vec_;
+
+    zhat0_rc_ = Eigen::MatrixXd::Zero(nx_, ny_);
+    zhat0_rs_ = Eigen::MatrixXd::Zero(nx_, ny_);
+    zhat0_ic_ = Eigen::MatrixXd::Zero(nx_, ny_);
+    zhat0_is_ = Eigen::MatrixXd::Zero(nx_, ny_);
+    for (int ikx = 1; ikx < nx_; ++ikx)
+    {
+      for (int iky = 1; iky < ny_; ++iky)
+      {
+        zhat0_rc_(ikx, iky) = + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ); 
+        zhat0_rs_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ); 
+        zhat0_is_(ikx, iky) = - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) );
+        zhat0_ic_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ); 
+      }
+    }
+
+    for (int iky = 1; iky < ny_/2+1; ++iky)
+    {
+      int ikx = 0;
+      zhat0_rc_(ikx, iky) = + ( r(ikx, iky) * psi_root(ikx, iky) + r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) );
+      zhat0_rs_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) + s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) );
+      zhat0_is_(ikx, iky) = - ( r(ikx, iky) * psi_root(ikx, iky) - r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) );
+      zhat0_ic_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) - s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) );
+    }
+
+    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
+    {
+      int iky = 0;
+      zhat0_rc_(ikx, iky) = + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) );
+      zhat0_rs_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) );
+      zhat0_is_(ikx, iky) = - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) );
+      zhat0_ic_(ikx, iky) = + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) );
+    }
+  }
+
+#define VECTORISE_ZHAT_CALCS 0
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeCurrentAmplitudesVectorised(
+      double time)
+  {
+    // // time update
+    Eigen::MatrixXd wt = omega_k_vec_.array() * time;
+    Eigen::MatrixXd cos_omega_k = Eigen::cos(wt.array());
+    Eigen::MatrixXd sin_omega_k = Eigen::sin(wt.array());
+
+    // non-vectorised reference version
+    Eigen::MatrixXcdRowMajor zhat = Eigen::MatrixXcd::Zero(nx_, ny_);
+    for (int ikx = 1; ikx < nx_; ++ikx)
+    {
+      for (int iky = 1; iky < ny_; ++iky)
+      {
+        zhat(ikx, iky) = complex(
+            + zhat0_rc_(ikx, iky) * cos_omega_k(ikx, iky)
+            + zhat0_rs_(ikx, iky) * sin_omega_k(ikx, iky),
+            + zhat0_is_(ikx, iky) * sin_omega_k(ikx, iky)
+            + zhat0_ic_(ikx, iky) * cos_omega_k(ikx, iky));
+      }
+    }
+
+    for (int iky = 1; iky < ny_/2+1; ++iky)
+    {
+      int ikx = 0;
+      zhat(ikx, iky) = complex(
+          + zhat0_rc_(ikx, iky) * cos_omega_k(ikx, iky)
+          + zhat0_rs_(ikx, iky) * sin_omega_k(ikx, iky),
+          + zhat0_is_(ikx, iky) * sin_omega_k(ikx, iky)
+          + zhat0_ic_(ikx, iky) * cos_omega_k(ikx, iky));
+      zhat(ikx, ny_-iky) = std::conj(zhat(ikx, iky));
+    }
+
+    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
+    {
+      int iky = 0;
+      zhat(ikx, iky) = complex(
+          + zhat0_rc_(ikx, iky) * cos_omega_k(ikx, iky)
+          + zhat0_rs_(ikx, iky) * sin_omega_k(ikx, iky),
+          + zhat0_is_(ikx, iky) * sin_omega_k(ikx, iky)
+          + zhat0_ic_(ikx, iky) * cos_omega_k(ikx, iky));
+      zhat(nx_-ikx, iky) = std::conj(zhat(ikx, iky));
+    }
+
+    zhat(0, 0) = complex(0.0, 0.0);
+
+    // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
+    const complex iunit(0.0, 1.0);
+    const complex czero(0.0, 0.0);
+
+/// \note array version is not faster than the loop.
+#if VECTORISE_ZHAT_CALCS
+    { // vectorised version: note: ook_ evaluates to zero when abs(k) < 1.0E-8
+      fft_h_      = zhat; //h
+      fft_h_ikx_  = zhat.array() * iunit * kx_.array(); //hikx
+      fft_h_iky_  = zhat.array() * iunit * ky_.array(); //hiky
+      fft_sx_     = zhat.array() * iunit * ook_.array() * kx_.array() * -1; //dx
+      fft_sy_     = zhat.array() * iunit * ook_.array() * ky_.array() * -1; //dy
+      fft_h_kxkx_ = zhat.array() * ook_.array() * kx2_.array(); //hkxkx
+      fft_h_kyky_ = zhat.array() * ook_.array() * ky2_.array(); //hkyky
+      fft_h_kxky_ = zhat.array() * ook_.array() * kx_.array() * ky_.array(); //hkxky
+    }
+#else
+    // loop version
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      double kx = kx_fft_[ikx];
+      double kx2 = kx*kx;
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        double ky = ky_fft_[iky];
+        double ky2 = ky*ky;
+        double k = sqrt(kx2 + ky2);
+
+        // elevation
+        complex h = zhat(ikx, iky);
+        complex hi = h * iunit;
+
+        // elevation derivatives
+        complex hikx = hi * kx;
+        complex hiky = hi * ky;
+
+        fft_h_(ikx, iky) = h;
+        fft_h_ikx_(ikx, iky) = hikx;
+        fft_h_iky_(ikx, iky) = hiky;
+
+        // displacement and derivatives
+        if (std::abs(k) < 1.0E-8)
+        {          
+          fft_sx_(ikx, iky) = czero;
+          fft_sy_(ikx, iky) = czero;
+          fft_h_kxkx_(ikx, iky) = czero;
+          fft_h_kyky_(ikx, iky) = czero;
+          fft_h_kxky_(ikx, iky) = czero;
+        }
+        else
+        {
+          // displacements
+          double ook = 1.0 / k;
+          complex hok = h * ook;
+          complex hiok = hi * ook;
+          complex dx = - hiok * kx;
+          complex dy = - hiok * ky;
+
+          // displacements derivatives
+          complex hkxkx = hok * kx2;
+          complex hkyky = hok * ky2;
+          complex hkxky = hok * kx * ky;
+          
+          fft_sx_(ikx, iky) = dx;
+          fft_sy_(ikx, iky) = dy;
+          fft_h_kxkx_(ikx, iky) = hkxkx;
+          fft_h_kyky_(ikx, iky) = hkyky;
+          fft_h_kxky_(ikx, iky) = hkxky;
+        }
+      }
+    }
+#endif
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeBaseAmplitudesReference()
+  {
+    InitFFTCoeffStorage();
+    InitWaveNumbers();
+
+    size_t n2 = nx_ * ny_;
+
+    // arrays for reference version
+    if (cap_psi_2s_root_ref_.size() == 0)
+    {
+      cap_psi_2s_root_ref_ = Eigen::MatrixXd::Zero(nx_, ny_);
+      rho_ref_             = Eigen::MatrixXd::Zero(nx_, ny_);
+      sigma_ref_           = Eigen::MatrixXd::Zero(nx_, ny_);
+      omega_k_ref_         = Eigen::MatrixXd::Zero(nx_, ny_);
+    }
+
+    // Guide to indexing conventions:  1. index, 2. math-order, 3. fft-order
+    // 
+    // 1. [ 0,  1,  2,  3,  4,  5,  6,  7]
+    // 2. [-4, -3, -2, -1,  0,  1,  2,  3]
+    // 3.                 [ 0,  1,  2,  3, -4, -3, -2, -3]
+    // 
+
+    // debug
+    gzmsg << "WaveSimulationFFTRef" << "\n";
+    gzmsg << "lx:           " << lx_ << "\n";
+    gzmsg << "ly:           " << ly_ << "\n";
+    gzmsg << "nx:           " << nx_ << "\n";
+    gzmsg << "ny:           " << ny_ << "\n";
+    gzmsg << "delta_x:      " << delta_x_ << "\n";
+    gzmsg << "delta_y:      " << delta_y_ << "\n";
+    gzmsg << "lambda_x_f:   " << lambda_x_f_ << "\n";
+    gzmsg << "lambda_y_f:   " << lambda_y_f_ << "\n";
+    gzmsg << "nu_x_f:       " << nu_x_f_ << "\n";
+    gzmsg << "nu_y_f:       " << nu_y_f_ << "\n";
+    gzmsg << "nu_x_nyquist: " << nu_x_nyquist_ << "\n";
+    gzmsg << "nu_y_nyquist: " << nu_y_nyquist_ << "\n";
+    gzmsg << "kx_f:         " << kx_f_ << "\n";
+    gzmsg << "ky_f:         " << ky_f_ << "\n";
+    gzmsg << "kx_nyquist:   " << kx_nyquist_ << "\n";
+    gzmsg << "ky_nyquist:   " << ky_nyquist_ << "\n";
+
+#if 0
+    {
+      std::ostringstream os;
+      os << "[ "; for (auto& v : kx_fft_) os << v << " "; os << "]\n";
+      gzmsg << "kx_fft:      " << os.str();
+    }
+    {
+      std::ostringstream os;
+      os << "[ "; for (auto& v : ky_fft_) os << v << " "; os << "]\n";
+      gzmsg << "ky_fft:      " << os.str();
+    }
+    {
+      std::ostringstream os;
+      os << "[ "; for (auto& v : kx_math_) os << v << " "; os << "]\n";
+      gzmsg << "kx_math:     " << os.str();
+    }
+    {
+      std::ostringstream os;
+      os << "[ "; for (auto& v : ky_math_) os << v << " "; os << "]\n";
+      gzmsg << "ky_math:     " << os.str();
+    }
+#endif
+
+    // continuous two-sided elevation variance spectrum
+    Eigen::MatrixXd cap_psi_2s_math = Eigen::MatrixXd::Zero(nx_, ny_);
+
+    // calculate spectrum in math-order (not vectorised)
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        double k = sqrt(kx_math_[ikx]*kx_math_[ikx]
+            + ky_math_[iky]*ky_math_[iky]);
+        double phi = atan2(ky_math_[iky], kx_math_[ikx]);
+
+        if (k == 0.0)
+        {
+          cap_psi_2s_math(ikx, iky) = 0.0;
+        }
+        else
+        {
+          double cap_psi = 0.0;
+          if (use_symmetric_spreading_fn_)
+          {
+            // standing waves - symmetric spreading function
+            cap_psi = WaveSimulationFFTRefImpl::ECKVSpreadingFunction(
+                k, phi - phi10_, u10_, cap_omega_c_, gravity_);
+          }
+          else
+          {
+            // travelling waves - asymmetric spreading function
+            cap_psi = WaveSimulationFFTRefImpl::Cos2sSpreadingFunction(
+                s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
+          }
+          double cap_s = WaveSimulationFFTRefImpl::ECKVOmniDirectionalSpectrum(
+              k, u10_, cap_omega_c_, gravity_);
+          cap_psi_2s_math(ikx, iky) = cap_s * cap_psi / k;
+        }
+      }
+    }
+
+    // debug
+#if 0
+    {
+      std::ostringstream os;
+      os << "[\n";
+      for (int ikx = 0; ikx < nx_; ++ikx)
+      {
+        os << " [ ";
+        for (auto& v : cap_psi_2s_math[ikx])
+        {
+          os << v << " ";
+        }
+        os << "]\n";
+      }
+      os << "]\n";
+
+      gzmsg << "cap_psi_2s:  " << os.str();
+    }
+#endif
+
+    // convert to fft-order
+    Eigen::MatrixXd cap_psi_2s_fft = Eigen::MatrixXd::Zero(nx_, ny_);
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      int ikx_fft = (ikx + nx_/2) % nx_;
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        int iky_fft = (iky + ny_/2) % ny_;
+        cap_psi_2s_fft(ikx_fft, iky_fft) = cap_psi_2s_math(ikx, iky);
+      }
+    }
+
+    // square-root of two-sided discrete elevation variance spectrum
+    double cap_psi_norm = 0.5;
+    double delta_kx = kx_f_;
+    double delta_ky = ky_f_;
+
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        cap_psi_2s_root_ref_(ikx, iky) =
+            cap_psi_norm * sqrt(cap_psi_2s_fft(ikx, iky) * delta_kx * delta_ky);
+      }
+    }
+
+    // iid random normals for real and imaginary parts of the amplitudes
+    auto seed = std::default_random_engine::default_seed;
+    std::default_random_engine generator(seed);
+    std::normal_distribution<double> distribution(0.0, 1.0);
+
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        rho_ref_(ikx, iky) = distribution(generator);
+        sigma_ref_(ikx, iky) = distribution(generator);
+      }
+    }
+
+    // angular temporal frequency for time-dependent (from dispersion)
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      double kx = kx_fft_[ikx];
+      double kx2 = kx*kx;
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        double ky = ky_fft_[iky];
+        double ky2 = ky*ky;
+        double k = sqrt(kx2 + ky2);
+        omega_k_ref_(ikx, iky) = sqrt(gravity_ * k);
+      }
+    }
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::ComputeCurrentAmplitudesReference(
+      double time)
+  {
+    // alias
+    const Eigen::Ref<const Eigen::MatrixXd>& r = rho_ref_;
+    const Eigen::Ref<const Eigen::MatrixXd>& s = sigma_ref_;
+    const Eigen::Ref<const Eigen::MatrixXd>& psi_root = cap_psi_2s_root_ref_;
+
+    // time update
+    Eigen::MatrixXd cos_omega_k = Eigen::MatrixXd::Zero(nx_, ny_);
+    Eigen::MatrixXd sin_omega_k = Eigen::MatrixXd::Zero(nx_, ny_);
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        cos_omega_k(ikx, iky) = cos(omega_k_ref_(ikx, iky) * time);
+        sin_omega_k(ikx, iky) = sin(omega_k_ref_(ikx, iky) * time);
+      }
+    }
+
+    // non-vectorised reference version
+    Eigen::MatrixXcd zhat = Eigen::MatrixXcd::Zero(nx_, ny_);
+    for (int ikx = 1; ikx < nx_; ++ikx)
+    {
+      for (int iky = 1; iky < ny_; ++iky)
+      {
+        zhat(ikx, iky) = complex(
+            + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * cos_omega_k(ikx, iky)
+            + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * sin_omega_k(ikx, iky),
+            - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * sin_omega_k(ikx, iky)
+            + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * cos_omega_k(ikx, iky));
+      }
+    }
+
+    for (int iky = 1; iky < ny_/2+1; ++iky)
+    {
+      int ikx = 0;
+      zhat(ikx, iky) = complex(
+          + ( r(ikx, iky) * psi_root(ikx, iky) + r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * cos_omega_k(ikx, iky)
+          + ( s(ikx, iky) * psi_root(ikx, iky) + s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * sin_omega_k(ikx, iky),
+          - ( r(ikx, iky) * psi_root(ikx, iky) - r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * sin_omega_k(ikx, iky)
+          + ( s(ikx, iky) * psi_root(ikx, iky) - s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * cos_omega_k(ikx, iky));
+      zhat(ikx, ny_-iky) = std::conj(zhat(ikx, iky));
+    }
+
+    for (int ikx = 1; ikx < nx_/2+1; ++ikx)
+    {
+      int iky = 0;
+      zhat(ikx, iky) = complex(
+          + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * cos_omega_k(ikx, iky)
+          + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * sin_omega_k(ikx, iky),
+          - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * sin_omega_k(ikx, iky)
+          + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * cos_omega_k(ikx, iky));
+      zhat(nx_-ikx, iky) = std::conj(zhat(ikx, iky));
+    }
+
+    zhat(0, 0) = complex(0.0, 0.0);
+
+    // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
+    const complex iunit(0.0, 1.0);
+    const complex czero(0.0, 0.0);
+    for (int ikx = 0; ikx < nx_; ++ikx)
+    {
+      double kx = kx_fft_[ikx];
+      double kx2 = kx*kx;
+      for (int iky = 0; iky < ny_; ++iky)
+      {
+        double ky = ky_fft_[iky];
+        double ky2 = ky*ky;
+        double k = sqrt(kx2 + ky2);
+        double ook = 1.0 / k;
+
+        complex h  = zhat(ikx, iky);
+        complex hi = h * iunit;
+        complex hok = h * ook;
+        complex hiok = hi * ook;
+
+        // height (amplitude)
+        fft_h_(ikx, iky) = h;
+
+        // height derivatives
+        complex hikx = hi * kx;
+        complex hiky = hi * ky;
+
+        fft_h_ikx_(ikx, iky) = hi * kx;
+        fft_h_iky_(ikx, iky) = hi * ky;
+
+        // displacement and derivatives
+        if (std::abs(k) < 1.0E-8)
+        {          
+          fft_sx_(ikx, iky)     = czero;
+          fft_sy_(ikx, iky)     = czero;
+          fft_h_kxkx_(ikx, iky) = czero;
+          fft_h_kyky_(ikx, iky) = czero;
+          fft_h_kxky_(ikx, iky) = czero;
+        }
+        else
+        {
+          complex dx  = - hiok * kx;
+          complex dy  = - hiok * ky;
+          complex hkxkx = hok * kx2;
+          complex hkyky = hok * ky2;
+          complex hkxky = hok * kx * ky;
+          
+          fft_sx_(ikx, iky)     = dx;
+          fft_sy_(ikx, iky)     = dy;
+          fft_h_kxkx_(ikx, iky) = hkxkx;
+          fft_h_kyky_(ikx, iky) = hkyky;
+          fft_h_kxky_(ikx, iky) = hkxky;
+        }
+      }
+    }
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::InitFFTCoeffStorage()
+  {
+    // initialise storage for Fourier coefficients
+    fft_h_      = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_ikx_  = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_iky_  = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_sx_     = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_sy_     = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_kxkx_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_kyky_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_h_kxky_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::InitWaveNumbers()
+  {
+    kx_fft_  = Eigen::VectorXd::Zero(nx_);
+    ky_fft_  = Eigen::VectorXd::Zero(ny_);
+    kx_math_ = Eigen::VectorXd::Zero(nx_);
+    ky_math_ = Eigen::VectorXd::Zero(ny_);
+
+    // wavenumbers in fft and math ordering
+    for(int ikx = 0; ikx < nx_; ++ikx)
+    {
+      double kx = (ikx - nx_/2) * kx_f_;
+      kx_math_(ikx) = kx;
+      kx_fft_((ikx + nx_/2) % nx_) = kx;
+    }
+
+    for(int iky = 0; iky < ny_; ++iky)
+    {
+      double ky = (iky - ny_/2) * ky_f_;
+      ky_math_(iky) = ky;
+      ky_fft_((iky + ny_/2) % ny_) = ky;
+    }
+
+#if VECTORISE_ZHAT_CALCS
+    // broadcast (fft) wavenumbers to arrays (aka meshgrid)
+    kx_ = Eigen::MatrixXd::Zero(nx_, ny_);
+    ky_ = Eigen::MatrixXd::Zero(nx_, ny_);
+    kx_.colwise() += kx_fft_;
+    ky_.rowwise() += ky_fft_.transpose();
+
+    // wavenumber and wave angle arrays
+    kx2_ = Eigen::pow(kx_.array(), 2.0);
+    ky2_ = Eigen::pow(ky_.array(), 2.0);
+    k_   = Eigen::sqrt(kx2_.array() + ky2_.array());
+    theta_ = ky_.binaryExpr(
+        kx_, [] (double y, double x) { return std::atan2(y, x);}
+    );
+
+    // array k_plus_ has no elements where abs(k_plus_) < 1.0E-8
+    k_plus_ = (Eigen::abs(k_.array()) < 1.0E-8).select(
+        Eigen::MatrixXd::Ones(nx_, ny_), k_);
+
+    // set 1/k to zero when abs(k) < 1.0E-8 as the quantities it multiplies
+    // have zero as the limit as k -> 0. 
+    ook_ = (Eigen::abs(k_.array()) < 1.0E-8).select(
+        Eigen::MatrixXd::Zero(nx_, ny_), 1.0 / k_plus_.array());
+#endif
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::CreateFFTWPlans()
+  {
+    // elevation
+    fft_out0_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out1_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out2_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+
+    // xy-displacements
+    fft_out3_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out4_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out5_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out6_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+    fft_out7_ = Eigen::MatrixXcdRowMajor::Zero(nx_, ny_);
+
+    // elevation
+    fft_plan0_ = fftw_plan_dft_2d(nx_, ny_,
+        reinterpret_cast<fftw_complex*>(fft_h_.data()),
+        reinterpret_cast<fftw_complex*>(fft_out0_.data()),
+        FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan1_ = fftw_plan_dft_2d(nx_, ny_,
+        reinterpret_cast<fftw_complex*>(fft_h_ikx_.data()),
+        reinterpret_cast<fftw_complex*>(fft_out1_.data()),
+        FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan2_ = fftw_plan_dft_2d(nx_, ny_,
+        reinterpret_cast<fftw_complex*>(fft_h_iky_.data()),
+        reinterpret_cast<fftw_complex*>(fft_out2_.data()),
+        FFTW_BACKWARD, FFTW_ESTIMATE);
+
+    // xy-displacements
+    fft_plan3_ = fftw_plan_dft_2d(nx_, ny_,
+        reinterpret_cast<fftw_complex*>(fft_sx_.data()),
+        reinterpret_cast<fftw_complex*>(fft_out3_.data()),
+        FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan4_ = fftw_plan_dft_2d(nx_, ny_,
+        reinterpret_cast<fftw_complex*>(fft_sy_.data()),
+        reinterpret_cast<fftw_complex*>(fft_out4_.data()),
+        FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan5_ = fftw_plan_dft_2d(nx_, ny_,
+        reinterpret_cast<fftw_complex*>(fft_h_kxkx_.data()),
+        reinterpret_cast<fftw_complex*>(fft_out5_.data()),
+        FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan6_ = fftw_plan_dft_2d(nx_, ny_,
+        reinterpret_cast<fftw_complex*>(fft_h_kyky_.data()),
+        reinterpret_cast<fftw_complex*>(fft_out6_.data()),
+        FFTW_BACKWARD, FFTW_ESTIMATE);
+    fft_plan7_ = fftw_plan_dft_2d(nx_, ny_,
+        reinterpret_cast<fftw_complex*>(fft_h_kxky_.data()),
+        reinterpret_cast<fftw_complex*>(fft_out7_.data()),
+        FFTW_BACKWARD, FFTW_ESTIMATE);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRefImpl::DestroyFFTWPlans()
+  {
+    fftw_destroy_plan(fft_plan0_);
+    fftw_destroy_plan(fft_plan1_);
+    fftw_destroy_plan(fft_plan2_);
+    fftw_destroy_plan(fft_plan3_);
+    fftw_destroy_plan(fft_plan4_);
+    fftw_destroy_plan(fft_plan5_);
+    fftw_destroy_plan(fft_plan6_);
+    fftw_destroy_plan(fft_plan7_);
+  }
+
+  //////////////////////////////////////////////////
+  //////////////////////////////////////////////////
+  double WaveSimulationFFTRefImpl::ECKVOmniDirectionalSpectrum(
+      double k, double u10, double cap_omega_c, double gravity)
+  {
+    if (std::abs(k) < 1.0E-8 || std::abs(u10) < 1.0E-8)
+    {
+      return 0.0;
+    }
+
+    double alpha = 0.0081;
+    double beta = 1.25;
+    double g = gravity;
+    double Cd_10N = 0.00144;
+    double u_star = sqrt(Cd_10N) * u10;
+    double ao = 0.1733;
+    double ap = 4.0;
+    double km = 370.0;
+    double cm = 0.23;
+    double am = 0.13 * u_star / cm;
+    
+    double gamma = 1.7;
+    if (cap_omega_c < 1.0)
+    {
+      gamma = 1.7;
+    }
+    else
+    {
+      gamma = 1.7 + 6.0 * log10(cap_omega_c);
+    }
+
+    double sigma = 0.08 * (1.0 + 4.0 * pow(cap_omega_c, -3.0));
+    double alpha_p = 0.006 * pow(cap_omega_c, 0.55);
+
+    double alpha_m; 
+    if (u_star <= cm)
+    {
+      alpha_m = 0.01 * (1.0 + log(u_star / cm));
+    }
+    else
+    {
+      alpha_m = 0.01 * (1.0 + 3.0 * log(u_star / cm));
+    }
+
+    double ko = g / u10 / u10;
+    double kp = ko * cap_omega_c * cap_omega_c;
+
+    double cp = sqrt(g / kp);
+    double c  = sqrt((g / k) * (1.0 + pow(k / km, 2.0)));
+        
+    double L_PM = exp(-1.25 * pow(kp / k, 2.0));
+    
+    double Gamma = exp(-1.0/(2.0 * pow(sigma, 2.0)) * pow(sqrt(k / kp) - 1.0, 2.0));
+    
+    double J_p = pow(gamma, Gamma);
+    
+    double F_p = L_PM * J_p * exp(-0.3162 * cap_omega_c * (sqrt(k / kp) - 1.0));
+
+    double F_m = L_PM * J_p * exp(-0.25 * pow(k / km - 1.0, 2.0));
+
+    double B_l = 0.5 * alpha_p * (cp / c) * F_p;
+    double B_h = 0.5 * alpha_m * (cm / c) * F_m;
+    
+    double k3 = k * k * k;
+    double S = (B_l + B_h) / k3;
+
+    // debug
+    // gzmsg << "g:       " << g << "\n";
+    // gzmsg << "Omega_c: " << cap_omega_c << "\n";
+    // gzmsg << "Cd10N:   " << Cd_10N << "\n";
+    // gzmsg << "ustar:   " << u_star << "\n";
+    // gzmsg << "ao:      " << ao << "\n";
+    // gzmsg << "ap:      " << ap << "\n";
+    // gzmsg << "cm:      " << cm << "\n";
+    // gzmsg << "am:      " << am << "\n";
+    // gzmsg << "km:      " << km << "\n";
+    // gzmsg << "gamma:   " << gamma << "\n";
+    // gzmsg << "sigma:   " << sigma << "\n";
+    // gzmsg << "alphap:  " << alpha_p << "\n";
+    // gzmsg << "alpham:  " << alpha_m << "\n";
+    // gzmsg << "ko:      " << ko << "\n";
+    // gzmsg << "kp:      " << kp << "\n";
+    // gzmsg << "cp:      " << cp << "\n";
+    // gzmsg << "c:       " << c << "\n";
+    // gzmsg << "Gamma:   " << Gamma << "\n";
+    // gzmsg << "fJp:     " << J_p << "\n";
+    // gzmsg << "fLpm:    " << L_PM << "\n";
+    // gzmsg << "Fp:      " << F_p << "\n";
+    // gzmsg << "Bl:      " << B_l << "\n";
+    // gzmsg << "Fm:      " << F_m << "\n";
+    // gzmsg << "Bh:      " << B_h << "\n";
+    
+    return S;
+  }
+
+  //////////////////////////////////////////////////
+  double WaveSimulationFFTRefImpl::ECKVSpreadingFunction(
+      double k, double phi, double u10, double cap_omega_c, double gravity)
+  {
+    double g = gravity;
+    double Cd_10N = 0.00144;
+    double u_star = sqrt(Cd_10N) * u10;
+    double ao = 0.1733;
+    double ap = 4.0;
+    double km = 370.0;
+    double cm = 0.23;
+    double am = 0.13 * u_star / cm;
+    double ko = g / u10 / u10;
+    double kp = ko * cap_omega_c * cap_omega_c;
+    double cp = sqrt(g / kp);
+    double c  = sqrt((g / k) * (1 + pow(k / km, 2.0)));
+    double cap_phi = (1 + tanh(ao + ap * pow(c / cp, 2.5)
+        + am * pow(cm / c, 2.5)) * cos(2.0 * phi))/ 2.0 / M_PI;
+    return cap_phi;
+  }
+
+  //////////////////////////////////////////////////
+  double WaveSimulationFFTRefImpl::Cos2sSpreadingFunction(
+      double s, double phi, double u10, double cap_omega_c, double gravity)
+  {
+    // Longuet-Higgins et al. 'cosine-2S' spreading function
+    //
+    // Eq. (B.18) from Ocean Optics
+
+
+    // Note: s is the spreading parameter and in general
+    // will depend on k, u10, cap_omega_c
+    // s = 2
+    double cap_c_s = std::tgamma(s + 1) / std::tgamma(s + 0.5) / 2 / sqrt(M_PI);
+    double cap_phi = cap_c_s * pow(cos(phi / 2), 2 * s);
+    return cap_phi;
+  }
+
+  //////////////////////////////////////////////////
+  //////////////////////////////////////////////////
+  WaveSimulationFFTRef::~WaveSimulationFFTRef()
+  {
+  }
+
+  //////////////////////////////////////////////////
+  WaveSimulationFFTRef::WaveSimulationFFTRef(
+    double lx, double ly, int nx, int ny) :
+    impl_(new WaveSimulationFFTRefImpl(lx, ly, nx, ny))
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRef::SetUseVectorised(bool value)
+  {
+    impl_->SetUseVectorised(value);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRef::SetLambda(double value)
+  {
+    impl_->SetLambda(value);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRef::SetWindVelocity(double ux, double uy)
+  {
+    impl_->SetWindVelocity(ux, uy);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRef::SetTime(double value)
+  {
+    impl_->SetTime(value);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRef::ComputeElevation(
+    Eigen::Ref<Eigen::MatrixXd> h)
+  {
+    impl_->ComputeElevation(h);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRef::ComputeElevationDerivatives(
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy)
+  {
+    impl_->ComputeElevationDerivatives(dhdx, dhdy);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRef::ComputeDisplacements(
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy)
+  {
+    impl_->ComputeDisplacements(sx, sy);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRef::ComputeDisplacementsDerivatives(
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
+  {
+    impl_->ComputeDisplacementsDerivatives(dsxdx, dsxdy, dsxdy);
+  }
+
+  //////////////////////////////////////////////////
+  void WaveSimulationFFTRef::ComputeDisplacementsAndDerivatives(
+    Eigen::Ref<Eigen::MatrixXd> h,
+    Eigen::Ref<Eigen::MatrixXd> sx,
+    Eigen::Ref<Eigen::MatrixXd> sy,
+    Eigen::Ref<Eigen::MatrixXd> dhdx,
+    Eigen::Ref<Eigen::MatrixXd> dhdy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdx,
+    Eigen::Ref<Eigen::MatrixXd> dsydy,
+    Eigen::Ref<Eigen::MatrixXd> dsxdy)
+  {
+    impl_->ComputeElevation(h);
+    impl_->ComputeElevationDerivatives(dhdx, dhdy);
+    impl_->ComputeDisplacements(sx, sy);
+    impl_->ComputeDisplacementsDerivatives(dsxdx, dsydy, dsxdy);
+  }
+}
+}

--- a/gz-waves/src/WaveSimulationFFTRefImpl.hh
+++ b/gz-waves/src/WaveSimulationFFTRefImpl.hh
@@ -1,0 +1,295 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_WAVES_WAVESIMULATIONFFTREF_IMPL_HH_
+#define GZ_WAVES_WAVESIMULATIONFFTREF_IMPL_HH_
+
+#include <complex>
+
+#include <Eigen/Dense>
+
+#include <fftw3.h>
+
+#include "gz/waves/WaveSimulation.hh"
+
+using Eigen::MatrixXcd;
+using Eigen::MatrixXd;
+using Eigen::VectorXcd;
+using Eigen::VectorXd;
+
+namespace Eigen
+{ 
+  typedef Eigen::Matrix<
+    std::complex<double>,
+    Eigen::Dynamic,
+    Eigen::Dynamic,
+    Eigen::RowMajor
+  > MatrixXcdRowMajor;
+
+  typedef Eigen::Matrix<
+    double,
+    Eigen::Dynamic,
+    Eigen::Dynamic,
+    Eigen::RowMajor
+  > MatrixXdRowMajor;
+}
+
+namespace gz
+{
+namespace waves
+{
+  //////////////////////////////////////////////////
+  // WaveSimulationFFTRefImpl
+
+  typedef double fftw_data_type;
+  typedef std::complex<fftw_data_type> complex;
+
+  /// \brief Implementation of a FFT based wave simulation model
+  ///
+  /// \note The FFT wave simulation mixes storage ordering which
+  ///       must be made consistent and should be column major
+  ///       which is the Eigen default..
+  ///
+  class WaveSimulationFFTRefImpl
+  {
+  public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    
+    /// \brief Destructor 
+    ~WaveSimulationFFTRefImpl();
+
+    /// \brief Construct a wave simulation model
+    WaveSimulationFFTRefImpl(double lx, double ly, int nx, int ny);
+
+    void SetUseVectorised(bool value);
+
+    /// \brief Set the components of the wind velocity (U10) in [m/s]
+    void SetWindVelocity(double ux, double uy);
+
+    /// \brief Set the current time in seconds
+    void SetTime(double value);
+
+    /// \brief Set the horizontal displacement scaling factor
+    void SetLambda(double value);
+
+    /// \brief Calculate the sea surface elevation
+    void ComputeElevation(
+      Eigen::Ref<Eigen::MatrixXd> h);
+
+    /// \brief Calculate the derivative of the elevation wrt x and y
+    void ComputeElevationDerivatives(
+      Eigen::Ref<Eigen::MatrixXd> dhdx,
+      Eigen::Ref<Eigen::MatrixXd> dhdy);
+
+    /// \brief Calculate the sea surface horizontal displacements
+    void ComputeDisplacements(
+      Eigen::Ref<Eigen::MatrixXd> sx,
+      Eigen::Ref<Eigen::MatrixXd> sy);
+
+    /// \brief Calculate the derivative of the horizontal displacements wrt x and y
+    void ComputeDisplacementsDerivatives(
+      Eigen::Ref<Eigen::MatrixXd> dsxdx,
+      Eigen::Ref<Eigen::MatrixXd> dsydy,
+      Eigen::Ref<Eigen::MatrixXd> dsxdy);
+
+    /// \brief Calculate the base (time-independent) Fourier amplitudes
+    void ComputeBaseAmplitudes();
+
+    /// \brief Calculate the time-independent Fourier amplitudes
+    void ComputeCurrentAmplitudes(double time);
+    
+    void ComputeBaseAmplitudesNonVectorised();
+    void ComputeCurrentAmplitudesNonVectorised(double time);
+
+    void ComputeBaseAmplitudesVectorised();
+    void ComputeCurrentAmplitudesVectorised(double time);
+
+    /// \brief Reference implementation of base amplitude calculation
+    void ComputeBaseAmplitudesReference();
+
+    /// \brief Reference implementation of time-dependent amplitude calculation
+    void ComputeCurrentAmplitudesReference(double time);
+
+    void InitFFTCoeffStorage();
+    void InitWaveNumbers();
+
+    void CreateFFTWPlans();
+    void DestroyFFTWPlans();
+
+    /// \note FFTW expects the multi-dimensional arrays to be in row-major
+    ///       format. Eigen::MatrixXcd is column-major, so here we
+    ///       explicity set the storage type.
+    ///
+    /// https://www.fftw.org/fftw3_doc/Row_002dmajor-Format.html 
+    ///
+    Eigen::MatrixXcdRowMajor fft_h_;       // FFT0 - height
+    Eigen::MatrixXcdRowMajor fft_h_ikx_;   // FFT1 - d height / dx
+    Eigen::MatrixXcdRowMajor fft_h_iky_;   // FFT1 - d height / dy
+    Eigen::MatrixXcdRowMajor fft_sx_;      // FFT3 - displacement x
+    Eigen::MatrixXcdRowMajor fft_sy_;      // FFT4 - displacement y
+    Eigen::MatrixXcdRowMajor fft_h_kxkx_;  // FFT5 - d displacement x / dx
+    Eigen::MatrixXcdRowMajor fft_h_kyky_;  // FFT6 - d displacement y / dy
+    Eigen::MatrixXcdRowMajor fft_h_kxky_;  // FFT7 - d displacement x / dy
+
+    Eigen::MatrixXcdRowMajor fft_out0_;
+    Eigen::MatrixXcdRowMajor fft_out1_;
+    Eigen::MatrixXcdRowMajor fft_out2_;
+    Eigen::MatrixXcdRowMajor fft_out3_;
+    Eigen::MatrixXcdRowMajor fft_out4_;
+    Eigen::MatrixXcdRowMajor fft_out5_;
+    Eigen::MatrixXcdRowMajor fft_out6_;
+    Eigen::MatrixXcdRowMajor fft_out7_;
+
+    fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
+    fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
+
+    // precalculated amplitudes (t=0)
+    Eigen::MatrixXd zhat0_rc_;
+    Eigen::MatrixXd zhat0_rs_;
+    Eigen::MatrixXd zhat0_ic_;
+    Eigen::MatrixXd zhat0_is_;
+
+    /// \brief Flag to select whether to use vectorised calculations. 
+    bool use_vectorised_{false};
+
+    /// \brief Gravity acceleration [m/s^2]
+    double gravity_{9.81};
+
+    /// \brief Horizontal displacement scaling factor. Zero for no displacement
+    double lambda_{0.0};
+
+    // grid parameters
+    double  lx_{1.0};
+    double  ly_{1.0};
+    int     nx_{2};
+    int     ny_{2};
+
+    /// \brief Wind speed at 10m above mean sea level [m]
+    double  u10_{5.0};
+
+    /// \brief Direction of u10. Counter clockwise angle from x-axis [rad]
+    double  phi10_{0.0};
+
+    /// \brief Spreading parameter for the cosine-2S model
+    double  s_param_{5.0};
+
+    /// \brief Parameter controlling the maturity of the sea state.
+    double  cap_omega_c_{0.84};
+
+    // derived quantities
+
+    // sample spacing [m]
+    double  delta_x_{lx_ / nx_};
+    double  delta_y_{ly_ / ny_};
+
+    // fundamental wavelength [m]
+    double  lambda_x_f_{lx_};
+    double  lambda_y_f_{ly_};
+
+    // nyquist wavelength [m]
+    double  lambda_x_nyquist_{2.0 * delta_x_};
+    double  lambda_y_nyquist_{2.0 * delta_y_};
+
+    // fundamental spatial frequency [1/m]
+    double  nu_x_f_{1.0 / lx_};
+    double  nu_y_f_{1.0 / ly_};
+
+    // nyquist spatial frequency [1/m]
+    double  nu_x_nyquist_{1.0 / (2.0 * delta_x_)};
+    double  nu_y_nyquist_{1.0 / (2.0 * delta_y_)};
+
+    // fundamental angular spatial frequency [rad/m]
+    double  kx_f_{2.0 * M_PI / lx_};
+    double  ky_f_{2.0 * M_PI / ly_};
+
+    // nyquist angular spatial frequency [rad/m]
+    double  kx_nyquist_{kx_f_ * nx_ / 2.0};
+    double  ky_nyquist_{ky_f_ * ny_ / 2.0};
+
+    // angular spatial frequencies in fft and math order
+    Eigen::VectorXd kx_fft_;
+    Eigen::VectorXd ky_fft_;
+    Eigen::VectorXd kx_math_;
+    Eigen::VectorXd ky_math_;
+    Eigen::MatrixXd kx_;
+    Eigen::MatrixXd ky_;
+    Eigen::MatrixXd kx2_;
+    Eigen::MatrixXd ky2_;
+    Eigen::MatrixXd k_;
+    Eigen::MatrixXd k_plus_;
+    Eigen::MatrixXd theta_;
+    Eigen::MatrixXd ook_;
+
+    /// \brief Set to 1 to use a symmetric spreading function (standing waves).
+    bool use_symmetric_spreading_fn_{false};
+
+    /// \todo consolidate different storage structures when checked correct
+
+    //////////////////////////////////////////////////
+    /// \note: flattened array storage for non-vectorised version
+
+    // square-root of two-sided discrete elevation variance spectrum
+    Eigen::VectorXd cap_psi_2s_root_;
+
+    // iid random normals for real and imaginary parts of the amplitudes
+    Eigen::VectorXd rho_;
+    Eigen::VectorXd sigma_;
+
+    // angular temporal frequency
+    Eigen::VectorXd omega_k_;
+
+    //////////////////////////////////////////////////
+    /// \note: array storage for vectorised version
+
+    // square-root of two-sided discrete elevation variance spectrum
+    Eigen::MatrixXd cap_psi_2s_root_vec_;
+
+    // iid random normals for real and imaginary parts of the amplitudes
+    Eigen::MatrixXd rho_vec_;
+    Eigen::MatrixXd sigma_vec_;
+
+    // angular temporal frequency
+    Eigen::MatrixXd omega_k_vec_;
+
+    //////////////////////////////////////////////////
+    /// \note: use 2d array storage for reference version, resized if required
+
+    // square-root of two-sided discrete elevation variance spectrum
+    Eigen::MatrixXd cap_psi_2s_root_ref_;
+
+    // iid random normals for real and imaginary parts of the amplitudes
+    Eigen::MatrixXd rho_ref_;
+    Eigen::MatrixXd sigma_ref_;
+
+    // angular temporal frequency
+    Eigen::MatrixXd omega_k_ref_;
+
+    static double ECKVOmniDirectionalSpectrum(
+        double k, double u10, double cap_omega_c=0.84,
+        double gravity=9.81);
+    static double ECKVSpreadingFunction(
+        double k, double phi, double u10, double cap_omega_c=0.84,
+        double gravity=9.81);
+    static double Cos2sSpreadingFunction(
+        double s_param, double phi, double u10, double cap_omega_c=0.84,
+        double gravity=9.81);
+
+    /// \brief For testing
+    friend class TestFixtureWaveSimulationFFT;
+  };
+}
+}
+
+#endif

--- a/gz-waves/src/WaveSimulationFFTRefImpl.hh
+++ b/gz-waves/src/WaveSimulationFFTRefImpl.hh
@@ -37,13 +37,6 @@ namespace Eigen
     Eigen::Dynamic,
     Eigen::RowMajor
   > MatrixXcdRowMajor;
-
-  typedef Eigen::Matrix<
-    double,
-    Eigen::Dynamic,
-    Eigen::Dynamic,
-    Eigen::RowMajor
-  > MatrixXdRowMajor;
 }
 
 namespace gz
@@ -72,8 +65,6 @@ namespace waves
 
     /// \brief Construct a wave simulation model
     WaveSimulationFFTRefImpl(double lx, double ly, int nx, int ny);
-
-    void SetUseVectorised(bool value);
 
     /// \brief Set the components of the wind velocity (U10) in [m/s]
     void SetWindVelocity(double ux, double uy);
@@ -104,23 +95,11 @@ namespace waves
       Eigen::Ref<Eigen::MatrixXd> dsydy,
       Eigen::Ref<Eigen::MatrixXd> dsxdy);
 
-    /// \brief Calculate the base (time-independent) Fourier amplitudes
+    /// \brief Base amplitude calculation
     void ComputeBaseAmplitudes();
 
-    /// \brief Calculate the time-independent Fourier amplitudes
+    /// \brief Time-dependent amplitude calculation
     void ComputeCurrentAmplitudes(double time);
-    
-    void ComputeBaseAmplitudesNonVectorised();
-    void ComputeCurrentAmplitudesNonVectorised(double time);
-
-    void ComputeBaseAmplitudesVectorised();
-    void ComputeCurrentAmplitudesVectorised(double time);
-
-    /// \brief Reference implementation of base amplitude calculation
-    void ComputeBaseAmplitudesReference();
-
-    /// \brief Reference implementation of time-dependent amplitude calculation
-    void ComputeCurrentAmplitudesReference(double time);
 
     void InitFFTCoeffStorage();
     void InitWaveNumbers();
@@ -155,15 +134,6 @@ namespace waves
     fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
     fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
 
-    // precalculated amplitudes (t=0)
-    Eigen::MatrixXd zhat0_rc_;
-    Eigen::MatrixXd zhat0_rs_;
-    Eigen::MatrixXd zhat0_ic_;
-    Eigen::MatrixXd zhat0_is_;
-
-    /// \brief Flag to select whether to use vectorised calculations. 
-    bool use_vectorised_{false};
-
     /// \brief Gravity acceleration [m/s^2]
     double gravity_{9.81};
 
@@ -188,93 +158,31 @@ namespace waves
     /// \brief Parameter controlling the maturity of the sea state.
     double  cap_omega_c_{0.84};
 
-    // derived quantities
-
-    // sample spacing [m]
-    double  delta_x_{lx_ / nx_};
-    double  delta_y_{ly_ / ny_};
-
-    // fundamental wavelength [m]
-    double  lambda_x_f_{lx_};
-    double  lambda_y_f_{ly_};
-
-    // nyquist wavelength [m]
-    double  lambda_x_nyquist_{2.0 * delta_x_};
-    double  lambda_y_nyquist_{2.0 * delta_y_};
-
-    // fundamental spatial frequency [1/m]
-    double  nu_x_f_{1.0 / lx_};
-    double  nu_y_f_{1.0 / ly_};
-
-    // nyquist spatial frequency [1/m]
-    double  nu_x_nyquist_{1.0 / (2.0 * delta_x_)};
-    double  nu_y_nyquist_{1.0 / (2.0 * delta_y_)};
-
     // fundamental angular spatial frequency [rad/m]
     double  kx_f_{2.0 * M_PI / lx_};
     double  ky_f_{2.0 * M_PI / ly_};
-
-    // nyquist angular spatial frequency [rad/m]
-    double  kx_nyquist_{kx_f_ * nx_ / 2.0};
-    double  ky_nyquist_{ky_f_ * ny_ / 2.0};
 
     // angular spatial frequencies in fft and math order
     Eigen::VectorXd kx_fft_;
     Eigen::VectorXd ky_fft_;
     Eigen::VectorXd kx_math_;
     Eigen::VectorXd ky_math_;
-    Eigen::MatrixXd kx_;
-    Eigen::MatrixXd ky_;
-    Eigen::MatrixXd kx2_;
-    Eigen::MatrixXd ky2_;
-    Eigen::MatrixXd k_;
-    Eigen::MatrixXd k_plus_;
-    Eigen::MatrixXd theta_;
-    Eigen::MatrixXd ook_;
 
     /// \brief Set to 1 to use a symmetric spreading function (standing waves).
     bool use_symmetric_spreading_fn_{false};
-
-    /// \todo consolidate different storage structures when checked correct
-
-    //////////////////////////////////////////////////
-    /// \note: flattened array storage for non-vectorised version
-
-    // square-root of two-sided discrete elevation variance spectrum
-    Eigen::VectorXd cap_psi_2s_root_;
-
-    // iid random normals for real and imaginary parts of the amplitudes
-    Eigen::VectorXd rho_;
-    Eigen::VectorXd sigma_;
-
-    // angular temporal frequency
-    Eigen::VectorXd omega_k_;
-
-    //////////////////////////////////////////////////
-    /// \note: array storage for vectorised version
-
-    // square-root of two-sided discrete elevation variance spectrum
-    Eigen::MatrixXd cap_psi_2s_root_vec_;
-
-    // iid random normals for real and imaginary parts of the amplitudes
-    Eigen::MatrixXd rho_vec_;
-    Eigen::MatrixXd sigma_vec_;
-
-    // angular temporal frequency
-    Eigen::MatrixXd omega_k_vec_;
 
     //////////////////////////////////////////////////
     /// \note: use 2d array storage for reference version, resized if required
 
     // square-root of two-sided discrete elevation variance spectrum
-    Eigen::MatrixXd cap_psi_2s_root_ref_;
+    Eigen::MatrixXd cap_psi_2s_root_;
 
     // iid random normals for real and imaginary parts of the amplitudes
-    Eigen::MatrixXd rho_ref_;
-    Eigen::MatrixXd sigma_ref_;
+    Eigen::MatrixXd rho_;
+    Eigen::MatrixXd sigma_;
 
     // angular temporal frequency
-    Eigen::MatrixXd omega_k_ref_;
+    Eigen::MatrixXd omega_k_;
 
     static double ECKVOmniDirectionalSpectrum(
         double k, double u10, double cap_omega_c=0.84,

--- a/gz-waves/src/WaveSimulationFFT_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT_TEST.cc
@@ -643,8 +643,8 @@ TEST_F(TestFixtureWaveSimulationFFT, Indexing)
 }
 
 //////////////////////////////////////////////////
-// Cross-check vectorised version 
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedHermitianTimeZero)
+// Cross-check array version 
+TEST_F(TestFixtureWaveSimulationFFT, HermitianTimeZeroMatrixXd)
 {
   WaveSimulationFFTImpl model1(lx_, ly_, nx_, ny_);
   model1.SetUseVectorised(false);
@@ -698,7 +698,7 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedHermitianTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedHermitianTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT, HermitianTimeNonZeroMatrixXd)
 {
   WaveSimulationFFTImpl model1(lx_, ly_, nx_, ny_);
   model1.SetUseVectorised(false);
@@ -754,7 +754,7 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedHermitianTimeNonZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedParsevalsIdentityTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT, ParsevalsIdentityTimeZeroMatrixXd)
 {
   int n2 = nx_ * ny_;
 
@@ -783,7 +783,7 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedParsevalsIdentityTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedParsevalsIdentityTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT, ParsevalsIdentityTimeNonZeroMatrixXd)
 {
   int n2 = nx_ * ny_;
 
@@ -812,7 +812,8 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedParsevalsIdentityTimeNonZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedHorizontalDisplacementsLambdaZero)
+TEST_F(TestFixtureWaveSimulationFFT,
+  HorizontalDisplacementsLambdaZeroMatrixXd)
 {
   int n2 = nx_ * ny_;
 
@@ -839,7 +840,7 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedHorizontalDisplacementsLambdaZero
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT, ElevationTimeZeroMatrixXd)
 {
   int n2 = nx_ * ny_;
 
@@ -869,7 +870,7 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT, ElevationTimeNonZeroMatrixXd)
 {
   int n2 = nx_ * ny_;
 
@@ -899,7 +900,7 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationTimeNonZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedDisplacement)
+TEST_F(TestFixtureWaveSimulationFFT, DisplacementMatrixXd)
 {
   int n2 = nx_ * ny_;
 
@@ -936,7 +937,7 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedDisplacement)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationDerivatives)
+TEST_F(TestFixtureWaveSimulationFFT, ElevationDerivativesMatrixXd)
 {
   int n2 = nx_ * ny_;
 
@@ -970,7 +971,7 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationDerivatives)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT, VectorisedDisplacementDerivatives)
+TEST_F(TestFixtureWaveSimulationFFT, DisplacementDerivativesMatrixXd)
 {
   int n2 = nx_ * ny_;
 

--- a/gz-waves/src/WaveSimulationFFT_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT_TEST.cc
@@ -13,9 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "gz/waves/WaveSimulationFFT2.hh"
+#include "gz/waves/WaveSimulationFFT.hh"
 
-#include "WaveSimulationFFT2Impl.hh"
+#include "WaveSimulationFFTImpl.hh"
 
 #include <gtest/gtest.h>
 
@@ -32,15 +32,15 @@ using namespace waves;
 
 //////////////////////////////////////////////////
 // Define fixture
-class TestFixtureWaveSimulationFFT2: public ::testing::Test
+class TestFixtureWaveSimulationFFT: public ::testing::Test
 { 
 public: 
-  virtual ~TestFixtureWaveSimulationFFT2()
+  virtual ~TestFixtureWaveSimulationFFT()
   {
     // cleanup any pending stuff, but no exceptions allowed
   }
 
-  TestFixtureWaveSimulationFFT2()
+  TestFixtureWaveSimulationFFT()
   {
     // initialization code here
   } 
@@ -65,9 +65,9 @@ public:
 
 //////////////////////////////////////////////////
 // Define tests
-TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
+TEST_F(TestFixtureWaveSimulationFFT, AngularSpatialWavenumber)
 {
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
 
   // check array dimensions
   EXPECT_EQ(model.kx_fft_.size(), nx_);
@@ -115,9 +115,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, AngularSpatialWavenumber)
 
 //////////////////////////////////////////////////
 // Reference version checks
-TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
+TEST_F(TestFixtureWaveSimulationFFT, HermitianTimeZeroReference)
 {
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(0.0);
 
@@ -148,9 +148,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZeroReference)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
+TEST_F(TestFixtureWaveSimulationFFT, HermitianTimeNonZeroReference)
 {
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(11.2);
 
@@ -187,11 +187,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZeroReference)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
+TEST_F(TestFixtureWaveSimulationFFT, ParsevalsIdentityTimeZeroReference)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(0.0);
 
@@ -214,11 +214,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZeroReference)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
+TEST_F(TestFixtureWaveSimulationFFT, ParsevalsIdentityTimeNonZeroReference)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudesReference();
   model.ComputeCurrentAmplitudesReference(25.3);
 
@@ -242,11 +242,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZeroReference)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference)
+TEST_F(TestFixtureWaveSimulationFFT, HorizontalDisplacementsLambdaZeroReference)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
 
   // displacements should be zero when lamda = 0
   model.SetLambda(0.0);
@@ -269,9 +269,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZeroReference
 
 //////////////////////////////////////////////////
 // Optimised version checks
-TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT, HermitianTimeZero)
 {
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
@@ -305,9 +305,9 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT, HermitianTimeNonZero)
 {
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(11.2);
 
@@ -344,11 +344,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, HermitianTimeNonZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT, ParsevalsIdentityTimeZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
@@ -372,11 +372,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT, ParsevalsIdentityTimeNonZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(25.3);
 
@@ -400,11 +400,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, ParsevalsIdentityTimeNonZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
+TEST_F(TestFixtureWaveSimulationFFT, HorizontalDisplacementsLambdaZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
 
   // displacements should be zero when lamda = 0
   model.SetLambda(0.0);
@@ -427,18 +427,18 @@ TEST_F(TestFixtureWaveSimulationFFT2, HorizontalDisplacementsLambdaZero)
 
 //////////////////////////////////////////////////
 // Cross-check optimised version against reference 
-TEST_F(TestFixtureWaveSimulationFFT2, ElevationTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT, ElevationTimeZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(0.0);
 
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
@@ -455,18 +455,18 @@ TEST_F(TestFixtureWaveSimulationFFT2, ElevationTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, ElevationTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT, ElevationTimeNonZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(31.7);
 
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(31.7);
 
@@ -483,11 +483,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, ElevationTimeNonZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
+TEST_F(TestFixtureWaveSimulationFFT, Displacement)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
 
@@ -495,7 +495,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
   Eigen::MatrixXd ref_sy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeDisplacements(ref_sx, ref_sy);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
 
@@ -516,11 +516,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, Displacement)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, ElevationDerivatives)
+TEST_F(TestFixtureWaveSimulationFFT, ElevationDerivatives)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
 
@@ -528,7 +528,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, ElevationDerivatives)
   Eigen::MatrixXd ref_dhdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevationDerivatives(ref_dhdx, ref_dhdy);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
 
@@ -549,11 +549,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, ElevationDerivatives)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, DisplacementDerivatives)
+TEST_F(TestFixtureWaveSimulationFFT, DisplacementDerivatives)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
 
@@ -562,7 +562,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, DisplacementDerivatives)
   Eigen::MatrixXd ref_dsxdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeDisplacementsDerivatives(ref_dsxdx, ref_dsydy, ref_dsxdy);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
 
@@ -588,7 +588,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, DisplacementDerivatives)
 
 //////////////////////////////////////////////////
 // check we're the indexing / stride rules used in the FFT routines
-TEST_F(TestFixtureWaveSimulationFFT2, Indexing)
+TEST_F(TestFixtureWaveSimulationFFT, Indexing)
 {
   int nxx = 4;
   int nyy = 3;
@@ -643,14 +643,14 @@ TEST_F(TestFixtureWaveSimulationFFT2, Indexing)
 
 //////////////////////////////////////////////////
 // Cross-check vectorised version 
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedHermitianTimeZero)
 {
-  WaveSimulationFFT2Impl model1(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model1(lx_, ly_, nx_, ny_);
   model1.SetUseVectorised(false);
   model1.ComputeBaseAmplitudes();
   model1.ComputeCurrentAmplitudes(0.0);
 
-  WaveSimulationFFT2Impl model2(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model2(lx_, ly_, nx_, ny_);
   model2.SetUseVectorised(true);
   model2.ComputeBaseAmplitudes();
   model2.ComputeCurrentAmplitudes(0.0);
@@ -697,14 +697,14 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedHermitianTimeNonZero)
 {
-  WaveSimulationFFT2Impl model1(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model1(lx_, ly_, nx_, ny_);
   model1.SetUseVectorised(false);
   model1.ComputeBaseAmplitudes();
   model1.ComputeCurrentAmplitudes(13.6);
 
-  WaveSimulationFFT2Impl model2(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model2(lx_, ly_, nx_, ny_);
   model2.SetUseVectorised(true);
   model2.ComputeBaseAmplitudes();
   model2.ComputeCurrentAmplitudes(13.6);
@@ -753,11 +753,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHermitianTimeNonZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedParsevalsIdentityTimeZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(true);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
@@ -782,11 +782,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedParsevalsIdentityTimeNonZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(true);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(25.3);
@@ -811,11 +811,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedParsevalsIdentityTimeNonZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHorizontalDisplacementsLambdaZero)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedHorizontalDisplacementsLambdaZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
 
   // displacements should be zero when lamda = 0
   model.SetUseVectorised(true);
@@ -838,11 +838,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedHorizontalDisplacementsLambdaZer
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeZero)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationTimeZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.SetUseVectorised(false);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(0.0);
@@ -850,7 +850,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeZero)
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(true);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
@@ -869,11 +869,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeNonZero)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationTimeNonZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.SetUseVectorised(false);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(31.7);
@@ -881,7 +881,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeNonZero)
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(true);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(31.7);
@@ -900,11 +900,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationTimeNonZero)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedDisplacement)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedDisplacement)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.SetUseVectorised(false);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
@@ -913,7 +913,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedDisplacement)
   Eigen::MatrixXd ref_sy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeDisplacements(ref_sx, ref_sy);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(true);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
@@ -938,11 +938,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedDisplacement)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationDerivatives)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationDerivatives)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.SetUseVectorised(false);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
@@ -951,7 +951,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationDerivatives)
   Eigen::MatrixXd ref_dhdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevationDerivatives(ref_dhdx, ref_dhdy);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(true);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);
@@ -973,11 +973,11 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedElevationDerivatives)
 }
 
 //////////////////////////////////////////////////
-TEST_F(TestFixtureWaveSimulationFFT2, VectorisedDisplacementDerivatives)
+TEST_F(TestFixtureWaveSimulationFFT, VectorisedDisplacementDerivatives)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFT2Impl ref_model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
   ref_model.SetUseVectorised(false);
   ref_model.ComputeBaseAmplitudesReference();
   ref_model.ComputeCurrentAmplitudesReference(12.2);
@@ -987,7 +987,7 @@ TEST_F(TestFixtureWaveSimulationFFT2, VectorisedDisplacementDerivatives)
   Eigen::MatrixXd ref_dsxdy = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeDisplacementsDerivatives(ref_dsxdx, ref_dsydy, ref_dsxdy);
 
-  WaveSimulationFFT2Impl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(true);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(12.2);

--- a/gz-waves/src/WaveSimulationFFT_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT_TEST.cc
@@ -16,6 +16,7 @@
 #include "gz/waves/WaveSimulationFFT.hh"
 
 #include "WaveSimulationFFTImpl.hh"
+#include "WaveSimulationFFTRefImpl.hh"
 
 #include <gtest/gtest.h>
 
@@ -117,9 +118,9 @@ TEST_F(TestFixtureWaveSimulationFFT, AngularSpatialWavenumber)
 // Reference version checks
 TEST_F(TestFixtureWaveSimulationFFT, HermitianTimeZeroReference)
 {
-  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
-  model.ComputeBaseAmplitudesReference();
-  model.ComputeCurrentAmplitudesReference(0.0);
+  WaveSimulationFFTRefImpl model(lx_, ly_, nx_, ny_);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(0.0);
 
   for (int ikx=0; ikx<nx_; ++ikx)
   {
@@ -150,9 +151,9 @@ TEST_F(TestFixtureWaveSimulationFFT, HermitianTimeZeroReference)
 //////////////////////////////////////////////////
 TEST_F(TestFixtureWaveSimulationFFT, HermitianTimeNonZeroReference)
 {
-  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
-  model.ComputeBaseAmplitudesReference();
-  model.ComputeCurrentAmplitudesReference(11.2);
+  WaveSimulationFFTRefImpl model(lx_, ly_, nx_, ny_);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(11.2);
 
   for (int ikx=0, idx=0; ikx<nx_; ++ikx)
   {
@@ -191,9 +192,9 @@ TEST_F(TestFixtureWaveSimulationFFT, ParsevalsIdentityTimeZeroReference)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
-  model.ComputeBaseAmplitudesReference();
-  model.ComputeCurrentAmplitudesReference(0.0);
+  WaveSimulationFFTRefImpl model(lx_, ly_, nx_, ny_);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(0.0);
 
   Eigen::MatrixXd z = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeElevation(z);
@@ -218,9 +219,9 @@ TEST_F(TestFixtureWaveSimulationFFT, ParsevalsIdentityTimeNonZeroReference)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
-  model.ComputeBaseAmplitudesReference();
-  model.ComputeCurrentAmplitudesReference(25.3);
+  WaveSimulationFFTRefImpl model(lx_, ly_, nx_, ny_);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(25.3);
 
   Eigen::MatrixXd z = Eigen::MatrixXd::Zero(n2, 1);
   model.ComputeElevation(z);
@@ -246,12 +247,12 @@ TEST_F(TestFixtureWaveSimulationFFT, HorizontalDisplacementsLambdaZeroReference)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl model(lx_, ly_, nx_, ny_);
+  WaveSimulationFFTRefImpl model(lx_, ly_, nx_, ny_);
 
   // displacements should be zero when lamda = 0
   model.SetLambda(0.0);
-  model.ComputeBaseAmplitudesReference();
-  model.ComputeCurrentAmplitudesReference(10.0);
+  model.ComputeBaseAmplitudes();
+  model.ComputeCurrentAmplitudes(10.0);
 
   Eigen::MatrixXd sx = Eigen::MatrixXd::Zero(n2, 1);
   Eigen::MatrixXd sy = Eigen::MatrixXd::Zero(n2, 1);
@@ -431,9 +432,9 @@ TEST_F(TestFixtureWaveSimulationFFT, ElevationTimeZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(0.0);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(0.0);
 
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
@@ -459,9 +460,9 @@ TEST_F(TestFixtureWaveSimulationFFT, ElevationTimeNonZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(31.7);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(31.7);
 
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
@@ -487,9 +488,9 @@ TEST_F(TestFixtureWaveSimulationFFT, Displacement)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(12.2);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(12.2);
 
   Eigen::MatrixXd ref_sx = Eigen::MatrixXd::Zero(n2, 1);
   Eigen::MatrixXd ref_sy = Eigen::MatrixXd::Zero(n2, 1);
@@ -520,9 +521,9 @@ TEST_F(TestFixtureWaveSimulationFFT, ElevationDerivatives)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(12.2);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(12.2);
 
   Eigen::MatrixXd ref_dhdx = Eigen::MatrixXd::Zero(n2, 1);
   Eigen::MatrixXd ref_dhdy = Eigen::MatrixXd::Zero(n2, 1);
@@ -553,9 +554,9 @@ TEST_F(TestFixtureWaveSimulationFFT, DisplacementDerivatives)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(12.2);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(12.2);
 
   Eigen::MatrixXd ref_dsxdx = Eigen::MatrixXd::Zero(n2, 1);
   Eigen::MatrixXd ref_dsydy = Eigen::MatrixXd::Zero(n2, 1);
@@ -842,10 +843,9 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationTimeZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.SetUseVectorised(false);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(0.0);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(0.0);
 
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
@@ -873,10 +873,9 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationTimeNonZero)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.SetUseVectorised(false);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(31.7);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(31.7);
 
   Eigen::MatrixXd ref_z = Eigen::MatrixXd::Zero(n2, 1);
   ref_model.ComputeElevation(ref_z);
@@ -904,10 +903,9 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedDisplacement)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.SetUseVectorised(false);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(12.2);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(12.2);
 
   Eigen::MatrixXd ref_sx = Eigen::MatrixXd::Zero(n2, 1);
   Eigen::MatrixXd ref_sy = Eigen::MatrixXd::Zero(n2, 1);
@@ -942,10 +940,9 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedElevationDerivatives)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.SetUseVectorised(false);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(12.2);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(12.2);
 
   Eigen::MatrixXd ref_dhdx = Eigen::MatrixXd::Zero(n2, 1);
   Eigen::MatrixXd ref_dhdy = Eigen::MatrixXd::Zero(n2, 1);
@@ -977,10 +974,9 @@ TEST_F(TestFixtureWaveSimulationFFT, VectorisedDisplacementDerivatives)
 {
   int n2 = nx_ * ny_;
 
-  WaveSimulationFFTImpl ref_model(lx_, ly_, nx_, ny_);
-  ref_model.SetUseVectorised(false);
-  ref_model.ComputeBaseAmplitudesReference();
-  ref_model.ComputeCurrentAmplitudesReference(12.2);
+  WaveSimulationFFTRefImpl ref_model(lx_, ly_, nx_, ny_);
+  ref_model.ComputeBaseAmplitudes();
+  ref_model.ComputeCurrentAmplitudes(12.2);
 
   Eigen::MatrixXd ref_dsxdx = Eigen::MatrixXd::Zero(n2, 1);
   Eigen::MatrixXd ref_dsydy = Eigen::MatrixXd::Zero(n2, 1);

--- a/gz-waves/src/WaveSimulation_TEST.cc
+++ b/gz-waves/src/WaveSimulation_TEST.cc
@@ -226,7 +226,7 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestDisplacementsDirX)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedGrid)
+TEST_F(WaveSimulationSinusoidTestSuite, TestEigenMeshGrid)
 {
   // check the behaviour of Eigen meshgrid
 
@@ -276,7 +276,7 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedGrid)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightsDirX)
+TEST_F(WaveSimulationSinusoidTestSuite, TestHeightsDirXMatrixXd)
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
@@ -286,12 +286,12 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightsDirX)
   wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
-  // vectorised
+  // array
   Eigen::VectorXd h1 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(true);
   wave_sim->ComputeElevation(h1);
  
-  // non-vectorised
+  // non-array
   Eigen::VectorXd h2 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeElevation(h2);
@@ -306,7 +306,7 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightsDirX)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightsDirXY)
+TEST_F(WaveSimulationSinusoidTestSuite, TestHeightsDirXYMatrixXd)
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
@@ -316,12 +316,12 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightsDirXY)
   wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
-  // vectorised
+  // array
   Eigen::VectorXd h1 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(true);
   wave_sim->ComputeElevation(h1);
  
-  // non-vectorised
+  // non-array
   Eigen::VectorXd h2 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeElevation(h2);
@@ -336,7 +336,7 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightsDirXY)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedDisplacments)
+TEST_F(WaveSimulationSinusoidTestSuite, TestDisplacmentsMatrixXd)
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
@@ -346,13 +346,13 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedDisplacments)
   wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
-  // vectorised
+  // array
   Eigen::VectorXd sx1 = Eigen::VectorXd::Zero(nx_ * ny_);
   Eigen::VectorXd sy1 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(true);
   wave_sim->ComputeDisplacements(sx1, sy1);
  
-  // non-vectorised
+  // non-array
   Eigen::VectorXd sx2 = Eigen::VectorXd::Zero(nx_ * ny_);
   Eigen::VectorXd sy2 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(false);
@@ -369,7 +369,7 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedDisplacments)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightDerivatives)
+TEST_F(WaveSimulationSinusoidTestSuite, TestHeightDerivativesMatrixXd)
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
@@ -379,13 +379,13 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightDerivatives)
   wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
-  // vectorised
+  // array
   Eigen::VectorXd dhdx1 = Eigen::VectorXd::Zero(nx_ * ny_);
   Eigen::VectorXd dhdy1 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(true);
   wave_sim->ComputeElevationDerivatives(dhdx1, dhdy1);
  
-  // non-vectorised
+  // non-array
   Eigen::VectorXd dhdx2 = Eigen::VectorXd::Zero(nx_ * ny_);
   Eigen::VectorXd dhdy2 = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->SetUseVectorised(false);
@@ -402,8 +402,7 @@ TEST_F(WaveSimulationSinusoidTestSuite, TestVectorisedHeightDerivatives)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSimulationSinusoidTestSuite,
-    TestVectorisedDisplacementsAndDerivatives)
+TEST_F(WaveSimulationSinusoidTestSuite, TestDisplacementsAndDerivativesMatrixXd)
 { 
   // Wave simulation
   std::unique_ptr<WaveSimulationSinusoid> wave_sim(
@@ -413,7 +412,7 @@ TEST_F(WaveSimulationSinusoidTestSuite,
   wave_sim->SetPeriod(period_);
   wave_sim->SetTime(5.0);
   
-  // vectorised
+  // array
   Eigen::VectorXd h1 = Eigen::VectorXd::Zero(nx_ * ny_);
   Eigen::VectorXd sx1 = Eigen::VectorXd::Zero(nx_ * ny_);
   Eigen::VectorXd sy1 = Eigen::VectorXd::Zero(nx_ * ny_);
@@ -426,7 +425,7 @@ TEST_F(WaveSimulationSinusoidTestSuite,
   wave_sim->ComputeDisplacementsAndDerivatives(
     h1, sx1, sy1, dhdx1, dhdy1, dsxdx1, dsydy1, dsxdy1);
  
-  // non-vectorised
+  // non-array
   Eigen::VectorXd h2 = Eigen::VectorXd::Zero(nx_ * ny_);
   Eigen::VectorXd sx2 = Eigen::VectorXd::Zero(nx_ * ny_);
   Eigen::VectorXd sy2 = Eigen::VectorXd::Zero(nx_ * ny_);

--- a/gz-waves/src/WaveSpectrum.cc
+++ b/gz-waves/src/WaveSpectrum.cc
@@ -69,9 +69,11 @@ void PiersonMoskowitzWaveSpectrum::Evaluate(
     Eigen::Ref<Eigen::MatrixXd> spectrum,
     const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
+  /// \note Eigen asserts cbegin and cend are from the same expression.
+  auto k_view = k.reshaped();
   std::transform(
-    k.reshaped().cbegin(),
-    k.reshaped().cend(),
+    k_view.cbegin(),
+    k_view.cend(),
     spectrum.reshaped().begin(),
     [this] (double k_i) -> double
     {
@@ -201,9 +203,10 @@ void ECKVWaveSpectrum::Evaluate(
     Eigen::Ref<Eigen::MatrixXd> spectrum,
     const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
+  auto k_view = k.reshaped();
   std::transform(
-    k.reshaped().cbegin(),
-    k.reshaped().cend(),
+    k_view.cbegin(),
+    k_view.cend(),
     spectrum.reshaped().begin(),
     [this] (double k_i) -> double
     {

--- a/gz-waves/src/WaveSpectrum.cc
+++ b/gz-waves/src/WaveSpectrum.cc
@@ -15,6 +15,7 @@
 
 #include "gz/waves/WaveSpectrum.hh"
 
+#include <algorithm>
 #include <cmath>
 
 using namespace gz;
@@ -68,36 +69,15 @@ void PiersonMoskowitzWaveSpectrum::Evaluate(
     Eigen::Ref<Eigen::MatrixXd> spectrum,
     const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
-  auto rows =  spectrum.rows();
-  auto cols =  spectrum.cols();
-
-  if (std::abs(u19_) < 1.0E-8)
-  {
-    spectrum.setZero();
-  }
-
-  // array1 k has no zero elements
-  Eigen::MatrixXd k1 = (k.array() == 0).select(
-      Eigen::MatrixXd::Ones(rows, cols), k);
-
-  // constants
-  const double alpha = 0.0081;
-  const double beta = 0.74;
-
-  // intermediates
-  double g2 = gravity_ * gravity_;
-  double u2 = u19_ * u19_;
-  double u4 = u2 * u2;
-  Eigen::MatrixXd k2 = Eigen::pow(k1.array(), 2.0);
-  Eigen::MatrixXd k3 = Eigen::pow(k1.array(), 3.0);
-
-  // evaluate for k1
-  Eigen::MatrixXd cap_s = alpha / 2.0 / k3.array()
-      * Eigen::exp(-beta * g2 / k2.array() / u4);
-
-  // apply filter for k
-  spectrum = (k.array() == 0).select(
-      Eigen::MatrixXd::Zero(rows, cols), cap_s);
+  std::transform(
+    k.reshaped().cbegin(),
+    k.reshaped().cend(),
+    spectrum.reshaped().begin(),
+    [this] (double k_i) -> double
+    {
+      return this->Evaluate(k_i);
+    }
+  );
 }
 
 //////////////////////////////////////////////////
@@ -221,90 +201,15 @@ void ECKVWaveSpectrum::Evaluate(
     Eigen::Ref<Eigen::MatrixXd> spectrum,
     const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
-  auto rows =  spectrum.rows();
-  auto cols =  spectrum.cols();
-
-  if (std::abs(u10_) < 1.0E-8)
-  {
-    spectrum.setZero();
-  }
-
-  // array k1 has no zero elements
-  Eigen::MatrixXd k1 = (k.array() == 0).select(
-      Eigen::MatrixXd::Ones(rows, cols), k);
-
-  // constants
-  const double alpha = 0.0081;
-  const double beta = 1.25;
-  const double cd_10n = 0.00144;
-  const double ao = 0.1733;
-  const double ap = 4.0;
-  const double km = 370.0;
-  const double cm = 0.23;
-
-  // intermediates
-  double u_star = std::sqrt(cd_10n) * u10_;
-  double am = 0.13 * u_star / cm;
-  
-  double gamma = 1.7;
-  if (cap_omega_c_ < 1.0)
-  {
-    gamma = 1.7;
-  }
-  else
-  {
-    gamma = 1.7 + 6.0 * std::log10(cap_omega_c_);
-  }
-
-  double sigma = 0.08 * (1.0 + 4.0 * std::pow(cap_omega_c_, -3.0));
-  double alpha_p = 0.006 * std::pow(cap_omega_c_, 0.55);
-
-  double alpha_m; 
-  if (u_star <= cm)
-  {
-    alpha_m = 0.01 * (1.0 + std::log(u_star / cm));
-  }
-  else
-  {
-    alpha_m = 0.01 * (1.0 + 3.0 * std::log(u_star / cm));
-  }
-
-  double ko = gravity_ / u10_ / u10_;
-  double kp = ko * cap_omega_c_ * cap_omega_c_;
-  double cp = std::sqrt(gravity_ / kp);
-
-  Eigen::MatrixXd c  = Eigen::sqrt(
-      (gravity_ / k1.array()) * (1.0 + Eigen::pow(k1.array() / km, 2.0))
+  std::transform(
+    k.reshaped().cbegin(),
+    k.reshaped().cend(),
+    spectrum.reshaped().begin(),
+    [this] (double k_i) -> double
+    {
+      return this->Evaluate(k_i);
+    }
   );
-
-  Eigen::MatrixXd l_pm = Eigen::exp(
-      -1.25 * Eigen::pow(kp / k1.array(), 2.0)
-  );
-  
-  Eigen::MatrixXd cap_gamma = Eigen::exp(
-      -1.0/(2.0 * std::pow(sigma, 2.0))
-      * Eigen::pow(Eigen::sqrt(k1.array() / kp) - 1.0, 2.0)
-  );
-  
-  Eigen::MatrixXd j_p = Eigen::pow(gamma, cap_gamma.array());
-  
-  Eigen::MatrixXd f_p = l_pm.array() * j_p.array() * Eigen::exp(
-      -0.3162 * cap_omega_c_ * (Eigen::sqrt(k1.array() / kp) - 1.0)
-  );
-
-  Eigen::MatrixXd f_m = l_pm.array() * j_p.array() * Eigen::exp(
-      -0.25 * Eigen::pow(k1.array() / km - 1.0, 2.0)
-  );
-
-  Eigen::MatrixXd b_l = 0.5 * alpha_p * (cp / c.array()) * f_p.array();
-  Eigen::MatrixXd b_h = 0.5 * alpha_m * (cm / c.array()) * f_m.array();
-  
-  Eigen::MatrixXd k3 = Eigen::pow(k1.array(), 3.0);
-  Eigen::MatrixXd cap_s = (b_l.array() + b_h.array()) / k3.array();
-
-   // apply filter
-  spectrum = (k.array() == 0).select(
-      Eigen::MatrixXd::Zero(rows, cols), cap_s);
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/WaveSpectrum_TEST.cc
+++ b/gz-waves/src/WaveSpectrum_TEST.cc
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/WaveSpectrum.hh"
-#include "WaveSimulationFFT2Impl.hh"
+#include "WaveSimulationFFTImpl.hh"
 
 #include <memory>
 #include <vector>
@@ -335,7 +335,7 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
       for (int j=0; j<ny; ++j)
       {
         double cap_s_test =
-            WaveSimulationFFT2Impl::ECKVOmniDirectionalSpectrum(
+            WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
                 k(i, j), u10, cap_omega_c);
         EXPECT_NEAR(cap_s(i, j), cap_s_test, tolerance);
       }

--- a/gz-waves/src/WaveSpectrum_TEST.cc
+++ b/gz-waves/src/WaveSpectrum_TEST.cc
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/WaveSpectrum.hh"
-#include "WaveSimulationFFTImpl.hh"
+#include "WaveSimulationFFTRefImpl.hh"
 
 #include <memory>
 #include <vector>
@@ -335,7 +335,7 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
       for (int j=0; j<ny; ++j)
       {
         double cap_s_test =
-            WaveSimulationFFTImpl::ECKVOmniDirectionalSpectrum(
+            WaveSimulationFFTRefImpl::ECKVOmniDirectionalSpectrum(
                 k(i, j), u10, cap_omega_c);
         EXPECT_NEAR(cap_s(i, j), cap_s_test, tolerance);
       }

--- a/gz-waves/src/WaveSpectrum_TEST.cc
+++ b/gz-waves/src/WaveSpectrum_TEST.cc
@@ -103,9 +103,9 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
   }
 }
 
-TEST(WaveSpectrum, PiersonMoskowitzSpectrumVectorised)
+TEST(WaveSpectrum, PiersonMoskowitzSpectrumMatrixXd)
 {
-  { // Eigen vectorised version
+  { // Eigen array version
     double tolerance = 1.0e-16;
 
     double lx = 200.0;
@@ -232,9 +232,9 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
   }
 }
 
-TEST(WaveSpectrum, ECKVSpectrumVectorised)
+TEST(WaveSpectrum, ECKVSpectrumMatrixXd)
 {
-  { // Eigen vectorised version
+  { // Eigen array version
     double tolerance = 1.0e-16;
 
     double lx = 200.0;
@@ -290,7 +290,7 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
   const double u10 = 5.0;
   const double cap_omega_c = 0.84;
 
-  { // Eigen vectorised version
+  { // Eigen array version
     double tolerance = 1.0e-16;
 
     double lx = 200.0;

--- a/gz-waves/src/WaveSpreadingFunction.cc
+++ b/gz-waves/src/WaveSpreadingFunction.cc
@@ -15,6 +15,7 @@
 
 #include "gz/waves/WaveSpreadingFunction.hh"
 
+#include <algorithm>
 #include <cmath>
 
 using namespace gz; 
@@ -57,10 +58,15 @@ void Cos2sSpreadingFunction::Evaluate(
     double theta_mean,
     const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
-  Eigen::MatrixXd angle = theta.array() - theta_mean;
-  Eigen::MatrixXd cp = Eigen::cos(angle.array() / 2.0);
-  Eigen::MatrixXd p1 = Eigen::pow(cp.array(), 2.0 * spread_);
-  phi = cap_c_s_ * p1.array();
+  std::transform(
+    theta.reshaped().cbegin(),
+    theta.reshaped().cend(),
+    phi.reshaped().begin(),
+    [&, this] (double theta_i) -> double
+    {
+      return this->Evaluate(theta_i, theta_mean);
+    }
+  );
 }
 
 //////////////////////////////////////////////////
@@ -79,9 +85,9 @@ void Cos2sSpreadingFunction::SetSpread(double value)
 //////////////////////////////////////////////////
 void Cos2sSpreadingFunction::RecalcCoeffs()
 {
-    double g1 = std::tgamma(spread_ + 1.0);
-    double g2 = std::tgamma(spread_ + 0.5);
-    cap_c_s_ = g1 / g2 / 2.0 / std::sqrt(M_PI);
+  double g1 = std::tgamma(spread_ + 1.0);
+  double g2 = std::tgamma(spread_ + 0.5);
+  cap_c_s_ = g1 / g2 / 2.0 / std::sqrt(M_PI);
 }
 
 //////////////////////////////////////////////////
@@ -95,10 +101,10 @@ ECKVSpreadingFunction::ECKVSpreadingFunction(
     double u10,
     double cap_omega_c,
     double gravity) :
-    DirectionalSpreadingFunction(),
-    u10_(u10),
-    cap_omega_c_(cap_omega_c),
-    gravity_(gravity)
+  DirectionalSpreadingFunction(),
+  u10_(u10),
+  cap_omega_c_(cap_omega_c),
+  gravity_(gravity)
 {
 }
 
@@ -107,7 +113,7 @@ double ECKVSpreadingFunction::Evaluate(
     double theta, double theta_mean, double k) const
 {
   double angle = theta - theta_mean;
-  
+
   const double cd_10n = 0.00144;
   const double ao = 0.1733;
   const double ap = 4.0;
@@ -134,27 +140,16 @@ void ECKVSpreadingFunction::Evaluate(
     double theta_mean,
     const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
-  /// \todo check the size of phi, theta and k match
-  
-  const double cd_10n = 0.00144;
-  const double ao = 0.1733;
-  const double ap = 4.0;
-  const double km = 370.0;
-  const double cm = 0.23;
-  double u_star = std::sqrt(cd_10n) * u10_;
-  double am = 0.13 * u_star / cm;
-  double ko = gravity_ / u10_ / u10_;
-  double kp = ko * cap_omega_c_ * cap_omega_c_;
-  double cp = std::sqrt(gravity_ / kp);
-
-  Eigen::MatrixXd angle = theta.array() - theta_mean;
-  Eigen::MatrixXd c = Eigen::sqrt((gravity_ / k.array())
-                    * (1.0 + Eigen::pow(k.array() / km, 2.0)));
-  Eigen::MatrixXd p1 = Eigen::pow(c.array() / cp, 2.5);
-  Eigen::MatrixXd p2 = Eigen::pow(cm / c.array(), 2.5);
-  Eigen::MatrixXd t1 = Eigen::tanh(ao + ap * p1.array() + am * p2.array());
-  Eigen::MatrixXd c2p = Eigen::cos(2.0 * angle.array());
-  phi = (1.0 + t1.array() * c2p.array()) / 2.0 / M_PI;
+  std::transform(
+    theta.reshaped().cbegin(),
+    theta.reshaped().cend(),
+    k.reshaped().cbegin(),
+    phi.reshaped().begin(),
+    [&, this] (double theta_i, double k_i) -> double
+    {
+      return this->Evaluate(theta_i, theta_mean, k_i);
+    }
+  );
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/WaveSpreadingFunction.cc
+++ b/gz-waves/src/WaveSpreadingFunction.cc
@@ -58,9 +58,10 @@ void Cos2sSpreadingFunction::Evaluate(
     double theta_mean,
     const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
+  auto theta_view = theta.reshaped();
   std::transform(
-    theta.reshaped().cbegin(),
-    theta.reshaped().cend(),
+    theta_view.cbegin(),
+    theta_view.cend(),
     phi.reshaped().begin(),
     [&, this] (double theta_i) -> double
     {
@@ -140,9 +141,10 @@ void ECKVSpreadingFunction::Evaluate(
     double theta_mean,
     const Eigen::Ref<const Eigen::MatrixXd> &k) const
 {
+  auto theta_view = theta.reshaped();
   std::transform(
-    theta.reshaped().cbegin(),
-    theta.reshaped().cend(),
+    theta_view.cbegin(),
+    theta_view.cend(),
     k.reshaped().cbegin(),
     phi.reshaped().begin(),
     [&, this] (double theta_i, double k_i) -> double

--- a/gz-waves/src/WaveSpreadingFunction_TEST.cc
+++ b/gz-waves/src/WaveSpreadingFunction_TEST.cc
@@ -59,9 +59,9 @@ TEST(WaveSpreadingFunction, Cos2sRegression)
   }
 }
 
-TEST(WaveSpreadingFunction, Cos2sVectorised)
+TEST(WaveSpreadingFunction, Cos2sVectorXd)
 {
-  { // Eigen vectorised version
+  { // Eigen array version
     Cos2sSpreadingFunction spreadingFn;
 
     double theta_mean = 0.0;
@@ -85,9 +85,9 @@ TEST(WaveSpreadingFunction, Cos2sVectorised)
   }
 }
 
-TEST(WaveSpreadingFunction, Cos2sVectorisedNonZeroMean)
+TEST(WaveSpreadingFunction, Cos2sNonZeroMeanVectorXd)
 {
-  { // Eigen vectorised version - non-zero mean
+  { // Eigen array version - non-zero mean
     Cos2sSpreadingFunction spreadingFn;
 
     double theta_mean = 1.5;
@@ -151,7 +151,7 @@ TEST(WaveSpreadingFunction, Cos2sAccessors)
   }
 }
 
-TEST(WaveSpreadingFunction, Cos2sVectorisedVirtual)
+TEST(WaveSpreadingFunction, Cos2sVirtualVectorXd)
 {
   { // Call virtually from base class ptr.
     auto derivedSpreadingFn = std::make_unique<Cos2sSpreadingFunction>();
@@ -191,7 +191,7 @@ TEST(WaveSpreadingFunction, Cos2sFFT2ImplRegression)
   const double u10 = 5.0;
   const double cap_omega_c = 0.84;
 
-  { // Eigen vectorised version
+  { // Eigen array version
     Cos2sSpreadingFunction spreadingFn(spread);
 
     double theta_mean = 0.0;
@@ -217,7 +217,7 @@ TEST(WaveSpreadingFunction, Cos2sFFT2ImplRegression)
   }
 }
 
-TEST(WaveSpreadingFunction, WaveNumberMatrix)
+TEST(WaveSpreadingFunction, WaveNumberMatrixXd)
 {
   { // componentwise operations
     double lx = 200.0;
@@ -350,9 +350,9 @@ TEST(WaveSpreadingFunction, ECKVRegression)
   }
 }
 
-TEST(WaveSpreadingFunction, ECKVVectorisedColVector)
+TEST(WaveSpreadingFunction, ECKVVectorXd)
 {
-  { // Eigen vectorised version
+  { // Eigen array version
     ECKVSpreadingFunction spreadingFn;
 
     double theta_mean = 0.0;
@@ -382,9 +382,9 @@ TEST(WaveSpreadingFunction, ECKVVectorisedColVector)
   }
 }
 
-TEST(WaveSpreadingFunction, ECKVVectorisedMatrix)
+TEST(WaveSpreadingFunction, ECKVMatrixXd)
 {
-  { // Eigen vectorised version
+  { // Eigen array version
     double lx = 200.0;
     double ly = 100.0;
     size_t nx = 32;
@@ -445,7 +445,7 @@ TEST(WaveSpreadingFunction, ECKVFFT2ImplRegression)
   const double u10 = 5.0;
   const double cap_omega_c = 0.84;
 
-  { // Eigen vectorised version
+  { // Eigen array version
     ECKVSpreadingFunction spreadingFn(u10, cap_omega_c);
 
     double theta_mean = 0.0;

--- a/gz-waves/src/WaveSpreadingFunction_TEST.cc
+++ b/gz-waves/src/WaveSpreadingFunction_TEST.cc
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/WaveSpreadingFunction.hh"
-#include "WaveSimulationFFT2Impl.hh"
+#include "WaveSimulationFFTImpl.hh"
 
 #include <memory>
 #include <vector>
@@ -210,7 +210,7 @@ TEST(WaveSpreadingFunction, Cos2sFFT2ImplRegression)
     for (int i=0; i<21; ++i)
     {
       double dtheta = theta(i) - theta_mean;
-      double phi_test = WaveSimulationFFT2Impl::Cos2sSpreadingFunction(
+      double phi_test = WaveSimulationFFTImpl::Cos2sSpreadingFunction(
           spread, dtheta, u10, cap_omega_c);
       EXPECT_DOUBLE_EQ(phi(i), phi_test);
     }
@@ -465,7 +465,7 @@ TEST(WaveSpreadingFunction, ECKVFFT2ImplRegression)
     for (int i=0; i<21; ++i)
     {
       double dtheta = theta(i) - theta_mean;
-      double phi_test = WaveSimulationFFT2Impl::ECKVSpreadingFunction(
+      double phi_test = WaveSimulationFFTImpl::ECKVSpreadingFunction(
           k(i), dtheta, u10, cap_omega_c);
       EXPECT_DOUBLE_EQ(phi(i), phi_test);
     }

--- a/gz-waves/src/WaveSpreadingFunction_TEST.cc
+++ b/gz-waves/src/WaveSpreadingFunction_TEST.cc
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/WaveSpreadingFunction.hh"
-#include "WaveSimulationFFTImpl.hh"
+#include "WaveSimulationFFTRefImpl.hh"
 
 #include <memory>
 #include <vector>
@@ -210,7 +210,7 @@ TEST(WaveSpreadingFunction, Cos2sFFT2ImplRegression)
     for (int i=0; i<21; ++i)
     {
       double dtheta = theta(i) - theta_mean;
-      double phi_test = WaveSimulationFFTImpl::Cos2sSpreadingFunction(
+      double phi_test = WaveSimulationFFTRefImpl::Cos2sSpreadingFunction(
           spread, dtheta, u10, cap_omega_c);
       EXPECT_DOUBLE_EQ(phi(i), phi_test);
     }
@@ -465,7 +465,7 @@ TEST(WaveSpreadingFunction, ECKVFFT2ImplRegression)
     for (int i=0; i<21; ++i)
     {
       double dtheta = theta(i) - theta_mean;
-      double phi_test = WaveSimulationFFTImpl::ECKVSpreadingFunction(
+      double phi_test = WaveSimulationFFTRefImpl::ECKVSpreadingFunction(
           k(i), dtheta, u10, cap_omega_c);
       EXPECT_DOUBLE_EQ(phi(i), phi_test);
     }

--- a/gz-waves/src/systems/waves/WavesVisual.cc
+++ b/gz-waves/src/systems/waves/WavesVisual.cc
@@ -50,7 +50,7 @@
 #include "gz/waves/WaveParameters.hh"
 
 #include "gz/waves/WaveSimulation.hh"
-#include "gz/waves/WaveSimulationFFT2.hh"
+#include "gz/waves/WaveSimulationFFT.hh"
 
 #include <gz/msgs/any.pb.h>
 #include <gz/msgs/param.pb.h>
@@ -898,8 +898,8 @@ void WavesVisualPrivate::InitWaveSim()
   double s   = this->waveParams->Steepness();
 
   // create wave model
-  std::unique_ptr<gz::waves::WaveSimulationFFT2> waveSim(
-      new gz::waves::WaveSimulationFFT2(L, L, N, N));
+  std::unique_ptr<gz::waves::WaveSimulationFFT> waveSim(
+      new gz::waves::WaveSimulationFFT(L, L, N, N));
 
   // set params
   waveSim->SetWindVelocity(ux, uy);

--- a/gz-waves/test/CMakeLists.txt
+++ b/gz-waves/test/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories (
 )
 
 #============================================================================
-# Do a fake install of gz-math in order to test the examples.
+# Do a fake install in order to test the examples.
 #============================================================================
 # install to FAKE_INSTALL_PREFIX defined in root CMakeLists.txt
 
@@ -28,5 +28,5 @@ ExternalProject_Add(
 
 add_subdirectory(gtest_vendor)
 # add_subdirectory(integration)
-# add_subdirectory(performance)
+add_subdirectory(performance)
 # add_subdirectory(regression)

--- a/gz-waves/test/performance/CMakeLists.txt
+++ b/gz-waves/test/performance/CMakeLists.txt
@@ -1,0 +1,14 @@
+gz_get_sources(tests)
+
+if("${CMAKE_BUILD_TYPE_UPPERCASE}" STREQUAL "COVERAGE")
+  list(REMOVE_ITEM tests
+    # add tests to remove here
+  )
+endif()
+
+gz_build_tests(
+  TYPE PERFORMANCE
+  SOURCES ${tests}
+  INCLUDE_DIRS     
+    ${PROJECT_SOURCE_DIR}/src
+)

--- a/gz-waves/test/performance/EigenReturnByValue.cc
+++ b/gz-waves/test/performance/EigenReturnByValue.cc
@@ -1,0 +1,21 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <gtest/gtest.h>
+
+TEST(EigenReturnByValue, MatrixReturnByValue)
+{
+
+}

--- a/gz-waves/test/performance/WaveSimFFTBaseAmplitudes.cc
+++ b/gz-waves/test/performance/WaveSimFFTBaseAmplitudes.cc
@@ -1,0 +1,77 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <chrono>
+#include <iostream>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include <gtest/gtest.h>
+
+#include "WaveSimulationFFTImpl.hh"
+
+using Eigen::MatrixXd;
+
+using std::chrono::steady_clock;
+using std::chrono::milliseconds;
+using std::chrono::duration_cast;
+
+using namespace gz;
+using namespace waves;
+
+TEST(WaveSimulationFFTPerf, BaseAmplitudes)
+{
+  double lx = 200.0;
+  double ly = 100.0;
+  int    nx = 256;
+  int    ny = 126;
+
+  WaveSimulationFFTImpl model(lx, ly, nx, ny);
+
+  int num_runs = 100;
+
+#if 1
+  {
+    model.SetUseVectorised(false);
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      model.ComputeBaseAmplitudes();
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+
+#if 1
+  {
+    model.SetUseVectorised(true);
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      model.ComputeBaseAmplitudes();
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+}

--- a/gz-waves/test/performance/WaveSimFFTCurrentAmplitudes.cc
+++ b/gz-waves/test/performance/WaveSimFFTCurrentAmplitudes.cc
@@ -1,0 +1,85 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <chrono>
+#include <iostream>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include <gtest/gtest.h>
+
+#include "WaveSimulationFFTImpl.hh"
+
+using Eigen::MatrixXd;
+
+using std::chrono::steady_clock;
+using std::chrono::milliseconds;
+using std::chrono::duration_cast;
+
+using namespace gz;
+using namespace waves;
+
+TEST(WaveSimulationFFTPerf, CurrentAmplitudes)
+{
+  double lx = 200.0;
+  double ly = 100.0;
+  int    nx = 256;
+  int    ny = 126;
+
+  WaveSimulationFFTImpl model(lx, ly, nx, ny);
+
+  int num_runs = 1000;
+
+#if 1
+  {
+    model.SetUseVectorised(false);
+    model.ComputeBaseAmplitudes();
+    double sim_time = 0.0;
+    double sim_step = 0.001;
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      model.ComputeCurrentAmplitudes(sim_time);
+      sim_time += sim_step;
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+
+#if 1
+  {
+    model.SetUseVectorised(true);
+    model.ComputeBaseAmplitudes();
+    double sim_time = 0.0;
+    double sim_step = 0.001;
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      model.ComputeCurrentAmplitudes(sim_time);
+      sim_time += sim_step;
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+}

--- a/gz-waves/test/performance/WaveSpectrumECKV.cc
+++ b/gz-waves/test/performance/WaveSpectrumECKV.cc
@@ -1,0 +1,268 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include <gtest/gtest.h>
+
+#include "gz/waves/WaveSpectrum.hh"
+
+using Eigen::MatrixXd;
+
+namespace Eigen
+{ 
+  typedef Eigen::Matrix<
+    double,
+    Eigen::Dynamic,
+    Eigen::Dynamic,
+    Eigen::RowMajor
+  > MatrixXdRowMajor;
+}
+
+using std::chrono::steady_clock;
+using std::chrono::milliseconds;
+using std::chrono::duration_cast;
+
+using namespace gz;
+using namespace waves;
+
+TEST(WaveSpectrumPerf, ECKV)
+{
+  double lx = 200.0;
+  double ly = 100.0;
+  int    nx = 256;
+  int    ny = 126;
+
+  double kx_nyquist = M_PI * nx / lx;
+  double ky_nyquist = M_PI * ny / ly;
+
+  // create wavenumber vectors
+  Eigen::VectorXd kx_v(nx);
+  Eigen::VectorXd ky_v(ny);
+
+  for (size_t i=0; i<nx; ++i)
+  {
+    kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
+  }
+  for (size_t i=0; i<ny; ++i)
+  {
+    ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
+  }
+
+  // broadcast to matrices (aka meshgrid)
+  Eigen::MatrixXd kx = Eigen::MatrixXd::Zero(nx, ny);
+  kx.colwise() += kx_v;
+  
+  Eigen::MatrixXd ky = Eigen::MatrixXd::Zero(nx, ny);
+  ky.rowwise() += ky_v.transpose();
+
+  Eigen::MatrixXd kx2 = Eigen::pow(kx.array(), 2.0);
+  Eigen::MatrixXd ky2 = Eigen::pow(ky.array(), 2.0);
+  Eigen::MatrixXd k = Eigen::sqrt(kx2.array() + ky2.array());
+
+  // spectrum
+  double u19 = 0.0;
+  ECKVWaveSpectrum spectrum(u19);
+
+  int num_runs = 1000;
+
+#if 1
+  { // non-vector version
+    std::cerr << "Eigen::MatrixXd double loop\n";
+    Eigen::MatrixXd cap_s(nx, ny);
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      for (int ikx = 0; ikx < nx; ++ikx)
+      {
+        for (int iky = 0; iky < ny; ++iky)
+        {
+          cap_s(ikx, iky) = spectrum.Evaluate(k(ikx, iky));
+        }
+      }
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+
+#if 1
+  { // loop in 'wrong' order
+    std::cerr << "Eigen::MatrixXd double loop, 'wrong' order\n";
+    Eigen::MatrixXd cap_s(nx, ny);
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      for (int iky = 0; iky < ny; ++iky)
+      {
+        for (int ikx = 0; ikx < nx; ++ikx)
+        {
+          cap_s(ikx, iky) = spectrum.Evaluate(k(ikx, iky));
+        }
+      }
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+
+#if 1
+  { // reshaped
+    std::cerr << "Eigen::MatrixXd reshaped iterator\n";
+    Eigen::MatrixXd cap_s(nx, ny);
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      Eigen::VectorXd k_view = k.reshaped();
+      Eigen::VectorXd cap_s_view = cap_s.reshaped();
+      for (
+        auto it1 = cap_s_view.begin(), it2 = k_view.begin();
+        it1 != cap_s_view.end() && it2 != k_view.end();
+        ++it1, ++it2
+      )
+      {
+        *it1 = spectrum.Evaluate(*it2);
+      }
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+
+#if 1
+  { // using row major std::vector
+    std::cerr << "std::vector double loop\n";
+    std::vector<double> kv(nx * ny);
+    for (int iky = 0, idx = 0; iky < ny; ++iky)
+    {
+      for (int ikx = 0; ikx < nx; ++ikx, ++idx)
+      {
+        kv[idx] = k(ikx, iky);
+      }
+    }
+
+    std::vector<double> cap_s(nx * ny);
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      for (int iky = 0, idx = 0; iky < ny; ++iky)
+      {
+        for (int ikx = 0; ikx < nx; ++ikx, ++idx)
+        {
+          cap_s[idx] = spectrum.Evaluate(kv[idx]);
+        }
+      }
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+
+#if 1
+  { // using row major std::vector
+    std::cerr << "std::vector single loop\n";
+    std::vector<double> kv(nx * ny);
+    for (int iky = 0, idx = 0; iky < ny; ++iky)
+    {
+      for (int ikx = 0; ikx < nx; ++ikx, ++idx)
+      {
+        kv[idx] = k(ikx, iky);
+      }
+    }
+
+    std::vector<double> cap_s(nx * ny);
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      for (int idx = 0; idx < nx * ny; ++idx)
+      {
+        cap_s[idx] = spectrum.Evaluate(kv[idx]);
+      }
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+
+#if 1
+  { // using row major std::vector iterators
+    std::cerr << "std::vector iterators\n";
+    std::vector<double> kv(nx * ny);
+    for (int iky = 0, idx = 0; iky < ny; ++iky)
+    {
+      for (int ikx = 0; ikx < nx; ++ikx, ++idx)
+      {
+        kv[idx] = k(ikx, iky);
+      }
+    }
+
+    std::vector<double> cap_s(nx * ny);
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      for (
+        auto it1 = cap_s.begin(), it2 = kv.begin();
+        it1 != cap_s.end() && it2 != kv.end();
+        ++it1, ++it2
+      )
+      {
+        *it1 = spectrum.Evaluate(*it2);
+      }
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+
+#if 1
+  { // Eigen cwise-array calc
+    std::cerr << "Eigen cwise-array\n";
+    Eigen::MatrixXd cap_s(nx, ny);
+    auto start = steady_clock::now();
+    for (int i = 0; i < num_runs; ++i)
+    {
+      spectrum.Evaluate(cap_s, k);
+    }
+    auto end = steady_clock::now();
+    std::chrono::duration<double, std::milli> duration_ms = end - start;
+    std::cerr << "num_runs:         " << num_runs << "\n";
+    std::cerr << "total time (ms):  " << duration_ms.count() << "\n";
+    std::cerr << "av per run (ms):  " << duration_ms.count() / num_runs << "\n";
+  }
+#endif
+}


### PR DESCRIPTION
This PR is the third part in a series of updates to the wave simulation to improve performance.

## Details

1. Add performance tests under test/performance and add examples for spectrum and FFT simulation calculations.   
2. Replace the component wise implementation of spectrum and spreading function calculations with a std::transform call using the unary / binary version of the evaluate function. This is many times faster than the array based calculation.
3. Split the reference implementation of the FFT calculation out into a separate class.
4. Relabel the indices for the elevation, displacement, etc. data in OceanTile - preparation for aligning the storage order to match the storage used in FFTW to reduce extra copies each update.    