### PR TITLE
Add wave spectrum, elevation and pressure plots  

### DIFF
--- a/.github/workflows/ubuntu-jammy-ci.yml
+++ b/.github/workflows/ubuntu-jammy-ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          path: src
+          path: src/asv_wave_sim
 
       - name: Install Build Essentials
         run: |

--- a/gz-waves/CMakeLists.txt
+++ b/gz-waves/CMakeLists.txt
@@ -20,12 +20,24 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 gz_configure_project()
 
 #============================================================================
+# Include cmake
+#============================================================================
+
+include(${PROJECT_SOURCE_DIR}/cmake/URL.conf.cmake)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+#============================================================================
 # Set project-specific options
 #============================================================================
 
 #============================================================================
 # Search for project-specific dependencies
 #============================================================================
+
+#--------------------------------------
+# Find gnuplot-iostream - the header is used by the examples in test/plots
+include(Add_gnuplot-iostream)
 
 #--------------------------------------
 # Find gz-math

--- a/gz-waves/cmake/Add_gnuplot-iostream.cmake
+++ b/gz-waves/cmake/Add_gnuplot-iostream.cmake
@@ -1,0 +1,12 @@
+include(FetchContent)
+
+set(GnuPlotIostream_BuildTests OFF CACHE INTERNAL "BuildTests OFF")
+set(GnuPlotIostream_BuildExamples OFF CACHE INTERNAL "BuildExamples OFF")
+
+FetchContent_Declare(
+  gnuplot-iostream
+  GIT_REPOSITORY ${gnuplot-iostream_URL}
+  GIT_TAG        ${gnuplot-iostream_TAG}
+)
+
+FetchContent_MakeAvailable(gnuplot-iostream)

--- a/gz-waves/cmake/URL.conf.cmake
+++ b/gz-waves/cmake/URL.conf.cmake
@@ -1,0 +1,8 @@
+
+# Declare the PATH, TAG and PATCH used by FetchContent 
+
+# gnuplot-iostream: master HEAD
+set(gnuplot-iostream_URL https://github.com/dstahlke/gnuplot-iostream.git)
+set(gnuplot-iostream_TAG d674bdf23b93c76d491f03246d2e6f72bf5739ce
+  CACHE STRING "gnuplot-iostream version")
+

--- a/gz-waves/test/CMakeLists.txt
+++ b/gz-waves/test/CMakeLists.txt
@@ -29,4 +29,5 @@ ExternalProject_Add(
 add_subdirectory(gtest_vendor)
 # add_subdirectory(integration)
 add_subdirectory(performance)
+add_subdirectory(plots)
 # add_subdirectory(regression)

--- a/gz-waves/test/plots/CMakeLists.txt
+++ b/gz-waves/test/plots/CMakeLists.txt
@@ -1,0 +1,75 @@
+
+#============================================================================
+# Find dependencies
+#============================================================================
+
+#--------------------------------------
+# Check gnuplot-iostream is populated
+# message("gnuplot-iostream_POPULATED: ${gnuplot-iostream_POPULATED}")
+# message("gnuplot-iostream_INCLUDE_DIRS: ${gnuplot-iostream_INCLUDE_DIRS}")
+# message("gnuplot-iostream_SOURCE_DIR: ${gnuplot-iostream_SOURCE_DIR}")
+
+#--------------------------------------
+# Find gnuplot-iostream
+# 
+# The header is used by the examples in test/plots.
+# gnuplot-iostream_INCLUDE_DIRS is not set by the project so we use
+# gnuplot-iostream_SOURCE_DIR instead.
+find_package(Boost COMPONENTS iostreams)
+set(gnuplot-iostream_INCLUDE_DIRS ${gnuplot-iostream_SOURCE_DIR})
+
+#============================================================================
+# Add executables
+#============================================================================
+
+add_executable(PLOT_GnuPlotExample PLOT_GnuPlotExample.cc)
+target_link_libraries(PLOT_GnuPlotExample
+  ${PROJECT_LIBRARY_TARGET_NAME}
+  Boost::iostreams
+)
+target_include_directories(PLOT_GnuPlotExample
+  PUBLIC ${gnuplot-iostream_INCLUDE_DIRS}
+)
+
+
+add_executable(PLOT_LinearRandomFFTWaves PLOT_LinearRandomFFTWaves.cc)
+target_link_libraries(PLOT_LinearRandomFFTWaves
+  ${PROJECT_LIBRARY_TARGET_NAME}
+  Boost::iostreams
+)
+target_include_directories(PLOT_LinearRandomFFTWaves
+  PUBLIC ${gnuplot-iostream_INCLUDE_DIRS}
+)
+
+
+add_executable(PLOT_LinearRegularWaves PLOT_LinearRegularWaves.cc)
+target_link_libraries(PLOT_LinearRegularWaves
+  ${PROJECT_LIBRARY_TARGET_NAME}
+  Boost::iostreams
+)
+target_include_directories(PLOT_LinearRegularWaves
+  PUBLIC ${gnuplot-iostream_INCLUDE_DIRS}
+)
+
+
+add_executable(PLOT_WaveSpectrum PLOT_WaveSpectrum.cc)
+target_link_libraries(PLOT_WaveSpectrum
+  ${PROJECT_LIBRARY_TARGET_NAME}
+  Boost::iostreams
+)
+target_include_directories(PLOT_WaveSpectrum
+  PUBLIC ${gnuplot-iostream_INCLUDE_DIRS}
+)
+
+#============================================================================
+# Install targets
+#============================================================================
+
+install(
+  TARGETS
+    PLOT_GnuPlotExample
+    PLOT_LinearRandomFFTWaves
+    PLOT_LinearRegularWaves
+    PLOT_WaveSpectrum
+  RUNTIME DESTINATION bin
+)

--- a/gz-waves/test/plots/PLOT_GnuPlotExample.cc
+++ b/gz-waves/test/plots/PLOT_GnuPlotExample.cc
@@ -1,0 +1,66 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <gnuplot-iostream.h>
+
+int main(int /*argc*/, const char **/*argv*/)
+{
+  try
+  {
+    std::cout << "PLOT_GnuPlotExample\n";
+
+    {
+      std::string s = "pkill gnuplot_qt";
+      std::system(s.c_str());
+    }
+
+    {
+      double A = 1;
+      double T = 12;
+      double phase = 0 * M_PI / 180;
+      double beta = 180 * M_PI / 180;
+      double k = pow(2 * M_PI / T, 2) / 9.81;
+
+      std::vector<double> pts_t;
+      std::vector<double> pts_eta;
+      double x = 0.0;
+      double y = 0.0;
+      double xx = x * cos(beta) + y * sin(beta);
+      for (double t = 0.0; t < 4.0 * T; t += 0.1)
+      {
+        pts_t.push_back(t);
+        pts_eta.push_back(A * cos(k * xx - 2 * M_PI * t / T + phase));
+      }
+      Gnuplot gp;
+      gp << "set term qt title 'Wave Elevation at Origin'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'time (s)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << "plot '-' w l title 'eta'\n";
+      gp.send1d(std::make_tuple(pts_t, pts_eta));
+    }
+
+  }
+  catch(...)
+  {
+    std::cerr << "Unknown exception\n";
+    return -1;
+  }
+  return 0;
+}
+

--- a/gz-waves/test/plots/PLOT_LinearRandomFFTWaves.cc
+++ b/gz-waves/test/plots/PLOT_LinearRandomFFTWaves.cc
@@ -1,0 +1,169 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+ #include <Eigen/Dense>
+
+#include <gnuplot-iostream.h>
+
+#include <gz/waves/WaveSimulation.hh>
+#include <gz/waves/LinearRandomFFTWaveSimulation.hh>
+
+using namespace gz;
+using namespace waves;
+
+int main(int /*argc*/, const char **/*argv*/)
+{
+  try
+  {
+    std::cout << "PLOT_LinearRandomFFTWaves\n";
+
+    {
+      std::string s = "pkill gnuplot_qt";
+      std::system(s.c_str());
+    }
+
+    double lx = 256.0;
+    double ly = 256.0;
+    Index nx = 128;
+    Index ny = 128;
+
+    { // wave elevation vs time
+      std::unique_ptr<LinearRandomFFTWaveSimulation> wave_sim(
+          new LinearRandomFFTWaveSimulation(lx, ly, nx, ny));
+      wave_sim->SetWindVelocity(10.0, 0.0);
+      wave_sim->SetLambda(0.0);
+      wave_sim->SetTime(5.0);
+      
+      double sample_time = 60.0;
+      std::vector<double> pts_t;
+      std::vector<double> pts_eta;
+      for (double t = 0.0; t < sample_time; t += 0.1)
+      {
+        double eta;
+        wave_sim->SetTime(t);
+        wave_sim->ElevationAt(0, 0, eta);
+
+        pts_t.push_back(t);
+        pts_eta.push_back(eta);
+      }
+      Gnuplot gp;
+      gp << "set term qt title 'Linear Random FFT Wave Elevation at Origin'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'time (s)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << "plot '-' w l title 'eta'"
+         << "\n";
+      gp.send1d(std::make_tuple(pts_t, pts_eta));
+    }
+
+    { // wave elevation vs position
+      std::unique_ptr<LinearRandomFFTWaveSimulation> wave_sim(
+          new LinearRandomFFTWaveSimulation(lx, ly, nx, ny));
+      wave_sim->SetWindVelocity(10.0, 0.0);
+      wave_sim->SetLambda(0.0);
+      wave_sim->SetTime(5.0);
+
+      Eigen::ArrayXXd h(nx * ny, 1);
+      wave_sim->ElevationAt(h);
+
+      std::vector<double> pts_x;
+      std::vector<double> pts_eta1;
+      std::vector<double> pts_eta2;
+      for (Index ix = 0; ix < nx; ++ix)
+      {
+        Index iy = ny / 2;
+        Index idx = iy * nx + ix;
+        double eta1 = 0.0;
+        double eta2 = h(idx, 0);
+        wave_sim->ElevationAt(ix, iy, eta1);
+
+        double x = -0.5 * lx + ix * lx / nx;
+        pts_x.push_back(x);
+        pts_eta1.push_back(eta1);
+        pts_eta2.push_back(eta2);
+      }
+      Gnuplot gp;
+      gp << "set term qt title 'Linear Random FFT Wave Elevation'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'x (m)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << "plot '-' w l title 'eta1'"
+         << ",'-' w l title 'eta2'"
+         << "\n";
+      gp.send1d(std::make_tuple(pts_x, pts_eta1));
+      gp.send1d(std::make_tuple(pts_x, pts_eta2));
+    }
+
+    { // wave pressure vs position
+      Index nz = 10;
+      double lz = 50.0;
+
+      std::unique_ptr<LinearRandomFFTWaveSimulation> wave_sim(
+          new LinearRandomFFTWaveSimulation(lx, ly, lz, nx, ny, nz));
+      wave_sim->SetWindVelocity(10.0, 0.0);
+      wave_sim->SetLambda(0.0);
+      wave_sim->SetTime(5.0);
+
+      std::vector<double> pts_x;
+      std::vector<std::vector<double>> pts_p(nz);
+      for (Index ix = 0; ix < nx; ++ix)
+      {
+        Index iy = ny / 2;
+        for (Index iz = 0; iz < nz; ++iz)
+        {
+          double p;
+          wave_sim->PressureAt(ix, iy, iz, p);
+          pts_p[iz].push_back(p);
+        }
+        double x = -0.5 * lx + ix * lx / nx;
+        pts_x.push_back(x);
+      }
+
+      // assume we always have at least one plot
+      std::string plot_str("plot '-' w l title 'p0'");
+      for (Index iz = 1; iz < nz; ++iz)
+      {
+        plot_str.append(",'-' w l title 'p")
+          .append(std::to_string(iz)).append("'");
+      }
+      plot_str.append("\n");
+
+      Gnuplot gp;
+      gp << "set term qt title 'Linear Random FFT Wave Pressure'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'x (m)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << plot_str;
+
+      for (Index iz = 0; iz < nz; ++iz)
+      {
+        gp.send1d(std::make_tuple(pts_x, pts_p[iz]));
+      }
+    }
+
+  }
+  catch(...)
+  {
+    std::cerr << "Unknown exception\n";
+    return -1;
+  }
+  return 0;
+}
+

--- a/gz-waves/test/plots/PLOT_LinearRegularWaves.cc
+++ b/gz-waves/test/plots/PLOT_LinearRegularWaves.cc
@@ -44,36 +44,6 @@ int main(int /*argc*/, const char **/*argv*/)
     Index nx = 128;
     Index ny = 128;
 
-    // {
-    //   double period = 12.0;
-
-    //   std::unique_ptr<LinearRegularWaveSimulation> wave_sim(
-    //       new LinearRegularWaveSimulation(lx, ly, nx, ny));
-    //   wave_sim->SetDirection(1.0, 0.0);
-    //   wave_sim->SetAmplitude(2.0);
-    //   wave_sim->SetPeriod(period);
-    //   wave_sim->SetTime(0.0);
-      
-    //   std::vector<double> pts_t;
-    //   std::vector<double> pts_eta;
-    //   for (double t = 0.0; t < 4.0 * period; t += 0.1)
-    //   {
-    //     double eta;
-    //     wave_sim->SetTime(t);
-    //     wave_sim->Elevation(0.0, 0.0, eta);
-
-    //     pts_t.push_back(t);
-    //     pts_eta.push_back(eta);
-    //   }
-    //   Gnuplot gp;
-    //   gp << "set term qt title 'Wave Elevation at Origin'\n";
-    //   gp << "set grid\n";
-    //   gp << "set xlabel 'time (s)'\n";
-    //   gp << "set ylabel '(m)'\n";
-    //   gp << "plot '-' w l title 'eta'\n";
-    //   gp.send1d(std::make_tuple(pts_t, pts_eta));
-    // }
-
     { // wave elevation vs time
       std::unique_ptr<LinearRegularWaveSimulation> wave_sim(
           new LinearRegularWaveSimulation(lx, ly, nx, ny));

--- a/gz-waves/test/plots/PLOT_LinearRegularWaves.cc
+++ b/gz-waves/test/plots/PLOT_LinearRegularWaves.cc
@@ -1,0 +1,201 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+ #include <Eigen/Dense>
+
+#include <gnuplot-iostream.h>
+
+#include <gz/waves/WaveSimulation.hh>
+#include <gz/waves/LinearRegularWaveSimulation.hh>
+
+using namespace gz;
+using namespace waves;
+
+int main(int /*argc*/, const char **/*argv*/)
+{
+  try
+  {
+    std::cout << "PLOT_LinearRegularWaves\n";
+
+    {
+      std::string s = "pkill gnuplot_qt";
+      std::system(s.c_str());
+    }
+
+    double lx = 256.0;
+    double ly = 256.0;
+    Index nx = 128;
+    Index ny = 128;
+
+    // {
+    //   double period = 12.0;
+
+    //   std::unique_ptr<LinearRegularWaveSimulation> wave_sim(
+    //       new LinearRegularWaveSimulation(lx, ly, nx, ny));
+    //   wave_sim->SetDirection(1.0, 0.0);
+    //   wave_sim->SetAmplitude(2.0);
+    //   wave_sim->SetPeriod(period);
+    //   wave_sim->SetTime(0.0);
+      
+    //   std::vector<double> pts_t;
+    //   std::vector<double> pts_eta;
+    //   for (double t = 0.0; t < 4.0 * period; t += 0.1)
+    //   {
+    //     double eta;
+    //     wave_sim->SetTime(t);
+    //     wave_sim->Elevation(0.0, 0.0, eta);
+
+    //     pts_t.push_back(t);
+    //     pts_eta.push_back(eta);
+    //   }
+    //   Gnuplot gp;
+    //   gp << "set term qt title 'Wave Elevation at Origin'\n";
+    //   gp << "set grid\n";
+    //   gp << "set xlabel 'time (s)'\n";
+    //   gp << "set ylabel '(m)'\n";
+    //   gp << "plot '-' w l title 'eta'\n";
+    //   gp.send1d(std::make_tuple(pts_t, pts_eta));
+    // }
+
+    { // wave elevation vs time
+      std::unique_ptr<LinearRegularWaveSimulation> wave_sim(
+          new LinearRegularWaveSimulation(lx, ly, nx, ny));
+      wave_sim->SetDirection(1.0, 0.0);
+      wave_sim->SetAmplitude(2.0);
+      wave_sim->SetPeriod(12.0);
+      wave_sim->SetTime(0.0);
+      
+      double sample_time = 60.0;
+      std::vector<double> pts_t;
+      std::vector<double> pts_eta;
+      for (double t = 0.0; t < sample_time; t += 0.1)
+      {
+        double eta;
+        wave_sim->SetTime(t);
+        wave_sim->ElevationAt(0, 0, eta);
+
+        pts_t.push_back(t);
+        pts_eta.push_back(eta);
+      }
+      Gnuplot gp;
+      gp << "set term qt title 'Linear Regular Wave Elevation at Origin'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'time (s)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << "plot '-' w l title 'eta'"
+         << "\n";
+      gp.send1d(std::make_tuple(pts_t, pts_eta));
+    }
+
+    { // wave elevation vs position
+      std::unique_ptr<LinearRegularWaveSimulation> wave_sim(
+          new LinearRegularWaveSimulation(lx, ly, nx, ny));
+      wave_sim->SetDirection(1.0, 0.0);
+      wave_sim->SetAmplitude(2.0);
+      wave_sim->SetPeriod(12.0);
+      wave_sim->SetTime(5.0);
+
+      Eigen::ArrayXXd h(nx * ny, 1);
+      wave_sim->ElevationAt(h);
+
+      std::vector<double> pts_x;
+      std::vector<double> pts_eta1;
+      std::vector<double> pts_eta2;
+      for (Index ix = 0; ix < nx; ++ix)
+      {
+        Index iy = ny / 2;
+        Index idx = iy * nx + ix;
+        double eta1 = 0.0;
+        double eta2 = h(idx, 0);
+        wave_sim->ElevationAt(ix, iy, eta1);
+
+        double x = -0.5 * lx + ix * lx / nx;
+        pts_x.push_back(x);
+        pts_eta1.push_back(eta1);
+        pts_eta2.push_back(eta2);
+      }
+      Gnuplot gp;
+      gp << "set term qt title 'Linear Regular Wave Elevation'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'x (m)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << "plot '-' w l title 'eta1'"
+         << ",'-' w l title 'eta2'"
+         << "\n";
+      gp.send1d(std::make_tuple(pts_x, pts_eta1));
+      gp.send1d(std::make_tuple(pts_x, pts_eta2));
+    }
+
+    { // wave pressure vs position
+      Index nz = 10;
+      double lz = 50.0;
+
+      std::unique_ptr<LinearRegularWaveSimulation> wave_sim(
+          new LinearRegularWaveSimulation(lx, ly, lz, nx, ny, nz));
+      wave_sim->SetDirection(1.0, 0.0);
+      wave_sim->SetAmplitude(2.0);
+      wave_sim->SetPeriod(12.0);
+      wave_sim->SetTime(5.0);
+
+      std::vector<double> pts_x;
+      std::vector<std::vector<double>> pts_p(nz);
+      for (Index ix = 0; ix < nx; ++ix)
+      {
+        Index iy = ny / 2;
+        for (Index iz = 0; iz < nz; ++iz)
+        {
+          double p;
+          wave_sim->PressureAt(ix, iy, iz, p);
+          pts_p[iz].push_back(p);
+        }
+        double x = -0.5 * lx + ix * lx / nx;
+        pts_x.push_back(x);
+      }
+
+      // assume we always have at least one plot
+      std::string plot_str("plot '-' w l title 'p0'");
+      for (Index iz = 1; iz < nz; ++iz)
+      {
+        plot_str.append(",'-' w l title 'p")
+          .append(std::to_string(iz)).append("'");
+      }
+      plot_str.append("\n");
+
+      Gnuplot gp;
+      gp << "set term qt title 'Linear Regular Wave Pressure'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'x (m)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << plot_str;
+
+      for (Index iz = 0; iz < nz; ++iz)
+      {
+        gp.send1d(std::make_tuple(pts_x, pts_p[iz]));
+      }
+    }
+  }
+  catch(...)
+  {
+    std::cerr << "Unknown exception\n";
+    return -1;
+  }
+  return 0;
+}
+

--- a/gz-waves/test/plots/PLOT_WaveSpectrum.cc
+++ b/gz-waves/test/plots/PLOT_WaveSpectrum.cc
@@ -1,0 +1,163 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+ #include <Eigen/Dense>
+
+#include <gnuplot-iostream.h>
+
+#include <gz/waves/WaveSimulation.hh>
+#include <gz/waves/WaveSpectrum.hh>
+
+using Eigen::ArrayXd;
+
+using namespace gz;
+using namespace waves;
+
+// https://stackoverflow.com/questions/16605967/set-precision-of-stdto-string-when-converting-floating-point-values
+template <typename T>
+std::string to_string_with_precision(const T a_value, const int n = 6)
+{
+    std::ostringstream out;
+    out.precision(n);
+    out << std::fixed << a_value;
+    return out.str();
+}
+
+int main(int /*argc*/, const char **/*argv*/)
+{
+  try
+  {
+    std::cout << "PLOT_WaveSpectrum\n";
+
+    {
+      std::string s = "pkill gnuplot_qt";
+      std::system(s.c_str());
+    }
+
+    {
+      ECKVWaveSpectrum spectrum;
+
+      Index nk = 200;
+      Eigen::ArrayXd k = Eigen::pow(10.0, ArrayXd::LinSpaced(nk, -3.0, 4.0));
+
+      Index nu = 5;
+      Eigen::ArrayXd u10 = ArrayXd::LinSpaced(nu, 0.0, 20.0);
+
+      std::vector<double> pts_k;
+      std::vector<std::vector<double>> pts_s(u10.size());
+
+      for (Index ik = 0; ik < nk; ++ik)
+      {
+        pts_k.push_back(k(ik));
+
+        for (Index iu = 0; iu < nu; ++iu)
+        {
+          spectrum.SetU10(u10(iu));
+          double s = spectrum.Evaluate(k(ik));
+          pts_s[iu].push_back(s);
+        }
+      }
+
+
+      // assume we always have at least one plot
+      std::string plot_str("plot '-' w l title 'u10 = ");
+      plot_str.append(to_string_with_precision(u10(0), 1)).append("'");
+      for (Index iu = 1; iu < nu; ++iu)
+      {
+        plot_str.append(",'-' w l title 'u10 = ")
+          .append(to_string_with_precision(u10(iu), 1)).append("'");
+      }
+      plot_str.append("\n");
+
+      Gnuplot gp;
+      gp << "set term qt title 'ECKV Wave Spectrum'\n";
+      gp << "set grid\n";
+      gp << "set logscale xy\n";
+      gp << "set xrange [1.0E-3:1.0E4]\n";
+      gp << "set yrange [1.0E-15:1.0E3]\n";
+      gp << "set xlabel 'spatial frequency k (rad/m)'\n";
+      gp << "set ylabel 'variance spectrum S(k) (m^2/(rad/m))'\n";
+      gp << plot_str;
+
+      for (Index iu = 0; iu < nu; ++iu)
+      {
+        gp.send1d(std::make_tuple(pts_k, pts_s[iu]));
+      }
+    }
+
+    {
+      PiersonMoskowitzWaveSpectrum spectrum;
+
+      Index nk = 200;
+      Eigen::ArrayXd k = Eigen::pow(10.0, ArrayXd::LinSpaced(nk, -3.0, 4.0));
+
+      Index nu = 5;
+      Eigen::ArrayXd u19 = ArrayXd::LinSpaced(nu, 0.0, 20.0);
+
+      std::vector<double> pts_k;
+      std::vector<std::vector<double>> pts_s(u19.size());
+
+      for (Index ik = 0; ik < nk; ++ik)
+      {
+        pts_k.push_back(k(ik));
+
+        for (Index iu = 0; iu < nu; ++iu)
+        {
+          spectrum.SetU19(u19(iu));
+          double s = spectrum.Evaluate(k(ik));
+          pts_s[iu].push_back(s);
+        }
+      }
+
+
+      // assume we always have at least one plot
+      std::string plot_str("plot '-' w l title 'u19 = ");
+      plot_str.append(to_string_with_precision(u19(0), 1)).append("'");
+      for (Index iu = 1; iu < nu; ++iu)
+      {
+        plot_str.append(",'-' w l title 'u19 = ")
+          .append(to_string_with_precision(u19(iu), 1)).append("'");
+      }
+      plot_str.append("\n");
+
+      Gnuplot gp;
+      gp << "set term qt title 'Pierson-Moskowitz Wave Spectrum'\n";
+      gp << "set grid\n";
+      gp << "set logscale xy\n";
+      gp << "set xrange [1.0E-3:1.0E4]\n";
+      gp << "set yrange [1.0E-15:1.0E3]\n";
+      gp << "set xlabel 'spatial frequency k (rad/m)'\n";
+      gp << "set ylabel 'variance spectrum S(k) (m^2/(rad/m))'\n";
+      gp << plot_str;
+
+      for (Index iu = 0; iu < nu; ++iu)
+      {
+        gp.send1d(std::make_tuple(pts_k, pts_s[iu]));
+      }
+    }
+  }
+  catch(...)
+  {
+    std::cerr << "Unknown exception\n";
+    return -1;
+  }
+  return 0;
+}
+


### PR DESCRIPTION
This PR adds test programs for plotting the spectrum, elevation and pressure for the different wave simulation types.

The examples depend on the header from gnuplot-iostream (https://github.com/dstahlke/gnuplot-iostream.git) which is provided using cmake FetchContent. Inspiration drawn from the the test programs for the free surface hydrodynamics in [buoy_sim](https://github.com/osrf/buoy_sim). 

The examples are run from the workspace directory:

```zsh
./install/bin/PLOT_WaveSpectrum
```

Figures: Omni-directional ECKV and Pierson-Moskowitz wave spectra as a function of wavenumber.

![PLOT_WaveSpectrum_PM](https://user-images.githubusercontent.com/24916364/205493196-00cb0057-4974-4be4-8f7f-14826263d952.png)
![PLOT_WaveSpectrum_ECKV](https://user-images.githubusercontent.com/24916364/205493195-e20e7910-4b8f-4673-9d86-e66995efdd26.png)

```zsh
./install/bin/PLOT_LinearRegularWaves
```
```zsh
./install/bin/PLOT_LinearRandomFFTWaves
```
Figures: Random FFT wave elevation at origin with no horizontal displacement: 1.  as a function of time, 2. as function of position. Normalised pressure at varying depths as function of position.  

![PLOT_LinearRandomFFTWaves_1](https://user-images.githubusercontent.com/24916364/205493211-3fdd28dc-9d6a-4d85-ae4e-1298ecd65902.png)
![PLOT_LinearRandomFFTWaves_2](https://user-images.githubusercontent.com/24916364/205493212-8e0a11c9-736c-49d7-908b-420d4f5aaed5.png)
![PLOT_LinearRandomFFTWaves_3](https://user-images.githubusercontent.com/24916364/205493214-e4d36e69-7495-4c26-8c93-61f7ad60a056.png)
