### PR TITLE
CI: clean build warnings

### DIFF
--- a/.github/workflows/ubuntu-jammy-ci.yml
+++ b/.github/workflows/ubuntu-jammy-ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build Wave Sim
         run: |
-          colcon build --symlink-install --merge-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING=ON
+          colcon build --symlink-install --merge-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra"
 
       - name: Test Wave Sim
         run: |

--- a/.github/workflows/ubuntu-jammy-ci.yml
+++ b/.github/workflows/ubuntu-jammy-ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build Wave Sim
         run: |
-          colcon build --symlink-install --merge-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING=ON -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra"
+          colcon build --symlink-install --merge-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING=ON
 
       - name: Test Wave Sim
         run: |

--- a/gz-waves/src/CGAL_TEST.cc
+++ b/gz-waves/src/CGAL_TEST.cc
@@ -113,7 +113,7 @@ TEST(CGAL, SurfaceMesh) {
   typedef CGAL::Simple_cartesian<double> K;
   typedef K::Point_3 Point3;
   typedef K::Plane_3 Plane;
-  typedef K::Vector_3 Vector;
+  // typedef K::Vector_3 Vector;
   typedef K::Segment_3 Segment;
   typedef CGAL::Surface_mesh<Point3> Mesh;
   typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
@@ -157,7 +157,7 @@ TEST(CGAL, SurfaceMesh) {
   if(intersection) {
     // gets intersection object
     if(boost::get<Point3>(&(intersection->first))) {
-      Point3* p = boost::get<Point3>(&(intersection->first));
+      // Point3* p = boost::get<Point3>(&(intersection->first));
       // std::cout << "intersection object is a point " << *p <<  std::endl;
       // std::cout << "with face "<< intersection->second  <<  std::endl;
     }
@@ -181,7 +181,7 @@ TEST(CGAL, SurfaceMesh) {
   Plane_intersection plane_intersection = tree.any_intersection(plane_query);
   if(plane_intersection) {
     if(boost::get<Segment>(&(plane_intersection->first))) {
-      Segment* s = boost::get<Segment>(&(plane_intersection->first));
+      // Segment* s = boost::get<Segment>(&(plane_intersection->first));
       // std::cout << "one intersection object is the segment " << s << std::endl;
       // std::cout << "with face "<< intersection->second  <<  std::endl;
     }
@@ -194,14 +194,14 @@ TEST(CGAL, SurfaceMesh) {
 ///
 TEST(CGAL, AABBPolyhedronFacetIntersection) {
   typedef CGAL::Simple_cartesian<double> K;
-  typedef K::FT FT;
+  // typedef K::FT FT;
   typedef K::Point_3 Point3;
-  typedef K::Segment_3 Segment;
+  // typedef K::Segment_3 Segment;
   typedef CGAL::Polyhedron_3<K> Polyhedron;
   typedef CGAL::AABB_face_graph_triangle_primitive<Polyhedron> Primitive;
   typedef CGAL::AABB_traits<K, Primitive> Traits;
   typedef CGAL::AABB_tree<Traits> Tree;
-  typedef Tree::Point_and_primitive_id Point_and_primitive_id;
+  // typedef Tree::Point_and_primitive_id Point_and_primitive_id;
 
   Point3 p(1.0, 0.0, 0.0);
   Point3 q(0.0, 1.0, 0.0);
@@ -216,20 +216,20 @@ TEST(CGAL, AABBPolyhedronFacetIntersection) {
   tree.accelerate_distance_queries();
 
   // query point
-  Point3 query(0.0, 0.0, 3.0);
+  // Point3 query(0.0, 0.0, 3.0);
 
   // computes squared distance from query
-  FT sqd = tree.squared_distance(query);
+  // FT sqd = tree.squared_distance(query);
   // std::cout << "squared distance: " << sqd << std::endl;
 
   // computes closest point
-  Point3 closest = tree.closest_point(query);
+  // Point3 closest = tree.closest_point(query);
   // std::cout << "closest point: " << closest << std::endl;
 
   // computes closest point and primitive id
-  Point_and_primitive_id pp = tree.closest_point_and_primitive(query);
-  Point3 closest_point = pp.first;
-  Polyhedron::Face_handle f = pp.second; // closest primitive id
+  // Point_and_primitive_id pp = tree.closest_point_and_primitive(query);
+  // Point3 closest_point = pp.first;
+  // Polyhedron::Face_handle f = pp.second; // closest primitive id
   // std::cout << "closest point: " << closest_point << std::endl;
   // std::cout << "closest triangle: ( "
   //   << f->halfedge()->vertex()->point() << " , " 
@@ -241,21 +241,21 @@ TEST(CGAL, AABBPolyhedronFacetIntersection) {
 TEST(CGAL, SurfaceMeshGridCell) {
   typedef CGAL::Simple_cartesian<double> K;
   typedef K::Point_3 Point3;
-  typedef K::Plane_3 Plane;
+  // typedef K::Plane_3 Plane;
   typedef K::Ray_3 Ray;
-  typedef K::Vector_3 Vector3;
-  typedef K::Segment_3 Segment;
+  // typedef K::Vector_3 Vector3;
+  // typedef K::Segment_3 Segment;
 
   typedef CGAL::Surface_mesh<Point3> Mesh;
-  typedef Mesh::Vertex_index vertex_descriptor;
-  typedef Mesh::Face_index face_descriptor;
+  // typedef Mesh::Vertex_index vertex_descriptor;
+  // typedef Mesh::Face_index face_descriptor;
 
   typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
   typedef CGAL::AABB_traits<K, Primitive> Traits;
   typedef CGAL::AABB_tree<Traits> Tree;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
-  typedef Tree::Primitive_id Primitive_id;
+  // typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
+  // typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
+  // typedef Tree::Primitive_id Primitive_id;
 
   typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
 
@@ -277,19 +277,19 @@ TEST(CGAL, SurfaceMeshGridCell) {
 
  { 
     // std::cout << "Vertices " << std::endl;    
-    for(auto&& vertex : mesh.vertices()) {
-      // std::cout << vertex << std::endl;
-    }
+    // for(auto&& vertex : mesh.vertices()) {
+    //   std::cout << vertex << std::endl;
+    // }
   }
 
   { 
     // std::cout << "Faces " << std::endl;
-    for(auto&& face : mesh.faces()) {
-      // std::cout << face << std::endl;
+    // for(auto&& face : mesh.faces()) {
+    //   std::cout << face << std::endl;
 
-      Triangle tri = waves::Geometry::MakeTriangle(mesh, face);
-      // std::cout << tri << std::endl;
-    }
+    //   Triangle tri = waves::Geometry::MakeTriangle(mesh, face);
+    //   std::cout << tri << std::endl;
+    // }
   }
 
   {
@@ -315,33 +315,33 @@ TEST(CGAL, SurfaceMeshGridCell) {
     t.stop();
     // std::cout << "Intersect (x1000): " << t.time() << " sec" << std::endl;
 
-    if(intersection) {
-      if(boost::get<Point3>(&(intersection->first))) {
-        const Point3* p =  boost::get<Point3>(&(intersection->first));
-        // std::cout <<  *p << std::endl;
-      }
-    }
+    // if(intersection) {
+    //   if(boost::get<Point3>(&(intersection->first))) {
+    //     const Point3* p =  boost::get<Point3>(&(intersection->first));
+    //     std::cout <<  *p << std::endl;
+    //   }
+    // }
   }
 }
 
 TEST(CGAL, SurfaceMeshGrid) {
   typedef CGAL::Simple_cartesian<double> K;
   typedef K::Point_3 Point3;
-  typedef K::Plane_3 Plane;
+  // typedef K::Plane_3 Plane;
   typedef K::Ray_3 Ray;
-  typedef K::Vector_3 Vector3;
-  typedef K::Segment_3 Segment;
+  // typedef K::Vector_3 Vector3;
+  // typedef K::Segment_3 Segment;
 
   typedef CGAL::Surface_mesh<Point3> Mesh;
-  typedef Mesh::Vertex_index vertex_descriptor;
-  typedef Mesh::Face_index face_descriptor;
+  // typedef Mesh::Vertex_index vertex_descriptor;
+  // typedef Mesh::Face_index face_descriptor;
 
   typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
   typedef CGAL::AABB_traits<K, Primitive> Traits;
   typedef CGAL::AABB_tree<Traits> Tree;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
-  typedef Tree::Primitive_id Primitive_id;
+  // typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
+  // typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
+  // typedef Tree::Primitive_id Primitive_id;
 
   typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
 
@@ -398,37 +398,37 @@ TEST(CGAL, SurfaceMeshGrid) {
     t.stop();
     // std::cout << "Intersect (x" << sphere->number_of_vertices() << "): " << t.time() << " sec" << std::endl;
 
-    if(intersection) {
-      if(boost::get<Point3>(&(intersection->first))) {
-        const Point3* p =  boost::get<Point3>(&(intersection->first));
-        // std::cout <<  *p << std::endl;
-      }
-    }
+    // if(intersection) {
+    //   if(boost::get<Point3>(&(intersection->first))) {
+    //     const Point3* p =  boost::get<Point3>(&(intersection->first));
+    //     std::cout <<  *p << std::endl;
+    //   }
+    // }
   }
 }
 
 TEST(CGAL, SurfaceMeshModifyGrid) {
   typedef CGAL::Simple_cartesian<double> K;
   typedef K::Point_3 Point3;
-  typedef K::Plane_3 Plane;
-  typedef K::Ray_3 Ray;
+  // typedef K::Plane_3 Plane;
+  // typedef K::Ray_3 Ray;
   typedef K::Vector_3 Vector3;
-  typedef K::Segment_3 Segment;
+  // typedef K::Segment_3 Segment;
 
-  typedef CGAL::Surface_mesh<Point3> Mesh;
-  typedef Mesh::Vertex_index vertex_descriptor;
-  typedef Mesh::Face_index face_descriptor;
+  // typedef CGAL::Surface_mesh<Point3> Mesh;
+  // typedef Mesh::Vertex_index vertex_descriptor;
+  // typedef Mesh::Face_index face_descriptor;
 
-  typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
-  typedef CGAL::AABB_traits<K, Primitive> Traits;
-  typedef CGAL::AABB_tree<Traits> Tree;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
-  typedef Tree::Primitive_id Primitive_id;
+  // typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
+  // typedef CGAL::AABB_traits<K, Primitive> Traits;
+  // typedef CGAL::AABB_tree<Traits> Tree;
+  // typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
+  // typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
+  // typedef Tree::Primitive_id Primitive_id;
 
-  typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
 
-  typedef CGAL::Timer Timer;
+  // typedef CGAL::Timer Timer;
 
   // Create Grid
   waves::Grid grid({ 100, 100 }, { 4, 4 });
@@ -447,35 +447,35 @@ TEST(CGAL, SurfaceMeshModifyGrid) {
 
   { 
     // std::cout << "Faces" << std::endl;
-    for(auto&& face : mesh.faces()) {
-      // std::cout << face << std::endl;
+    // for(auto&& face : mesh.faces()) {
+    //   std::cout << face << std::endl;
 
-      Triangle tri = waves::Geometry::MakeTriangle(mesh, face);
-      // std::cout << tri << std::endl;
-    }
+    //   Triangle tri = waves::Geometry::MakeTriangle(mesh, face);
+    //   std::cout << tri << std::endl;
+    // }
   }
 }
 
 TEST(CGAL, SurfaceMeshWavefield) {
-  typedef CGAL::Simple_cartesian<double> K;
-  typedef K::Point_3 Point3;
-  typedef K::Plane_3 Plane;
-  typedef K::Ray_3 Ray;
-  typedef K::Vector_3 Vector3;
-  typedef K::Segment_3 Segment;
+  // typedef CGAL::Simple_cartesian<double> K;
+  // typedef K::Point_3 Point3;
+  // typedef K::Plane_3 Plane;
+  // typedef K::Ray_3 Ray;
+  // typedef K::Vector_3 Vector3;
+  // typedef K::Segment_3 Segment;
 
-  typedef CGAL::Surface_mesh<Point3> Mesh;
-  typedef Mesh::Vertex_index vertex_descriptor;
-  typedef Mesh::Face_index face_descriptor;
+  // typedef CGAL::Surface_mesh<Point3> Mesh;
+  // typedef Mesh::Vertex_index vertex_descriptor;
+  // typedef Mesh::Face_index face_descriptor;
 
-  typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
-  typedef CGAL::AABB_traits<K, Primitive> Traits;
-  typedef CGAL::AABB_tree<Traits> Tree;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
-  typedef Tree::Primitive_id Primitive_id;
+  // typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
+  // typedef CGAL::AABB_traits<K, Primitive> Traits;
+  // typedef CGAL::AABB_tree<Traits> Tree;
+  // typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
+  // typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
+  // typedef Tree::Primitive_id Primitive_id;
 
-  typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
 
   typedef CGAL::Timer Timer;
 
@@ -553,24 +553,24 @@ TEST(CGAL, VertexRangeIterator) {
   mesh.add_face(v0, v2, v3);
 
   // Iterate over one variable
-  for (
-    auto&& vb = std::begin(mesh.vertices());
-    vb != std::end(mesh.vertices());
-    ++vb) {
-    auto&& v  = *vb;
-    const Point3& p = mesh.point(v);
-    // std::cout << p << std::endl;
-  }
+  // for (
+  //   auto&& vb = std::begin(mesh.vertices());
+  //   vb != std::end(mesh.vertices());
+  //   ++vb) {
+  //   auto&& v  = *vb;
+  //   const Point3& p = mesh.point(v);
+  //   std::cout << p << std::endl;
+  // }
 
   // Iterate over two variables using std::pair
-  for (
-    auto&& it = std::make_pair(std::begin(mesh.vertices()), 0);
-    it.first != std::end(mesh.vertices());
-    ++it.first, ++it.second) {
-    auto&& v = *it.first;
-    const Point3& p = mesh.point(v);
-    // std::cout << it.second << ": " << p << std::endl;
-  }
+  // for (
+  //   auto&& it = std::make_pair(std::begin(mesh.vertices()), 0);
+  //   it.first != std::end(mesh.vertices());
+  //   ++it.first, ++it.second) {
+  //   auto&& v = *it.first;
+  //   const Point3& p = mesh.point(v);
+  //   std::cout << it.second << ": " << p << std::endl;
+  // }
 
 }
 
@@ -1198,14 +1198,14 @@ TEST(CGAL, CreateTriangulation3) {
   typedef CGAL::Triangulation_2<K, Tds>                    TBase;
 
   typedef CGAL::Triangulation_hierarchy_2<TBase>  Triangulation;
-  typedef Triangulation::Vertex_circulator        Vertex_circulator;
+  // typedef Triangulation::Vertex_circulator        Vertex_circulator;
   typedef Triangulation::Vertex_handle            Vertex_handle;
   typedef Triangulation::Face_handle              Face_handle;
   typedef Triangulation::Point                    Point;
-  typedef Triangulation::Face                     Face;
-  typedef Triangulation::Triangle                 Triangle;
-  typedef Triangulation::Edge                     Edge;
-  typedef Triangulation::Segment                  Segment;
+  // typedef Triangulation::Face                     Face;
+  // typedef Triangulation::Triangle                 Triangle;
+  // typedef Triangulation::Edge                     Edge;
+  // typedef Triangulation::Segment                  Segment;
 
   
   // Points
@@ -1217,7 +1217,7 @@ TEST(CGAL, CreateTriangulation3) {
   {
     // Automatically create a triangulation
     Triangulation t;
-    Triangulation::Triangulation_data_structure& tds = t.tds();
+    // Triangulation::Triangulation_data_structure& tds = t.tds();
 
     t.insert(p1);
     t.insert(p2);
@@ -1463,14 +1463,14 @@ TEST(CGAL, CreateTriangulation3) {
 TEST(CGAL, CreateTriangulation4) {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
   typedef CGAL::Triangulation_2<K>                Triangulation;
-  typedef Triangulation::Vertex_circulator        Vertex_circulator;
+  // typedef Triangulation::Vertex_circulator        Vertex_circulator;
   typedef Triangulation::Vertex_handle            Vertex_handle;
   typedef Triangulation::Face_handle              Face_handle;
   typedef Triangulation::Point                    Point;
-  typedef Triangulation::Face                     Face;
-  typedef Triangulation::Triangle                 Triangle;
-  typedef Triangulation::Edge                     Edge;
-  typedef Triangulation::Segment                  Segment;
+  // typedef Triangulation::Face                     Face;
+  // typedef Triangulation::Triangle                 Triangle;
+  // typedef Triangulation::Edge                     Edge;
+  // typedef Triangulation::Segment                  Segment;
   
   // Points
   Point p0(0, 0);
@@ -1607,15 +1607,15 @@ TEST(CGAL, CreateConstrainedTrianguation4) {
   typedef CGAL::Triangulation_hierarchy_vertex_base_2<Vbb>    Vb;
   typedef CGAL::Constrained_triangulation_face_base_2<K>      Fb;
   typedef CGAL::Triangulation_data_structure_2<Vb, Fb>        Tds;
-  typedef CGAL::No_constraint_intersection_tag                Itag;
+  // typedef CGAL::No_constraint_intersection_tag                Itag;
   typedef CGAL::Constrained_triangulation_2<K, Tds>           TBase;
 
   typedef CGAL::Triangulation_hierarchy_2<TBase>  Triangulation;
-  typedef Triangulation::Vertex_circulator        Vertex_circulator;
-  typedef Triangulation::Vertex_handle            Vertex_handle;
-  typedef Triangulation::Face_handle              Face_handle;
+  // typedef Triangulation::Vertex_circulator        Vertex_circulator;
+  // typedef Triangulation::Vertex_handle            Vertex_handle;
+  // typedef Triangulation::Face_handle              Face_handle;
   typedef Triangulation::Point                    Point;
-  typedef Triangulation::Face                     Face;
+  // typedef Triangulation::Face                     Face;
   
   // Points
   Point p0(0, 0);
@@ -1625,7 +1625,7 @@ TEST(CGAL, CreateConstrainedTrianguation4) {
 
   // Create a triangulation
   Triangulation t;
-  Triangulation::Triangulation_data_structure& tds = t.tds();
+  // Triangulation::Triangulation_data_structure& tds = t.tds();
 
   // Insert constraints (i.e. all edges)
   t.insert_constraint(p0, p1);
@@ -1651,15 +1651,15 @@ TEST(CGAL, CreateCTAlt) {
   typedef CGAL::Triangulation_hierarchy_vertex_base_2<Vbb>    Vb;
   typedef CGAL::Constrained_triangulation_face_base_2<K>      Fb;
   typedef CGAL::Triangulation_data_structure_2<Vb, Fb>        Tds;
-  typedef CGAL::No_constraint_intersection_tag                Itag;
+  // typedef CGAL::No_constraint_intersection_tag                Itag;
   typedef CGAL::Constrained_triangulation_2<K, Tds>           TBase;
 
   typedef CGAL::Triangulation_hierarchy_2<TBase>  Triangulation;
-  typedef Triangulation::Vertex_circulator        Vertex_circulator;
-  typedef Triangulation::Vertex_handle            Vertex_handle;
-  typedef Triangulation::Face_handle              Face_handle;
+  // typedef Triangulation::Vertex_circulator        Vertex_circulator;
+  // typedef Triangulation::Vertex_handle            Vertex_handle;
+  // typedef Triangulation::Face_handle              Face_handle;
   typedef Triangulation::Point                    Point;
-  typedef Triangulation::Face                     Face;
+  // typedef Triangulation::Face                     Face;
   
   // Points
   Point p0(0, 0);
@@ -1669,7 +1669,7 @@ TEST(CGAL, CreateCTAlt) {
 
   // Create a triangulation
   Triangulation t;
-  Triangulation::Triangulation_data_structure& tds = t.tds();
+  // Triangulation::Triangulation_data_structure& tds = t.tds();
 
   // Insert first row
   t.insert(p0);
@@ -1697,15 +1697,15 @@ TEST(CGAL, CreateCTAltN) {
   typedef CGAL::Triangulation_hierarchy_vertex_base_2<Vbb>    Vb;
   typedef CGAL::Constrained_triangulation_face_base_2<Kp>     Fb;
   typedef CGAL::Triangulation_data_structure_2<Vb, Fb>        Tds;
-  typedef CGAL::No_constraint_intersection_tag                Itag;
+  // typedef CGAL::No_constraint_intersection_tag                Itag;
   typedef CGAL::Constrained_Delaunay_triangulation_2<Kp, Tds> TBase;
 
   typedef CGAL::Triangulation_hierarchy_2<TBase>  Triangulation;
-  typedef Triangulation::Vertex_circulator        Vertex_circulator;
-  typedef Triangulation::Vertex_handle            Vertex_handle;
-  typedef Triangulation::Face_handle              Face_handle;
+  // typedef Triangulation::Vertex_circulator        Vertex_circulator;
+  // typedef Triangulation::Vertex_handle            Vertex_handle;
+  // typedef Triangulation::Face_handle              Face_handle;
   typedef K::Point_3                              Point;
-  typedef Triangulation::Face                     Face;
+  // typedef Triangulation::Face                     Face;
   
   // Create the mesh
   std::vector<Point> points;
@@ -1720,7 +1720,7 @@ TEST(CGAL, CreateCTAltN) {
 
   // Create a triangulation
   Triangulation t;
-  Triangulation::Triangulation_data_structure& tds = t.tds();
+  // Triangulation::Triangulation_data_structure& tds = t.tds();
 
   // Points - (N+1) points in each row / column 
   for (size_t iy=0; iy<=N; ++iy) {

--- a/gz-waves/src/Grid_TEST.cc
+++ b/gz-waves/src/Grid_TEST.cc
@@ -106,10 +106,10 @@ TEST(Grid, FindIntersectionIndex)
   std::array<size_t, 2> cellCount = { 4, 2 };
   Grid grid(size, cellCount);
 
-  double Lx = size[0];
-  double Ly = size[1];
-  size_t nx = cellCount[0];
-  size_t ny = cellCount[1];
+  // double Lx = size[0];
+  // double Ly = size[1];
+  // size_t nx = cellCount[0];
+  // size_t ny = cellCount[1];
 
   // 16 cases to check...
   { // cell(0, 0)
@@ -281,10 +281,10 @@ TEST(Grid, FindIntersectionTriangle)
   std::array<size_t, 2> cellCount = { 4, 2 };
   Grid grid(size, cellCount);
 
-  double Lx = size[0];
-  double Ly = size[1];
-  size_t nx = cellCount[0];
-  size_t ny = cellCount[1];
+  // double Lx = size[0];
+  // double Ly = size[1];
+  // size_t nx = cellCount[0];
+  // size_t ny = cellCount[1];
 
   std::cout << std::endl;
 
@@ -361,10 +361,10 @@ TEST(Grid, FindIntersectionCell)
   std::array<size_t, 2> cellCount = { 4, 2 };
   Grid grid(size, cellCount);
 
-  double Lx = size[0];
-  double Ly = size[1];
-  size_t nx = cellCount[0];
-  size_t ny = cellCount[1];
+  // double Lx = size[0];
+  // double Ly = size[1];
+  // size_t nx = cellCount[0];
+  // size_t ny = cellCount[1];
 
   std::cout << std::endl;
 
@@ -405,10 +405,10 @@ TEST(Grid, FindIntersectionGrid)
   std::array<size_t, 2> cellCount = { 4, 2 };
   Grid grid(size, cellCount);
 
-  double Lx = size[0];
-  double Ly = size[1];
-  size_t nx = cellCount[0];
-  size_t ny = cellCount[1];
+  // double Lx = size[0];
+  // double Ly = size[1];
+  // size_t nx = cellCount[0];
+  // size_t ny = cellCount[1];
 
   std::cout << std::endl;
 

--- a/gz-waves/src/MeshTools.cc
+++ b/gz-waves/src/MeshTools.cc
@@ -90,9 +90,10 @@ namespace waves
       auto&& v1 = vertices[i++];
       auto&& v2 = vertices[i++];
       cgal::Point3 p(v0, v1, v2);
-      auto&& v = _target.add_vertex(p);
       
       // @DEBUG_INFO
+      //auto& v = 
+      _target.add_vertex(p);
       // gzmsg << v << ": " << _target.point(v) << std::endl; 
     }
 

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -958,6 +958,7 @@ void OceanTilePrivate<cgal::Point3>::UpdateMesh(
 {
   /// \note This template specialisation is supplied for compilation on
   ///       macOS M1 (arm64). It should never be called. 
+  GZ_ASSERT(false, "Should never reach here");
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -732,15 +732,11 @@ void OceanTilePrivate<cgal::Point3>::UpdateVertexAndTangents(
     size_t v_idx, size_t w_idx)
 {
   // 1. Update vertex
-  double h  = mHeights[w_idx];
-  double sx = mDisplacementsX[w_idx];
-  double sy = mDisplacementsY[w_idx];
+  // double h  = mHeights[w_idx];
+  // double sx = mDisplacementsX[w_idx];
+  // double sy = mDisplacementsY[w_idx];
 
-  auto&& v0 = mVertices0[v_idx];
-  auto&& v  = mVertices[v_idx] = cgal::Point3(
-    v0.x() + sy,
-    v0.y() + sx,
-    v0.z() + h);
+  // auto&& v0 = mVertices0[v_idx];
 
   // 2. Update tangent and bitangent vectors (not normalised).
   // @TODO Check sign for displacement terms
@@ -782,7 +778,7 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
       {
         size_t v_idx_cm = iy * NPlus1 + ix;
         size_t w_idx_cm = iy * N + ix;
-        size_t w_idx_rm = ix * N + iy;
+        // size_t w_idx_rm = ix * N + iy;
         UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
       }
     }
@@ -794,14 +790,14 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
       {
         size_t v_idx_cm = N * NPlus1 + i;
         size_t w_idx_cm = i;
-        size_t w_idx_rm = i * N;
+        // size_t w_idx_rm = i * N;
         UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
       }
       // Right column (ix = N) periodic with left column (ix = 0)
       {
         size_t v_idx_cm = i * NPlus1 + N;
         size_t w_idx_cm = i * N;
-        size_t w_idx_rm = i;
+        // size_t w_idx_rm = i;
         UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
       }
     }
@@ -809,7 +805,7 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
       // Top right corner period with bottom right corner.
       size_t v_idx_cm = NPlus1 * NPlus1 - 1;
       size_t w_idx_cm = 0;
-      size_t w_idx_rm = 0;
+      // size_t w_idx_rm = 0;
       UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
     }  
   }
@@ -827,7 +823,7 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
       {
         size_t v_idx_cm = iy * NPlus1 + ix;
         size_t w_idx_cm = iy * N + ix;
-        size_t w_idx_rm = ix * N + iy;
+        // size_t w_idx_rm = ix * N + iy;
         UpdateVertex(v_idx_cm, w_idx_cm);
       }
     }
@@ -839,14 +835,14 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
       {
         size_t v_idx_cm = N * NPlus1 + i;
         size_t w_idx_cm = i;
-        size_t w_idx_rm = i * N;
+        // size_t w_idx_rm = i * N;
         UpdateVertex(v_idx_cm, w_idx_cm);
       }
       // Right column (ix = N) periodic with left column (ix = 0)
       {
         size_t v_idx_cm = i * NPlus1 + N;
         size_t w_idx_cm = i * N;
-        size_t w_idx_rm = i;
+        // size_t w_idx_rm = i;
         UpdateVertex(v_idx_cm, w_idx_cm);
       }
     }
@@ -854,7 +850,7 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
       // Top right corner period with bottom right corner.
       size_t v_idx_cm = NPlus1 * NPlus1 - 1;
       size_t w_idx_cm = 0;
-      size_t w_idx_rm = 0;
+      // size_t w_idx_rm = 0;
       UpdateVertex(v_idx_cm, w_idx_cm);
     }
   }

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -958,7 +958,6 @@ void OceanTilePrivate<cgal::Point3>::UpdateMesh(
 {
   /// \note This template specialisation is supplied for compilation on
   ///       macOS M1 (arm64). It should never be called. 
-  GZ_ASSERT(false, "Should never reach here");
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/TriangulatedGrid_TEST.cc
+++ b/gz-waves/src/TriangulatedGrid_TEST.cc
@@ -36,8 +36,8 @@ TEST(TriangulatedGrid, Create) {
   // Create
   int n = 2;
   int length = 100.0;
-  std::unique_ptr<TriangulatedGrid> tri_grid 
-    = std::move(TriangulatedGrid::Create(n, length));
+  auto grid = TriangulatedGrid::Create(n, length);
+  std::unique_ptr<TriangulatedGrid> tri_grid = std::move(grid);
   // tri_grid->DebugPrintMesh();
   // tri_grid->DebugPrintTriangulation();
   EXPECT_TRUE(tri_grid->IsValid());
@@ -57,8 +57,8 @@ TEST(TriangulatedGrid, Height) {
   int n = 16;
   int length = 100.0;
   int nplus1 = n + 1;
-  std::unique_ptr<TriangulatedGrid> source 
-    = std::move(TriangulatedGrid::Create(n, length));
+  auto grid = TriangulatedGrid::Create(n, length);
+  std::unique_ptr<TriangulatedGrid> source = std::move(grid);
   EXPECT_TRUE(source->IsValid());
 
   cgal::Point3 query(-5.0, -5.0, 0.0);
@@ -89,8 +89,8 @@ TEST(TriangulatedGrid, Interpolate) {
   int n = 16;
   int length = 100.0;
   int nplus1 = n + 1;
-  std::unique_ptr<TriangulatedGrid> source 
-    = std::move(TriangulatedGrid::Create(n, length));
+  auto grid1 = TriangulatedGrid::Create(n, length);
+  std::unique_ptr<TriangulatedGrid> source = std::move(grid1);
   EXPECT_TRUE(source->IsValid());
 
   // Set points
@@ -108,8 +108,8 @@ TEST(TriangulatedGrid, Interpolate) {
   // source->DebugPrintTriangulation();
 
   // Create patch
-  std::unique_ptr<TriangulatedGrid> patch 
-    = std::move(TriangulatedGrid::Create(2, 10.0));
+  auto grid2 = TriangulatedGrid::Create(2, 10.0);
+  std::unique_ptr<TriangulatedGrid> patch = std::move(grid2);
   // patch->DebugPrintMesh();
   // patch->DebugPrintTriangulation();
   EXPECT_TRUE(patch->IsValid());

--- a/gz-waves/src/Utilities.cc
+++ b/gz-waves/src/Utilities.cc
@@ -51,7 +51,7 @@ T SdfParam(const sdf::Element& _sdf, const std::string &_paramName, const T _def
 
 /// \brief Template function for extracting a value from a parameter message.
 template <typename T>
-T MsgParamGetValue(const gz::msgs::Param& _msg)
+T MsgParamGetValue(const gz::msgs::Param& /*_msg*/)
 {
   gzwarn << "Using default template for MsgParamGetValue" << std::endl;
   return T();  

--- a/gz-waves/src/WaveSimulationFFT.cc
+++ b/gz-waves/src/WaveSimulationFFT.cc
@@ -55,11 +55,11 @@ namespace waves
   //////////////////////////////////////////////////
   WaveSimulationFFTImpl::WaveSimulationFFTImpl(
     double lx, double ly, int nx, int ny) :
-    nx_(nx),
-    ny_(ny),
+    lambda_(0.6),
     lx_(lx),
     ly_(ly),
-    lambda_(0.6)
+    nx_(nx),
+    ny_(ny)
   {
     CreateFFTWPlans();
     ComputeBaseAmplitudes();
@@ -544,7 +544,7 @@ namespace waves
     Eigen::Ref<Eigen::MatrixXd> dsydy,
     Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    impl_->ComputeDisplacementsDerivatives(dsxdx, dsxdy, dsxdy);
+    impl_->ComputeDisplacementsDerivatives(dsxdx, dsydy, dsxdy);
   }
 
   //////////////////////////////////////////////////

--- a/gz-waves/src/WaveSimulationFFTRef.cc
+++ b/gz-waves/src/WaveSimulationFFTRef.cc
@@ -247,7 +247,7 @@ namespace waves
             + ky_math_[iky]*ky_math_[iky]);
         double phi = atan2(ky_math_[iky], kx_math_[ikx]);
 
-        if (k == 0.0)
+        if (std::abs(k) < 1.0E-8)
         {
           cap_psi_2s_math(ikx, iky) = 0.0;
         }

--- a/gz-waves/src/WaveSimulationFFTRef.cc
+++ b/gz-waves/src/WaveSimulationFFTRef.cc
@@ -52,11 +52,11 @@ namespace waves
   //////////////////////////////////////////////////
   WaveSimulationFFTRefImpl::WaveSimulationFFTRefImpl(
     double lx, double ly, int nx, int ny) :
-    nx_(nx),
-    ny_(ny),
+    lambda_(0.6),
     lx_(lx),
     ly_(ly),
-    lambda_(0.6)
+    nx_(nx),
+    ny_(ny)
   {
     ComputeBaseAmplitudes();
     CreateFFTWPlans();
@@ -151,7 +151,7 @@ namespace waves
     InitFFTCoeffStorage();
     InitWaveNumbers();
 
-    size_t n2 = nx_ * ny_;
+    // size_t n2 = nx_ * ny_;
 
     // arrays for reference version
     if (cap_psi_2s_root_.size() == 0)
@@ -178,8 +178,8 @@ namespace waves
     double  lambda_y_f{ly_};
 
     // nyquist wavelength [m]
-    double  lambda_x_nyquist{2.0 * delta_x};
-    double  lambda_y_nyquist{2.0 * delta_y};
+    // double  lambda_x_nyquist{2.0 * delta_x};
+    // double  lambda_y_nyquist{2.0 * delta_y};
 
     // fundamental spatial frequency [1/m]
     double  nu_x_f{1.0 / lx_};
@@ -597,16 +597,16 @@ namespace waves
       return 0.0;
     }
 
-    double alpha = 0.0081;
-    double beta = 1.25;
+    // double alpha = 0.0081;
+    // double beta = 1.25;
     double g = gravity;
     double Cd_10N = 0.00144;
     double u_star = sqrt(Cd_10N) * u10;
-    double ao = 0.1733;
-    double ap = 4.0;
+    // double ao = 0.1733;
+    // double ap = 4.0;
     double km = 370.0;
     double cm = 0.23;
-    double am = 0.13 * u_star / cm;
+    // double am = 0.13 * u_star / cm;
     
     double gamma = 1.7;
     if (cap_omega_c < 1.0)
@@ -705,7 +705,8 @@ namespace waves
 
   //////////////////////////////////////////////////
   double WaveSimulationFFTRefImpl::Cos2sSpreadingFunction(
-      double s, double phi, double u10, double cap_omega_c, double gravity)
+      double s, double phi, double /*u10*/,
+      double /*cap_omega_c*/, double /*gravity*/)
   {
     // Longuet-Higgins et al. 'cosine-2S' spreading function
     //
@@ -780,7 +781,7 @@ namespace waves
     Eigen::Ref<Eigen::MatrixXd> dsydy,
     Eigen::Ref<Eigen::MatrixXd> dsxdy)
   {
-    impl_->ComputeDisplacementsDerivatives(dsxdx, dsxdy, dsxdy);
+    impl_->ComputeDisplacementsDerivatives(dsxdx, dsydy, dsxdy);
   }
 
   //////////////////////////////////////////////////

--- a/gz-waves/src/WaveSimulationFFT_TEST.cc
+++ b/gz-waves/src/WaveSimulationFFT_TEST.cc
@@ -373,18 +373,18 @@ TEST_F(WaveSimulationFFTFixture, HermitianTimeNonZeroReference)
     for (int iky=0; iky<ny_; ++iky, ++idx)
     {
       // index for conjugate
-      int cdx = 0;
+      // int cdx = 0;
       int ckx = 0;
       if (ikx != 0)
       {
         ckx = nx_ - ikx;
-        cdx += ckx * ny_;
+        // cdx += ckx * ny_;
       }
       int cky = 0;
       if (iky != 0)
       {
         cky = ny_ - iky;
-        cdx += cky;
+        // cdx += cky;
       }
 
       // look up amplitude and conjugate

--- a/gz-waves/src/WaveSimulationSinusoid.cc
+++ b/gz-waves/src/WaveSimulationSinusoid.cc
@@ -190,7 +190,8 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationSinusoid::Impl::SetWindVelocity(double _ux, double _uy)
+  void WaveSimulationSinusoid::Impl::SetWindVelocity(
+      double /*_ux*/, double /*_uy*/)
   {
     // @TODO NO IMPLEMENTATION
   }
@@ -226,10 +227,10 @@ namespace waves
       double dy = ly_ / ny_;
       double lx_min = - lx_ / 2.0;
       double ly_min = - ly_ / 2.0;
-      for (size_t iy=0, idx=0; iy<ny_; ++iy)
+      for (int iy=0, idx=0; iy<ny_; ++iy)
       {
         double y = iy * dy + ly_min;
-        for (size_t ix=0; ix<nx_; ++ix, ++idx)
+        for (int ix=0; ix<nx_; ++ix, ++idx)
         {
           double x = ix * dx + lx_min;
           double a  = k * (x * cd + y * sd) - wt;
@@ -271,10 +272,10 @@ namespace waves
       double dy = ly_ / ny_;
       double lx_min = - lx_ / 2.0;
       double ly_min = - ly_ / 2.0;
-      for (size_t iy=0, idx=0; iy<ny_; ++iy)
+      for (int iy=0, idx=0; iy<ny_; ++iy)
       {
         double y = iy * dy + ly_min;
-        for (size_t ix=0; ix<nx_; ++ix, ++idx)
+        for (int ix=0; ix<nx_; ++ix, ++idx)
         {
           double x = ix * dx + lx_min;
           double a  = k * (x * cd + y * sd) - wt;
@@ -290,17 +291,17 @@ namespace waves
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::Impl::ComputeDisplacements(
-    Eigen::Ref<Eigen::MatrixXd> sx,
-    Eigen::Ref<Eigen::MatrixXd> sy)
+    Eigen::Ref<Eigen::MatrixXd> /*sx*/,
+    Eigen::Ref<Eigen::MatrixXd> /*sy*/)
   {
     // No xy-displacement
   }
 
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::Impl::ComputeDisplacementsDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> dsydy,
-    Eigen::Ref<Eigen::MatrixXd> dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> /*dsxdx*/,
+    Eigen::Ref<Eigen::MatrixXd> /*dsydy*/,
+    Eigen::Ref<Eigen::MatrixXd> /*dsxdy*/)
   {
     // No xy-displacement
   }
@@ -308,13 +309,13 @@ namespace waves
   //////////////////////////////////////////////////
   void WaveSimulationSinusoid::Impl::ComputeDisplacementsAndDerivatives(
     Eigen::Ref<Eigen::MatrixXd> h,
-    Eigen::Ref<Eigen::MatrixXd> sx,
-    Eigen::Ref<Eigen::MatrixXd> sy,
+    Eigen::Ref<Eigen::MatrixXd> /*sx*/,
+    Eigen::Ref<Eigen::MatrixXd> /*sy*/,
     Eigen::Ref<Eigen::MatrixXd> dhdx,
     Eigen::Ref<Eigen::MatrixXd> dhdy,
-    Eigen::Ref<Eigen::MatrixXd> dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> dsydy,
-    Eigen::Ref<Eigen::MatrixXd> dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> /*dsxdx*/,
+    Eigen::Ref<Eigen::MatrixXd> /*dsydy*/,
+    Eigen::Ref<Eigen::MatrixXd> /*dsxdy*/)
   {
     // derived wave properties
     double w = 2.0 * M_PI / period_;
@@ -344,10 +345,10 @@ namespace waves
       double dy = ly_ / ny_;
       double lx_min = - lx_ / 2.0;
       double ly_min = - ly_ / 2.0;
-      for (size_t iy=0, idx=0; iy<ny_; ++iy)
+      for (int iy=0, idx=0; iy<ny_; ++iy)
       {
         double y = iy * dy + ly_min;
-        for (size_t ix=0; ix<nx_; ++ix, ++idx)
+        for (int ix=0; ix<nx_; ++ix, ++idx)
         {
           double x = ix * dx + lx_min;
           double a  = k * (x * cd + y * sd) - wt;

--- a/gz-waves/src/WaveSimulationTrochoid.cc
+++ b/gz-waves/src/WaveSimulationTrochoid.cc
@@ -83,7 +83,8 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void WaveSimulationTrochoidImpl::SetWindVelocity(double ux, double uy)
+  void WaveSimulationTrochoidImpl::SetWindVelocity(
+      double /*ux*/, double /*uy*/)
   {
     // @TODO NO IMPLEMENTATION
   }
@@ -105,7 +106,7 @@ namespace waves
     const auto& wavenumber = this->params_->Wavenumber_V();
     const auto& omega      = this->params_->AngularFrequency_V();
     const auto& phase      = this->params_->Phase_V();
-    const auto& q          = this->params_->Steepness_V();
+    // const auto& q          = this->params_->Steepness_V();
     const auto& direction  = this->params_->Direction_V();
 
     // Multiple wave update 
@@ -117,14 +118,14 @@ namespace waves
       const auto& omega_i = omega[i];
       const auto& phase_i = phase[i];
       const auto& direction_i = direction[i];
-      const auto& q_i = q[i];
+      // const auto& q_i = q[i];
 
-      for (size_t iy=0; iy<this->N_; ++iy)
+      for (int iy=0; iy<this->N_; ++iy)
       {
-        for (size_t ix=0; ix<this->N_; ++ix)
+        for (int ix=0; ix<this->N_; ++ix)
         {
           // Col major index
-          size_t idx = iy * this->N_ + ix;
+          int idx = iy * this->N_ + ix;
 
           // Regular grid
           double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;
@@ -147,8 +148,8 @@ namespace waves
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoidImpl::ComputeElevationDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> dhdx,
-    Eigen::Ref<Eigen::MatrixXd> dhdy)
+    Eigen::Ref<Eigen::MatrixXd> /*dhdx*/,
+    Eigen::Ref<Eigen::MatrixXd> /*dhdy*/)
   {
     // @TODO NO IMPLEMENTATION
   }
@@ -179,9 +180,9 @@ namespace waves
       const auto& direction_i = direction[i];
       const auto& q_i = q[i];
 
-      for (size_t iy=0; iy<this->N_; ++iy)
+      for (int iy=0; iy<this->N_; ++iy)
       {
-        for (size_t ix=0; ix<this->N_; ++ix)
+        for (int ix=0; ix<this->N_; ++ix)
         {
           // Col major index
           size_t idx = iy * this->N_ + ix;
@@ -208,9 +209,9 @@ namespace waves
 
   //////////////////////////////////////////////////
   void WaveSimulationTrochoidImpl::ComputeDisplacementsDerivatives(
-    Eigen::Ref<Eigen::MatrixXd> dsxdx,
-    Eigen::Ref<Eigen::MatrixXd> dsydy,
-    Eigen::Ref<Eigen::MatrixXd> dsxdy)
+    Eigen::Ref<Eigen::MatrixXd> /*dsxdx*/,
+    Eigen::Ref<Eigen::MatrixXd> /*dsydy*/,
+    Eigen::Ref<Eigen::MatrixXd> /*dsxdy*/)
   {
     // @TODO NO IMPLEMENTATION
   }

--- a/gz-waves/src/WaveSimulation_TEST.cc
+++ b/gz-waves/src/WaveSimulation_TEST.cc
@@ -134,18 +134,18 @@ TEST_F(WaveSimulationSinusoidFixture, TestHeightsDirX)
 
   // Grid spacing and offset
   double lx_min = - lx_ / 2.0;
-  double ly_min = - ly_ / 2.0;
+  // double ly_min = - ly_ / 2.0;
   double dx = lx_ / nx_;
-  double dy = ly_ / ny_;
+  // double dy = ly_ / ny_;
 
   // Verify heights
   Eigen::VectorXd h = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->ComputeElevation(h);
 
-  for (size_t iy=0, idx=0; iy<ny_; ++iy)
+  for (int iy=0, idx=0; iy<ny_; ++iy)
   {
-    double y = iy * dy + ly_min;
-    for (size_t ix=0; ix<nx_; ++ix, ++idx)
+    // double y = iy * dy + ly_min;
+    for (int ix=0; ix<nx_; ++ix, ++idx)
     {
       double x = ix * dx + lx_min;
       double a = k_ * x - w_ * time;
@@ -184,10 +184,10 @@ TEST_F(WaveSimulationSinusoidFixture, TestHeightsDirXY)
   Eigen::VectorXd h = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->ComputeElevation(h);
 
-  for (size_t iy=0, idx=0; iy<ny_; ++iy)
+  for (int iy=0, idx=0; iy<ny_; ++iy)
   {
     double y = iy * dy + ly_min;
-    for (size_t ix=0; ix<nx_; ++ix, ++idx)
+    for (int ix=0; ix<nx_; ++ix, ++idx)
     {
       double x = ix * dx + lx_min;
       double a = k_ * (x * cd + y * sd) - wt;
@@ -215,9 +215,9 @@ TEST_F(WaveSimulationSinusoidFixture, TestDisplacementsDirX)
   Eigen::VectorXd sy = Eigen::VectorXd::Zero(nx_ * ny_);
   wave_sim->ComputeDisplacements(sx, sy);
 
-  for (size_t iy=0, idx=0; iy<ny_; ++iy)
+  for (int iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx_; ++ix, ++idx)
+    for (int ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(sx(idx), 0.0);
       EXPECT_DOUBLE_EQ(sy(idx), 0.0);
@@ -250,21 +250,21 @@ TEST_F(WaveSimulationSinusoidFixture, TestEigenMeshGrid)
   x_grid.colwise() += x_v;
   y_grid.rowwise() += y_v.transpose();
 
-  for (size_t ix=0; ix<nx_; ++ix)
+  for (int ix=0; ix<nx_; ++ix)
   {
     double x_test = ix * dx + lx_min;
     EXPECT_DOUBLE_EQ(x_v(ix), x_test);
   }
 
-  for (size_t iy=0; iy<ny_; ++iy)
+  for (int iy=0; iy<ny_; ++iy)
   {
     double y_test = iy * dy + ly_min;
     EXPECT_DOUBLE_EQ(y_v(iy), y_test);
   }
 
-  for (size_t ix=0; ix<nx_; ++ix)
+  for (int ix=0; ix<nx_; ++ix)
   {
-    for (size_t iy=0; iy<ny_; ++iy)
+    for (int iy=0; iy<ny_; ++iy)
     {
       double x_test = ix * dx + lx_min;
       double y_test = iy * dy + ly_min;
@@ -296,9 +296,9 @@ TEST_F(WaveSimulationSinusoidFixture, TestHeightsDirXMatrixXd)
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeElevation(h2);
 
-  for (size_t iy=0, idx=0; iy<ny_; ++iy)
+  for (int iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx_; ++ix, ++idx)
+    for (int ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(h1(idx), h2(idx));
     }
@@ -326,9 +326,9 @@ TEST_F(WaveSimulationSinusoidFixture, TestHeightsDirXYMatrixXd)
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeElevation(h2);
 
-  for (size_t iy=0, idx=0; iy<ny_; ++iy)
+  for (int iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx_; ++ix, ++idx)
+    for (int ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(h1(idx), h2(idx));
     }
@@ -358,9 +358,9 @@ TEST_F(WaveSimulationSinusoidFixture, TestDisplacmentsMatrixXd)
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeDisplacements(sx2, sy2);
 
-  for (size_t iy=0, idx=0; iy<ny_; ++iy)
+  for (int iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx_; ++ix, ++idx)
+    for (int ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(sx1(idx), sx2(idx));
       EXPECT_DOUBLE_EQ(sy1(idx), sy2(idx));
@@ -391,9 +391,9 @@ TEST_F(WaveSimulationSinusoidFixture, TestHeightDerivativesMatrixXd)
   wave_sim->SetUseVectorised(false);
   wave_sim->ComputeElevationDerivatives(dhdx2, dhdy2);
 
-  for (size_t iy=0, idx=0; iy<ny_; ++iy)
+  for (int iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx_; ++ix, ++idx)
+    for (int ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(dhdx1(idx), dhdx2(idx));
       EXPECT_DOUBLE_EQ(dhdy1(idx), dhdy2(idx));
@@ -438,9 +438,9 @@ TEST_F(WaveSimulationSinusoidFixture, TestDisplacementsAndDerivativesMatrixXd)
   wave_sim->ComputeDisplacementsAndDerivatives(
     h2, sx2, sy2, dhdx2, dhdy2, dsxdx2, dsydy2, dsxdy2);
 
-  for (size_t iy=0, idx=0; iy<ny_; ++iy)
+  for (int iy=0, idx=0; iy<ny_; ++iy)
   {
-    for (size_t ix=0; ix<nx_; ++ix, ++idx)
+    for (int ix=0; ix<nx_; ++ix, ++idx)
     {
       EXPECT_DOUBLE_EQ(h1(idx), h2(idx));
       EXPECT_DOUBLE_EQ(sx1(idx), sx2(idx));
@@ -486,10 +486,10 @@ TEST(OceanTile, WaveSimulationSinusoid)
   }
 
   EXPECT_EQ(oceanTile->Vertices().size(), NPlus12);
-  for (size_t iy=0; iy<NPlus1; ++iy)
+  for (int iy=0; iy<NPlus1; ++iy)
   {
     double vy = iy * dl + lm;
-    for (size_t ix=0; ix<NPlus1; ++ix)
+    for (int ix=0; ix<NPlus1; ++ix)
     {
       double vx = ix * dl + lm;
       size_t idx = iy * NPlus1 + ix;
@@ -507,10 +507,10 @@ TEST(OceanTile, WaveSimulationSinusoid)
   }
 
   EXPECT_EQ(oceanTile->Vertices().size(), NPlus12);
-  for (size_t iy=0; iy<NPlus1; ++iy)
+  for (int iy=0; iy<NPlus1; ++iy)
   {
     double vy = iy * dl + lm;
-    for (size_t ix=0; ix<NPlus1; ++ix)
+    for (int ix=0; ix<NPlus1; ++ix)
     {
       double vx = ix * dl + lm;
       size_t idx = iy * NPlus1 + ix;

--- a/gz-waves/src/WaveSpectrum.cc
+++ b/gz-waves/src/WaveSpectrum.cc
@@ -36,8 +36,8 @@ PiersonMoskowitzWaveSpectrum::~PiersonMoskowitzWaveSpectrum()
 PiersonMoskowitzWaveSpectrum::PiersonMoskowitzWaveSpectrum(
     double u19, double gravity) :
   OmniDirectionalWaveSpectrum(),
-  u19_(u19),
-  gravity_(gravity)
+  gravity_(gravity),
+  u19_(u19)
 {
 }
 
@@ -116,9 +116,9 @@ ECKVWaveSpectrum::~ECKVWaveSpectrum()
 ECKVWaveSpectrum::ECKVWaveSpectrum(
     double u10, double cap_omega_c, double gravity) :
   OmniDirectionalWaveSpectrum(),
+  gravity_(gravity),
   u10_(u10),
-  cap_omega_c_(cap_omega_c),
-  gravity_(gravity)
+  cap_omega_c_(cap_omega_c)
 {
 }
 
@@ -131,17 +131,17 @@ double ECKVWaveSpectrum::Evaluate(double k) const
   }
 
   // constants
-  const double alpha = 0.0081;
-  const double beta = 1.25;
+  // const double alpha = 0.0081;
+  // const double beta = 1.25;
   const double cd_10n = 0.00144;
-  const double ao = 0.1733;
-  const double ap = 4.0;
+  // const double ao = 0.1733;
+  // const double ap = 4.0;
   const double km = 370.0;
   const double cm = 0.23;
 
   // intermediates
   double u_star = std::sqrt(cd_10n) * u10_;
-  double am = 0.13 * u_star / cm;
+  // double am = 0.13 * u_star / cm;
   
   double gamma = 1.7;
   if (cap_omega_c_ < 1.0)

--- a/gz-waves/src/WaveSpectrum_TEST.cc
+++ b/gz-waves/src/WaveSpectrum_TEST.cc
@@ -110,8 +110,8 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumMatrixXd)
 
     double lx = 200.0;
     double ly = 100.0;
-    size_t nx = 32;
-    size_t ny = 16;
+    int nx = 32;
+    int ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -120,11 +120,11 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumMatrixXd)
     Eigen::VectorXd kx_v(nx);
     Eigen::VectorXd ky_v(ny);
 
-    for (size_t i=0; i<nx; ++i)
+    for (int i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (size_t i=0; i<ny; ++i)
+    for (int i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -239,8 +239,8 @@ TEST(WaveSpectrum, ECKVSpectrumMatrixXd)
 
     double lx = 200.0;
     double ly = 100.0;
-    size_t nx = 32;
-    size_t ny = 16;
+    int nx = 32;
+    int ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -249,11 +249,11 @@ TEST(WaveSpectrum, ECKVSpectrumMatrixXd)
     Eigen::VectorXd kx_v(nx);
     Eigen::VectorXd ky_v(ny);
 
-    for (size_t i=0; i<nx; ++i)
+    for (int i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (size_t i=0; i<ny; ++i)
+    for (int i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -295,8 +295,8 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
 
     double lx = 200.0;
     double ly = 100.0;
-    size_t nx = 32;
-    size_t ny = 16;
+    int nx = 32;
+    int ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -305,11 +305,11 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
     Eigen::VectorXd kx_v(nx);
     Eigen::VectorXd ky_v(ny);
 
-    for (size_t i=0; i<nx; ++i)
+    for (int i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (size_t i=0; i<ny; ++i)
+    for (int i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }

--- a/gz-waves/src/WaveSpreadingFunction.cc
+++ b/gz-waves/src/WaveSpreadingFunction.cc
@@ -42,7 +42,7 @@ Cos2sSpreadingFunction::Cos2sSpreadingFunction(double spread) :
 
 //////////////////////////////////////////////////
 double Cos2sSpreadingFunction::Evaluate(
-    double theta, double theta_mean, double k) const
+    double theta, double theta_mean, double /*k*/) const
 {
   double phi = theta - theta_mean;
   double cp = std::cos(phi / 2.0);
@@ -56,7 +56,7 @@ void Cos2sSpreadingFunction::Evaluate(
     Eigen::Ref<Eigen::MatrixXd> phi,
     const Eigen::Ref<const Eigen::MatrixXd> &theta,
     double theta_mean,
-    const Eigen::Ref<const Eigen::MatrixXd> &k) const
+    const Eigen::Ref<const Eigen::MatrixXd>& /*k*/) const
 {
   auto theta_view = theta.reshaped();
   std::transform(
@@ -103,9 +103,9 @@ ECKVSpreadingFunction::ECKVSpreadingFunction(
     double cap_omega_c,
     double gravity) :
   DirectionalSpreadingFunction(),
+  gravity_(gravity),
   u10_(u10),
-  cap_omega_c_(cap_omega_c),
-  gravity_(gravity)
+  cap_omega_c_(cap_omega_c)
 {
 }
 

--- a/gz-waves/src/WaveSpreadingFunction_TEST.cc
+++ b/gz-waves/src/WaveSpreadingFunction_TEST.cc
@@ -222,8 +222,8 @@ TEST(WaveSpreadingFunction, WaveNumberMatrixXd)
   { // componentwise operations
     double lx = 200.0;
     double ly = 100.0;
-    size_t nx = 32;
-    size_t ny = 16;
+    int nx = 32;
+    int ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -232,11 +232,11 @@ TEST(WaveSpreadingFunction, WaveNumberMatrixXd)
     Eigen::VectorXd kx_v(nx);
     Eigen::VectorXd ky_v(ny);
 
-    for (size_t i=0; i<nx; ++i)
+    for (int i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (size_t i=0; i<ny; ++i)
+    for (int i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -279,9 +279,9 @@ TEST(WaveSpreadingFunction, WaveNumberMatrixXd)
     EXPECT_EQ(ky.cols(), ny);
 
     // check contents
-    for (size_t i=0; i<nx; ++i)
+    for (int i=0; i<nx; ++i)
     {
-      for (size_t j=0; j<ny; ++j)
+      for (int j=0; j<ny; ++j)
       {
         EXPECT_DOUBLE_EQ(kx(i, j), kx_v(i));
         EXPECT_DOUBLE_EQ(ky(i, j), ky_v(j));
@@ -296,9 +296,9 @@ TEST(WaveSpreadingFunction, WaveNumberMatrixXd)
     );
 
     // check the wave number matrix and angle matrices
-    for (size_t i=0; i<nx; ++i)
+    for (int i=0; i<nx; ++i)
     { 
-      for (size_t j=0; j<ny; ++j)
+      for (int j=0; j<ny; ++j)
       {
         double kxij = kx(i, j);
         double kx2ij = kxij * kxij;
@@ -387,8 +387,8 @@ TEST(WaveSpreadingFunction, ECKVMatrixXd)
   { // Eigen array version
     double lx = 200.0;
     double ly = 100.0;
-    size_t nx = 32;
-    size_t ny = 16;
+    int nx = 32;
+    int ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -397,11 +397,11 @@ TEST(WaveSpreadingFunction, ECKVMatrixXd)
     Eigen::VectorXd kx_v(nx);
     Eigen::VectorXd ky_v(ny);
 
-    for (size_t i=0; i<nx; ++i)
+    for (int i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (size_t i=0; i<ny; ++i)
+    for (int i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }

--- a/gz-waves/src/Wavefield.cc
+++ b/gz-waves/src/Wavefield.cc
@@ -134,7 +134,8 @@ namespace waves
 
     // Point Locator
     gzmsg << "Creating triangulated grid." <<  std::endl;
-    this->dataPtr->triangulatedGrid = std::move(TriangulatedGrid::Create(N, L));
+    auto grid = TriangulatedGrid::Create(N, L);
+    this->dataPtr->triangulatedGrid = std::move(grid);
   }
 
   /////////////////////////////////////////////////
@@ -176,7 +177,7 @@ namespace waves
       {
         /// \todo: assert the type is double
         auto param = it->second;
-        auto type = param.type();
+        // auto type = param.type();
         auto value = param.double_value();
         windSpeed = value;
       }
@@ -187,7 +188,7 @@ namespace waves
       {
         /// \todo: assert the type is double
         auto param = it->second;
-        auto type = param.type();
+        // auto type = param.type();
         auto value = param.double_value();
         windAngleRad = M_PI/180.0*value;
       }
@@ -198,7 +199,7 @@ namespace waves
       {
         /// \todo: assert the type is double
         auto param = it->second;
-        auto type = param.type();
+        // auto type = param.type();
         auto value = param.double_value();
         steepness = value;
       }

--- a/gz-waves/src/WavefieldSampler.cc
+++ b/gz-waves/src/WavefieldSampler.cc
@@ -204,8 +204,8 @@ namespace waves
       J(0, 1) =  0;
       J(1, 0) =  0;
       J(1, 1) = -1;
-      const size_t n = wp.a.size();
-      for (auto&& i=0; i<n; ++i)
+      size_t n = wp.a.size();
+      for (size_t i=0; i<n; ++i)
       {
         const double dx = wp.dir[i].X();
         const double dy = wp.dir[i].Y();

--- a/gz-waves/src/Wavefield_TEST.cc
+++ b/gz-waves/src/Wavefield_TEST.cc
@@ -67,9 +67,9 @@ TEST(Wavefield, WaveSolver1D)
   {
     const double theta = wp.k * x - wp.omega * t;
     const double s = std::sin(theta);
-    const double c = std::cos(theta);
+    // const double c = std::cos(theta);
     const double px = x - wp.a * s;
-    const double pz = wp.a * c;
+    // const double pz = wp.a * c;
 
     return px;
   };
@@ -78,15 +78,15 @@ TEST(Wavefield, WaveSolver1D)
   {
     const double theta = wp.k * x - wp.omega * t;
     const double s = std::sin(theta);
-    const double c = std::cos(theta);
+    // const double c = std::cos(theta);
     const double f = p - x + wp.a * s;
     return f;
   };
 
-  auto wave_df = [=](auto x, auto p, auto t, auto& wp)
+  auto wave_df = [=](auto x, auto /*p*/, auto t, auto& wp)
   {
     const double theta = wp.k * x - wp.omega * t;
-    const double s = std::sin(theta);
+    // const double s = std::sin(theta);
     const double c = std::cos(theta);
     const double df = wp.a * wp.k * c - 1;
     return df;
@@ -192,7 +192,7 @@ TEST(Wavefield, WaveSolver2D)
     return f;
   };
 
-  auto wave_df = [=](auto x, auto p, auto t, auto& wp)
+  auto wave_df = [=](auto x, auto /*p*/, auto t, auto& wp)
   {
     const double theta = wp.k * x.dot(wp.dir)  - wp.omega * t;
     const double c = std::cos(theta);
@@ -241,7 +241,7 @@ TEST(Wavefield, WaveSolver2D)
   auto p3 = wave(x0, t, wp);
   Eigen::Vector2d p(p3(0), p3(1));
   auto F  = wave_f(x0, p, t, wp);
-  auto J = wave_df(x0, p, t, wp);
+  // auto J = wave_df(x0, p, t, wp);
 
   const double tol = 1E-8;
   const double nmax = 20;
@@ -290,8 +290,8 @@ TEST(Wavefield, NWaveSolver2D)
   auto wave = [=](auto x, auto t, auto& wp)
   {
     Eigen::Vector3d p(x.x(), x.y(), 0.0);
-    const size_t n = wp.a.size();
-    for (auto&& i=0; i<n; ++i)
+    size_t n = wp.a.size();
+    for (size_t i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -311,8 +311,8 @@ TEST(Wavefield, NWaveSolver2D)
   auto wave_f = [=](auto x, auto p, auto t, auto& wp)
   {
     Eigen::Vector2d f(p.x() - x.x(), p.y() - x.y());
-    const size_t n = wp.a.size();
-    for (auto&& i=0; i<n; ++i)
+    size_t n = wp.a.size();
+    for (size_t i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -327,15 +327,15 @@ TEST(Wavefield, NWaveSolver2D)
     return f;
   };
 
-  auto wave_df = [=](auto x, auto p, auto t, auto& wp)
+  auto wave_df = [=](auto x, auto /*p*/, auto t, auto& wp)
   {
     Eigen::Matrix2d J;
     J(0, 0) = -1;
     J(0, 1) =  0;
     J(1, 0) =  0;
     J(1, 1) = -1;
-    const size_t n = wp.a.size();
-    for (auto&& i=0; i<n; ++i)
+    size_t n = wp.a.size();
+    for (size_t i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double c = std::cos(theta);
@@ -386,7 +386,7 @@ TEST(Wavefield, NWaveSolver2D)
   auto p3 = wave(x0, t, wp);
   Eigen::Vector2d p(p3(0), p3(1));
   auto F  = wave_f(x0, p, t, wp);
-  auto J = wave_df(x0, p, t, wp);
+  // auto J = wave_df(x0, p, t, wp);
 
   const double tol = 1E-8;
   const double nmax = 20;
@@ -431,8 +431,8 @@ TEST(Wavefield, NWaveFdFSolver2D)
   auto wave = [=](auto x, auto t, auto& wp)
   {
     Eigen::Vector3d p(x.x(), x.y(), 0.0);
-    const size_t n = wp.a.size();
-    for (auto&& i=0; i<n; ++i)
+    size_t n = wp.a.size();
+    for (size_t i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -457,8 +457,8 @@ TEST(Wavefield, NWaveFdFSolver2D)
     J(0, 1) =  0;
     J(1, 0) =  0;
     J(1, 1) = -1;
-    const size_t n = wp.a.size();
-    for (auto&& i=0; i<n; ++i)
+    size_t n = wp.a.size();
+    for (size_t i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);

--- a/gz-waves/src/systems/dynamic/DynamicGeometry.cc
+++ b/gz-waves/src/systems/dynamic/DynamicGeometry.cc
@@ -220,7 +220,7 @@ inline namespace GZ_RENDERING_VERSION_NAMESPACE {
     }
 
     /// \brief Override
-    protected: virtual bool LoadImpl(const MeshDescriptor &_desc) override
+    protected: virtual bool LoadImpl(const MeshDescriptor &/*_desc*/) override
     {
       /// \todo: currently assume we've already loaded from the tile
       /// but should handle better
@@ -377,7 +377,7 @@ DynamicGeometry::~DynamicGeometry()
 
 /////////////////////////////////////////////////
 void DynamicGeometry::Configure(const Entity &_entity,
-    const std::shared_ptr<const sdf::Element> &_sdf,
+    const std::shared_ptr<const sdf::Element> &/*_sdf*/,
     EntityComponentManager &_ecm,
     EventManager &_eventMgr)
 {
@@ -387,7 +387,7 @@ void DynamicGeometry::Configure(const Entity &_entity,
 
   // Ugly, but needed because the sdf::Element::GetElement is not a const
   // function and _sdf is a const shared pointer to a const sdf::Element.
-  auto sdf = const_cast<sdf::Element *>(_sdf.get());
+  // auto sdf = const_cast<sdf::Element *>(_sdf.get());
 
   // capture entity 
   this->dataPtr->entity = _entity;

--- a/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -359,7 +359,7 @@ Hydrodynamics::~Hydrodynamics()
 void Hydrodynamics::Configure(const Entity &_entity,
     const std::shared_ptr<const sdf::Element> &_sdf,
     EntityComponentManager &_ecm,
-    EventManager &_eventMgr)
+    EventManager &/*_eventMgr*/)
 {
   GZ_PROFILE("Hydrodynamics::Configure");
 
@@ -616,7 +616,7 @@ bool HydrodynamicsPrivate::InitPhysics(EntityComponentManager &_ecm)
     /// \todo WorldCoGPose is currently not available
     // cgal::Vector3 linVelocityCoM = waves::ToVector3(
     //     hd->link.WorldCoGLinearVelocity(_ecm).value());
-    cgal::Vector3 linVelocityCoM = linVelocity;
+    // cgal::Vector3 linVelocityCoM = linVelocity;
 
     for (size_t j=0; j<meshCount; ++j)
     {
@@ -666,13 +666,13 @@ void HydrodynamicsPrivate::Update(const UpdateInfo &_info,
 }
 
 /////////////////////////////////////////////////
-void HydrodynamicsPrivate::UpdatePhysics(const UpdateInfo &_info,
+void HydrodynamicsPrivate::UpdatePhysics(const UpdateInfo &/*_info*/,
     EntityComponentManager &_ecm)
 {
   ////////// BEGIN TESTING
 
   // Get the wave height at the origin
-  double simTime = std::chrono::duration<double>(_info.simTime).count();
+  // double simTime = std::chrono::duration<double>(_info.simTime).count();
   cgal::Point3 point(0.0, 0.0, 0.0);
   double waveHeight{0.0};
   this->wavefield.lock()->Height(point, waveHeight);
@@ -715,10 +715,10 @@ void HydrodynamicsPrivate::UpdatePhysics(const UpdateInfo &_info,
     /// \todo WorldCoGLinearVel is currently not available
     // cgal::Vector3 linVelocityCoM = waves::ToVector3(
     //     hd->link.WorldCoGLinearVel(_ecm).value());
-    cgal::Vector3 linVelocityCoM = linVelocity;
+    // cgal::Vector3 linVelocityCoM = linVelocity;
 
     // Meshes
-    size_t nSubTri = 0;
+    // size_t nSubTri = 0;
     for (size_t j=0; j<hd->linkMeshes.size(); ++j)
     {
       // Update link mesh
@@ -749,7 +749,7 @@ void HydrodynamicsPrivate::UpdatePhysics(const UpdateInfo &_info,
       }
 
       // Info for Markers
-      nSubTri += hd->hydrodynamics[j]->GetSubmergedTriangles().size();
+      // nSubTri += hd->hydrodynamics[j]->GetSubmergedTriangles().size();
 
       // DEBUG_INFO
       // gzmsg << "Link:         " << hd->link->GetName() << "\n";
@@ -872,7 +872,7 @@ void HydrodynamicsPrivate::CreateCollisionMeshes(
         continue;
       }
 
-      double volume = 0;
+      // double volume = 0;
       switch (coll->Data().Geom()->Type())
       {
         case sdf::GeometryType::BOX:
@@ -1203,8 +1203,8 @@ void HydrodynamicsPrivate::UpdateMarkers(
 
 //////////////////////////////////////////////////
 void HydrodynamicsPrivate::UpdateWaterPatchMarkers(
-    const UpdateInfo &_info,
-    EntityComponentManager &_ecm)
+    const UpdateInfo &/*_info*/,
+    EntityComponentManager &/*_ecm*/)
 {
   std::string topicName("/marker");
 
@@ -1233,8 +1233,8 @@ void HydrodynamicsPrivate::UpdateWaterPatchMarkers(
 
 //////////////////////////////////////////////////
 void HydrodynamicsPrivate::UpdateWaterlineMarkers(
-    const UpdateInfo &_info,
-    EntityComponentManager &_ecm)
+    const UpdateInfo &/*_info*/,
+    EntityComponentManager &/*_ecm*/)
 {
   std::string topicName("/marker");
 
@@ -1261,8 +1261,8 @@ void HydrodynamicsPrivate::UpdateWaterlineMarkers(
 
 //////////////////////////////////////////////////
 void HydrodynamicsPrivate::UpdateUnderwaterSurfaceMarkers(
-    const UpdateInfo &_info,
-    EntityComponentManager &_ecm)
+    const UpdateInfo &/*_info*/,
+    EntityComponentManager &/*_ecm*/)
 {
   std::string topicName("/marker");
 
@@ -1300,7 +1300,7 @@ void HydrodynamicsPrivate::OnWaveMarkersMsg(const gz::msgs::Param &_msg)
     {
       /// \todo: assert the type is bool
       auto param = it->second;
-      auto type = param.type();
+      // auto type = param.type();
       auto value = param.bool_value();
       this->showWaterPatch = value;
     }
@@ -1311,7 +1311,7 @@ void HydrodynamicsPrivate::OnWaveMarkersMsg(const gz::msgs::Param &_msg)
     {
       /// \todo: assert the type is bool
       auto param = it->second;
-      auto type = param.type();
+      // auto type = param.type();
       auto value = param.bool_value();
       this->showWaterline = value;
     }
@@ -1322,7 +1322,7 @@ void HydrodynamicsPrivate::OnWaveMarkersMsg(const gz::msgs::Param &_msg)
     {
       /// \todo: assert the type is bool
       auto param = it->second;
-      auto type = param.type();
+      // auto type = param.type();
       auto value = param.bool_value();
       this->showUnderwaterSurface = value;
     }

--- a/gz-waves/src/systems/waves/BaseOceanGeometry.hh
+++ b/gz-waves/src/systems/waves/BaseOceanGeometry.hh
@@ -64,22 +64,22 @@ namespace gz
 
     /////////////////////////////////////////////////
     template <class T>
-    void BaseOceanGeometry<T>::LoadMesh(gz::common::MeshPtr _mesh)
+    void BaseOceanGeometry<T>::LoadMesh(gz::common::MeshPtr /*_mesh*/)
     {
       // no default implementation
     }
 
     /////////////////////////////////////////////////
     template <class T>
-    void BaseOceanGeometry<T>::UpdateMesh(gz::common::MeshPtr _mesh)
+    void BaseOceanGeometry<T>::UpdateMesh(gz::common::MeshPtr /*_mesh*/)
     {
       // no default implementation
     }
 
     /////////////////////////////////////////////////
     template <class T>
-    void BaseOceanGeometry<T>::InitObject(ScenePtr _scene,
-        unsigned int _id, const std::string &_name)
+    void BaseOceanGeometry<T>::InitObject(ScenePtr /*_scene*/,
+        unsigned int /*_id*/, const std::string &/*_name*/)
     {
       // no default implementation
     }

--- a/gz-waves/src/systems/waves/BaseOceanVisual.hh
+++ b/gz-waves/src/systems/waves/BaseOceanVisual.hh
@@ -137,7 +137,7 @@ namespace gz
     //////////////////////////////////////////////////
     template <class T>
     void BaseOceanVisual<T>::LoadOceanTile(
-      waves::visual::OceanTilePtr _oceanTile)
+      waves::visual::OceanTilePtr /*_oceanTile*/)
     {
       // no default implementation
     }
@@ -145,29 +145,29 @@ namespace gz
     //////////////////////////////////////////////////
     template <class T>
     void BaseOceanVisual<T>::UpdateOceanTile(
-      waves::visual::OceanTilePtr _oceanTile)
+      waves::visual::OceanTilePtr /*_oceanTile*/)
     {
       // no default implementation
     }
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseOceanVisual<T>::LoadMesh(gz::common::MeshPtr _mesh)
+    void BaseOceanVisual<T>::LoadMesh(gz::common::MeshPtr /*_mesh*/)
     {
       // no default implementation
     }
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseOceanVisual<T>::UpdateMesh(gz::common::MeshPtr _mesh)
+    void BaseOceanVisual<T>::UpdateMesh(gz::common::MeshPtr /*_mesh*/)
     {
       // no default implementation
     }
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseOceanVisual<T>::InitObject(ScenePtr _scene,
-        unsigned int _id, const std::string &_name)
+    void BaseOceanVisual<T>::InitObject(ScenePtr /*_scene*/,
+        unsigned int /*_id*/, const std::string &/*_name*/)
     {
       // no default implementation
     }

--- a/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
+++ b/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
@@ -27,9 +27,9 @@ Ogre2DisplacementMap::Ogre2DisplacementMap(
   uint64_t _entity,
   uint32_t _width,
   uint32_t _height) :
-  entity(_entity),
   scene(_scene),
   material(_material),
+  entity(_entity),
   width(_width),
   height(_height)
 {

--- a/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
+++ b/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
@@ -306,29 +306,29 @@ void Ogre2DisplacementMap::UpdateTextures(
       ogre2SceneManager->getDestinationRenderSystem()->getTextureGpuManager();
 
   // update the image data
-  uint32_t width  = mHeightMapImage->getWidth();
-  uint32_t height = mHeightMapImage->getHeight();
+  uint32_t mapWidth  = mHeightMapImage->getWidth();
+  uint32_t mapHeight = mHeightMapImage->getHeight();
 
   Ogre::TextureBox heightBox  = mHeightMapImage->getData(0);
   Ogre::TextureBox normalBox  = mNormalMapImage->getData(0);
   Ogre::TextureBox tangentBox = mTangentMapImage->getData(0);
 
-  for (uint32_t iv=0; iv < height; ++iv)
+  for (uint32_t iv=0; iv < mapHeight; ++iv)
   {
       /// \todo: coordinates are flipped in the vertex shader
       // texture index to vertex index
-      int32_t iy = /*height - 1 - */ iv;
-      for (uint32_t iu=0; iu < width; ++iu)
+      int32_t iy = /*mapHeight - 1 - */ iv;
+      for (uint32_t iu=0; iu < mapWidth; ++iu)
       {
           // texture index to vertex index
-          int32_t ix = /* width - 1 - */ iu;
+          int32_t ix = /* mapWidth - 1 - */ iu;
 
           float Dx{0.0}, Dy{0.0}, Dz{0.0};
           float Tx{1.0}, Ty{0.0}, Tz{0.0};
           float Bx{0.0}, By{1.0}, Bz{0.0};
           float Nx{0.0}, Ny{0.0}, Nz{1.0};
 
-          int32_t idx = iy * width + ix;
+          int32_t idx = iy * mapWidth + ix;
           double h  = mHeights(idx, 0);
           double sx = mDisplacementsX(idx, 0);
           double sy = mDisplacementsY(idx, 0);

--- a/gz-waves/src/systems/waves/Ogre2OceanGeometry.cc
+++ b/gz-waves/src/systems/waves/Ogre2OceanGeometry.cc
@@ -153,7 +153,7 @@ void Ogre2OceanGeometry::LoadMesh(gz::common::MeshPtr _mesh)
   }
 
   // Loop over all indices
-  for (auto i=0; i < subMesh->IndexCount(); ++i)
+  for (size_t i=0; i < subMesh->IndexCount(); ++i)
   {
     auto index = subMesh->Index(i);
     auto vertex = subMesh->Vertex(index);
@@ -187,7 +187,7 @@ void Ogre2OceanGeometry::UpdateMesh(gz::common::MeshPtr _mesh)
   }
 
   // Loop over all indices
-  for (auto i=0; i < subMesh->IndexCount(); ++i)
+  for (size_t i=0; i < subMesh->IndexCount(); ++i)
   {
     auto index = subMesh->Index(i);
     auto vertex = subMesh->Vertex(index);

--- a/gz-waves/src/systems/waves/Ogre2OceanVisual.cc
+++ b/gz-waves/src/systems/waves/Ogre2OceanVisual.cc
@@ -215,7 +215,7 @@ void Ogre2OceanVisual::LoadOceanTile(waves::visual::OceanTilePtr _oceanTile)
   }
 
   // Add points and texture coordinates for each face
-  for (auto i=0, v=0; i < _oceanTile->FaceCount(); i++, v+=3)
+  for (size_t i=0, v=0; i < _oceanTile->FaceCount(); i++, v+=3)
   {
     auto face = _oceanTile->Face(i);
     // positions
@@ -236,7 +236,7 @@ void Ogre2OceanVisual::LoadOceanTile(waves::visual::OceanTilePtr _oceanTile)
 void Ogre2OceanVisual::UpdateOceanTile(waves::visual::OceanTilePtr _oceanTile)
 {
   // Update positions and texture coordinates for each face
-  for (auto i=0, v=0; i < _oceanTile->FaceCount(); i++, v+=3)
+  for (size_t i=0, v=0; i < _oceanTile->FaceCount(); i++, v+=3)
   {
     auto face = _oceanTile->Face(i);
     // positions
@@ -288,7 +288,7 @@ void Ogre2OceanVisual::LoadMesh(gz::common::MeshPtr _mesh)
   }
 
   // Loop over all indices
-  for (auto i=0; i < subMesh->IndexCount(); ++i)
+  for (size_t i=0; i < subMesh->IndexCount(); ++i)
   {
     auto index = subMesh->Index(i);
     auto vertex = subMesh->Vertex(index);
@@ -322,7 +322,7 @@ void Ogre2OceanVisual::UpdateMesh(gz::common::MeshPtr _mesh)
   }
 
   // Loop over all indices
-  for (auto i=0; i < subMesh->IndexCount(); ++i)
+  for (size_t i=0; i < subMesh->IndexCount(); ++i)
   {
     auto index = subMesh->Index(i);
     auto vertex = subMesh->Vertex(index);

--- a/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.cc
+++ b/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.cc
@@ -83,7 +83,7 @@ std::string Ogre2RenderEngineExtension::Name() const
 
 //////////////////////////////////////////////////
 bool Ogre2RenderEngineExtension::LoadImpl(
-    const std::map<std::string, std::string> &_params)
+    const std::map<std::string, std::string> &/*_params*/)
 {
   try
   {

--- a/gz-waves/src/systems/waves/WavesModel.cc
+++ b/gz-waves/src/systems/waves/WavesModel.cc
@@ -108,7 +108,7 @@ WavesModel::~WavesModel()
 void WavesModel::Configure(const Entity &_entity,
     const std::shared_ptr<const sdf::Element> &_sdf,
     EntityComponentManager &_ecm,
-    EventManager &_eventMgr)
+    EventManager &/*_eventMgr*/)
 {
   GZ_PROFILE("WavesModel::Configure");
 
@@ -232,7 +232,7 @@ void WavesModelPrivate::Load(EntityComponentManager &_ecm)
 
 /////////////////////////////////////////////////
 void WavesModelPrivate::UpdateWaves(const UpdateInfo &_info,
-    EntityComponentManager &_ecm)
+    EntityComponentManager &/*_ecm*/)
 {
   if (!this->isStatic)
   {  

--- a/gz-waves/src/systems/waves/WavesVisual.cc
+++ b/gz-waves/src/systems/waves/WavesVisual.cc
@@ -556,7 +556,7 @@ void WavesVisualPrivate::OnUpdate()
         // RenderUtil stores gazebo-entity user data as uint64_t
         auto variant = n->UserData("gazebo-entity");
         const uint64_t *value = std::get_if<uint64_t>(&variant);
-        if (value && *value == static_cast<int>(this->entity))
+        if (value && *value == static_cast<uint64_t>(this->entity))
         {
           this->visual = std::dynamic_pointer_cast<rendering::Visual>(n);
           break;
@@ -585,7 +585,7 @@ void WavesVisualPrivate::OnUpdate()
   double simTime = this->currentSimTimeSeconds;
 
   // ocean tile parameters
-  size_t N = this->waveParams->CellCount();
+  // size_t N = this->waveParams->CellCount();
   double L = this->waveParams->TileSize();
   double ux = this->waveParams->WindVelocity().X();
   double uy = this->waveParams->WindVelocity().Y();
@@ -777,7 +777,7 @@ void WavesVisualPrivate::OnUpdate()
       {
         double ux = this->waveParams->WindVelocity().X();
         double uy = this->waveParams->WindVelocity().Y();
-        double s  = this->waveParams->Steepness();
+        // double s  = this->waveParams->Steepness();
 
         // set params
         this->mWaveSim->SetWindVelocity(ux, uy);
@@ -818,7 +818,7 @@ void WavesVisualPrivate::OnWaveMsg(const gz::msgs::Param &_msg)
     {
       /// \todo: assert the type is double
       auto param = it->second;
-      auto type = param.type();
+      // auto type = param.type();
       auto value = param.double_value();
       windSpeed = value;
     }
@@ -829,7 +829,7 @@ void WavesVisualPrivate::OnWaveMsg(const gz::msgs::Param &_msg)
     {
       /// \todo: assert the type is double
       auto param = it->second;
-      auto type = param.type();
+      // auto type = param.type();
       auto value = param.double_value();
       windAngleRad = M_PI/180.0*value;
     }
@@ -840,7 +840,7 @@ void WavesVisualPrivate::OnWaveMsg(const gz::msgs::Param &_msg)
     {
       /// \todo: assert the type is double
       auto param = it->second;
-      auto type = param.type();
+      // auto type = param.type();
       auto value = param.double_value();
       steepness = value;
     }

--- a/gz-waves/src/systems/waves/WavesVisual.cc
+++ b/gz-waves/src/systems/waves/WavesVisual.cc
@@ -693,9 +693,9 @@ void WavesVisualPrivate::OnUpdate()
 
       if (this->waveParamsDirty)
       {
-        double ux = this->waveParams->WindVelocity().X();
-        double uy = this->waveParams->WindVelocity().Y();
-        this->oceanTile->SetWindVelocity(ux, uy);
+        double newUx = this->waveParams->WindVelocity().X();
+        double newUy = this->waveParams->WindVelocity().Y();
+        this->oceanTile->SetWindVelocity(newUx, newUy);
         this->waveParamsDirty = false;
       }
 
@@ -775,12 +775,12 @@ void WavesVisualPrivate::OnUpdate()
 
       if (this->waveParamsDirty)
       {
-        double ux = this->waveParams->WindVelocity().X();
-        double uy = this->waveParams->WindVelocity().Y();
+        double newUx = this->waveParams->WindVelocity().X();
+        double newUy = this->waveParams->WindVelocity().Y();
         // double s  = this->waveParams->Steepness();
 
         // set params
-        this->mWaveSim->SetWindVelocity(ux, uy);
+        this->mWaveSim->SetWindVelocity(newUx, newUy);
         // waveSim->SetLambda(s);
 
         this->waveParamsDirty = false;

--- a/gz-waves/test/performance/WaveSpectrumECKV.cc
+++ b/gz-waves/test/performance/WaveSpectrumECKV.cc
@@ -60,11 +60,11 @@ public:
     Eigen::VectorXd kx_v(nx_);
     Eigen::VectorXd ky_v(ny_);
 
-    for (size_t i=0; i<nx_; ++i)
+    for (int i=0; i<nx_; ++i)
     {
       kx_v(i) = (i * 2.0 / nx_ - 1.0) * kx_nyquist;
     }
-    for (size_t i=0; i<ny_; ++i)
+    for (int i=0; i<ny_; ++i)
     {
       ky_v(i) = (i * 2.0 / ny_ - 1.0) * ky_nyquist;
     }


### PR DESCRIPTION
This PR addresses compilation warnings and errors when using the flags `-Werror -Wall -Wextra`.

## Details

1. Clean build of all warnings.
2. Disable unused variables from tests (primarily present for printing info).
3. Comment unused parameters in function sigs.
4. Fix int type comparison warnings in loops.
5. Fix initialisation order errors in constructors.