### PR TITLE
Waves FFT: add just in time evaluation

### DIFF
--- a/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
@@ -171,6 +171,9 @@ namespace waves
     std::vector<Eigen::ArrayXXdRowMajor>    fft_out_p_;
     std::vector<fftw_plan>                  fft_plan_p_;
 
+    /// \brief lazy evaluation flags
+    std::vector<bool> fft_needs_update_;
+
     /// \brief Gravity acceleration [m/s^2]
     double gravity_{9.81};
 


### PR DESCRIPTION
Add just in time evaluation to the FFT wave simulation which also prevents `fftw_execute` being called a second time after the input array is overwritten.

Closes #94 
