### PR TITLE
Add non-FFT based linear random wave model

### DIFF
--- a/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
@@ -26,6 +26,28 @@ namespace gz
 {
 namespace waves
 {
+  /// \brief A non-FFT linear random wave simulation.
+  ///
+  /// Model provided for comparison with the LinearIncidentWave model
+  /// used in buoy_sim with the wave spectrum type set to Pierson-Moskowitz.
+  ///
+  /// Properties:
+  ///   - superposition of num_waves waves.
+  ///   - sampled at constant angular frequency steps delta omega.
+  ///   - amplitude determined by Pierson-Moskowitz spectrum.
+  ///   - wave direction may be set.
+  ///   - waves do not spread, all waves propagate in the same direction.
+  ///   - waves have random phases.
+  ///
+  /// Usage:
+  ///   - performance is poor on grids with resolution greater than 64 x 64.
+  ///
+  /// \todo(srmainwaring)
+  ///   - elevation derivatives
+  ///   - pressure calculations
+  ///   - orientation checks
+  ///   - tests
+  ///
   class LinearRandomWaveSimulation :
       public IWaveSimulation,
       public IWaveField

--- a/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
@@ -28,25 +28,21 @@ namespace waves
 {
   /// \brief A non-FFT linear random wave simulation.
   ///
-  /// Model provided for comparison with the LinearIncidentWave model
-  /// used in buoy_sim with the wave spectrum type set to Pierson-Moskowitz.
+  /// The model is provided for comparison with the LinearIncidentWave model
+  /// used in buoy_sim when the wave spectrum type is set to Pierson-Moskowitz.
   ///
   /// Properties:
-  ///   - superposition of num_waves waves.
-  ///   - sampled at constant angular frequency steps delta omega.
-  ///   - amplitude determined by Pierson-Moskowitz spectrum.
-  ///   - wave direction may be set.
-  ///   - waves do not spread, all waves propagate in the same direction.
-  ///   - waves have random phases.
+  ///   - Superposition of num_waves waves.
+  ///   - Sampled at constant angular frequency: MaxOmega / NumWaves.
+  ///   - Amplitudes determined by the Pierson-Moskowitz spectrum.
+  ///   - Wave direction may be set.
+  ///   - Waves do not spread, all waves propagate in the same direction.
+  ///   - Waves are assigned random phases.
   ///
-  /// Usage:
-  ///   - performance is poor on grids with resolution greater than 64 x 64.
-  ///
-  /// \todo(srmainwaring)
-  ///   - elevation derivatives
-  ///   - pressure calculations
-  ///   - orientation checks
-  ///   - tests
+  /// Performance estimates for various grid sizes:
+  ///   num waves       nx x ny         RTF
+  ///   100             128 x 128         6
+  ///   300             128 x 128         2
   ///
   class LinearRandomWaveSimulation :
       public IWaveSimulation,
@@ -64,7 +60,7 @@ namespace waves
     /// \brief The number of wave components.
     Index NumWaves() const; 
 
-    /// \brief Set the number of wave components (has default = 30).
+    /// \brief Set the number of wave components (has default = 100).
     void SetNumWaves(Index value);
 
     /// \brief The maximum angular frequency rad/s).

--- a/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
@@ -39,6 +39,10 @@ namespace waves
     LinearRandomWaveSimulation(double lx, double ly, double lz,
         Index nx, Index ny, Index nz);
 
+    void SetNumWaves(Index value);
+
+    virtual void SetWindVelocity(double ux, double uy) override;
+
     virtual void SetTime(double value) override;
 
     virtual Index SizeX() const override;

--- a/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
@@ -61,7 +61,17 @@ namespace waves
     LinearRandomWaveSimulation(double lx, double ly, double lz,
         Index nx, Index ny, Index nz);
 
+    /// \brief The number of wave components.
+    Index NumWaves() const; 
+
+    /// \brief Set the number of wave components (has default = 30).
     void SetNumWaves(Index value);
+
+    /// \brief The maximum angular frequency rad/s).
+    double MaxOmega() const;
+
+    /// \brief Set the maximum angular frequency (has default = 6.0 (rad/s)).
+    void SetMaxOmega(double value);
 
     virtual void SetWindVelocity(double ux, double uy) override;
 

--- a/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
@@ -1,0 +1,121 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_WAVES_LINEARRANDOMWAVESIMULATION_HH_
+#define GZ_WAVES_LINEARRANDOMWAVESIMULATION_HH_
+
+#include <memory>
+
+#include "WaveSimulation.hh"
+
+using Eigen::ArrayXXd;
+
+namespace gz
+{
+namespace waves
+{
+  class LinearRandomWaveSimulation :
+      public IWaveSimulation,
+      public IWaveField
+  {
+  public:
+    virtual ~LinearRandomWaveSimulation();
+
+    LinearRandomWaveSimulation(double lx, double ly,
+        Index nx, Index ny);
+
+    LinearRandomWaveSimulation(double lx, double ly, double lz,
+        Index nx, Index ny, Index nz);
+
+    virtual void SetTime(double value) override;
+
+    virtual Index SizeX() const override;
+
+    virtual Index SizeY() const override;
+
+    virtual Index SizeZ() const override;
+
+    // IWaveField - interface.
+    virtual void Elevation(
+        double x, double y,
+        double &eta) override;
+
+    virtual void Elevation(
+        const Eigen::Ref<const Eigen::ArrayXd> &x,
+        const Eigen::Ref<const Eigen::ArrayXd> &y,
+        Eigen::Ref<Eigen::ArrayXd> eta) override;
+
+    virtual void Pressure(
+        double x, double y, double z,
+        double &pressure) override;
+
+    virtual void Pressure(
+        const Eigen::Ref<const Eigen::ArrayXd> &x,
+        const Eigen::Ref<const Eigen::ArrayXd> &y,
+        const Eigen::Ref<const Eigen::ArrayXd> &z,
+        Eigen::Ref<Eigen::ArrayXd> pressure) override;
+
+    // lookup interface - array
+    virtual void ElevationAt(
+        Eigen::Ref<Eigen::ArrayXXd> h) override;
+
+    virtual void ElevationDerivAt(
+        Eigen::Ref<Eigen::ArrayXXd> dhdx,
+        Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+
+    virtual void DisplacementAt(
+        Eigen::Ref<Eigen::ArrayXXd> sx,
+        Eigen::Ref<Eigen::ArrayXXd> sy) override;
+
+    virtual void DisplacementDerivAt(
+        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+        Eigen::Ref<Eigen::ArrayXXd> dsydy,
+        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+
+    virtual void DisplacementAndDerivAt(
+        Eigen::Ref<Eigen::ArrayXXd> h,
+        Eigen::Ref<Eigen::ArrayXXd> sx,
+        Eigen::Ref<Eigen::ArrayXXd> sy,
+        Eigen::Ref<Eigen::ArrayXXd> dhdx,
+        Eigen::Ref<Eigen::ArrayXXd> dhdy,
+        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+        Eigen::Ref<Eigen::ArrayXXd> dsydy,
+        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+
+    virtual void PressureAt(
+        Index iz,
+        Eigen::Ref<Eigen::ArrayXXd> pressure) override;
+
+    // lookup interface - scalar
+    virtual void ElevationAt(
+        Index ix, Index iy,
+        double &eta) override;
+
+    virtual void DisplacementAt(
+        Index ix, Index iy,
+        double &sx, double &sy) override;
+
+    virtual void PressureAt(
+        Index ix, Index iy, Index iz,
+        double &pressure) override;
+
+  private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+  };
+}
+}
+
+#endif

--- a/gz-waves/src/CMakeLists.txt
+++ b/gz-waves/src/CMakeLists.txt
@@ -25,6 +25,7 @@ set(sources
   WaveSimulation.cc
   LinearRandomFFTWaveSimulation.cc
   LinearRandomFFTWaveSimulationRef.cc
+  LinearRandomWaveSimulation.cc
   LinearRegularWaveSimulation.cc
   TrochoidIrregularWaveSimulation.cc
   WaveSpectrum.cc

--- a/gz-waves/src/LinearRandomFFTWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulation.cc
@@ -110,23 +110,23 @@ namespace waves
   void LinearRandomFFTWaveSimulation::Impl::ElevationDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dhdx,
       Eigen::Ref<Eigen::ArrayXXd> dhdy)
+  {
+    // run the FFTs
+    if (fft_needs_update_[1])
     {
-      // run the FFTs
-      if (fft_needs_update_[1])
-      {
-        fftw_execute(fft_plan1_);
-        fft_needs_update_[1] = false;
-      }
-      if (fft_needs_update_[2])
-      {
-        fftw_execute(fft_plan2_);
-        fft_needs_update_[2] = false;
-      }
-      // change from row to column major storage
-      size_t n2 = nx_ * ny_;
-      dhdy = fft_out1_.reshaped<Eigen::ColMajor>(n2, 1);
-      dhdx = fft_out2_.reshaped<Eigen::ColMajor>(n2, 1);
+      fftw_execute(fft_plan1_);
+      fft_needs_update_[1] = false;
     }
+    if (fft_needs_update_[2])
+    {
+      fftw_execute(fft_plan2_);
+      fft_needs_update_[2] = false;
+    }
+    // change from row to column major storage
+    size_t n2 = nx_ * ny_;
+    dhdy = fft_out1_.reshaped<Eigen::ColMajor>(n2, 1);
+    dhdx = fft_out2_.reshaped<Eigen::ColMajor>(n2, 1);
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulation::Impl::DisplacementAt(
@@ -156,30 +156,30 @@ namespace waves
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
       Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+  {
+    // run the FFTs
+    if (fft_needs_update_[5])
     {
-      // run the FFTs
-      if (fft_needs_update_[5])
-      {
-        fftw_execute(fft_plan5_);
-        fft_needs_update_[5] = false;
-      }
-      if (fft_needs_update_[6])
-      {
-        fftw_execute(fft_plan6_);
-        fft_needs_update_[6] = false;
-      }
-      if (fft_needs_update_[7])
-      {
-        fftw_execute(fft_plan7_);
-        fft_needs_update_[7] = false;
-      }
-
-      // change from row to column major storage
-      size_t n2 = nx_ * ny_;
-      dsydy = fft_out5_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
-      dsxdx = fft_out6_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
-      dsxdy = fft_out7_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ *  1.0;
+      fftw_execute(fft_plan5_);
+      fft_needs_update_[5] = false;
     }
+    if (fft_needs_update_[6])
+    {
+      fftw_execute(fft_plan6_);
+      fft_needs_update_[6] = false;
+    }
+    if (fft_needs_update_[7])
+    {
+      fftw_execute(fft_plan7_);
+      fft_needs_update_[7] = false;
+    }
+
+    // change from row to column major storage
+    size_t n2 = nx_ * ny_;
+    dsydy = fft_out5_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
+    dsxdx = fft_out6_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
+    dsxdy = fft_out7_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ *  1.0;
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulation::Impl::PressureAt(
@@ -710,26 +710,26 @@ namespace waves
   void LinearRandomFFTWaveSimulation::ElevationDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dhdx,
       Eigen::Ref<Eigen::ArrayXXd> dhdy)
-    {
-      impl_->ElevationDerivAt(dhdx, dhdy);
-    }
+  {
+    impl_->ElevationDerivAt(dhdx, dhdy);
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulation::DisplacementAt(
       Eigen::Ref<Eigen::ArrayXXd> sx,
       Eigen::Ref<Eigen::ArrayXXd> sy)
-    {
-      impl_->DisplacementAt(sx, sy);
-    }
+  {
+    impl_->DisplacementAt(sx, sy);
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulation::DisplacementDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
       Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-    {
-      impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
-    }
+  {
+    impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulation::DisplacementAndDerivAt(
@@ -741,12 +741,12 @@ namespace waves
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
       Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-    {
-      impl_->ElevationAt(h);
-      impl_->ElevationDerivAt(dhdx, dhdy);
-      impl_->DisplacementAt(sx, sy);
-      impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
-    }
+  {
+    impl_->ElevationAt(h);
+    impl_->ElevationDerivAt(dhdx, dhdy);
+    impl_->DisplacementAt(sx, sy);
+    impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulation::PressureAt(

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -1,0 +1,389 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+#include "gz/waves/LinearRandomWaveSimulation.hh"
+
+#include <complex>
+#include <random>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include <gz/common.hh>
+
+#include "gz/waves/WaveSpectrum.hh"
+#include "gz/waves/WaveSpreadingFunction.hh"
+
+namespace gz
+{
+namespace waves
+{
+
+  //////////////////////////////////////////////////
+  class LinearRandomWaveSimulation::Impl
+  {
+  public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    ~Impl();
+
+    Impl(double lx, double ly, Index nx, Index ny);
+
+    Impl(double lx, double ly, double lz, Index nx, Index ny, Index nz);
+
+    void InitGrid();
+
+    void SetTime(double value);
+
+    // interpolation interface
+    void Elevation(
+        double x, double y,
+        double &eta);
+
+    void Elevation(
+        const Eigen::Ref<const Eigen::ArrayXd> &x,
+        const Eigen::Ref<const Eigen::ArrayXd> &y,
+        Eigen::Ref<Eigen::ArrayXd> eta);
+
+    void Pressure(
+        double x, double y, double z,
+        double &pressure);
+
+    void Pressure(
+        const Eigen::Ref<const Eigen::ArrayXd> &x,
+        const Eigen::Ref<const Eigen::ArrayXd> &y,
+        const Eigen::Ref<const Eigen::ArrayXd> &z,
+        Eigen::Ref<Eigen::ArrayXd> pressure);
+
+    // lookup interface
+    void ElevationAt(
+        Eigen::Ref<Eigen::ArrayXXd> h);
+
+    void ElevationDerivAt(
+        Eigen::Ref<Eigen::ArrayXXd> dhdx,
+        Eigen::Ref<Eigen::ArrayXXd> dhdy);
+
+    void DisplacementAndDerivAt(
+        Eigen::Ref<Eigen::ArrayXXd> h,
+        Eigen::Ref<Eigen::ArrayXXd> sx,
+        Eigen::Ref<Eigen::ArrayXXd> sy,
+        Eigen::Ref<Eigen::ArrayXXd> dhdx,
+        Eigen::Ref<Eigen::ArrayXXd> dhdy,
+        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+        Eigen::Ref<Eigen::ArrayXXd> dsydy,
+        Eigen::Ref<Eigen::ArrayXXd> dsxdy);
+
+    void ElevationAt(
+        Index ix, Index iy,
+        double &h);
+
+    void PressureAt(
+        Index ix, Index iy, Index iz,
+        double &pressure);
+
+    void PressureAt(
+        Index iz,
+        Eigen::Ref<Eigen::ArrayXXd> pressure);
+
+    static inline void PreComputeCoeff(
+      double period, double t, double wave_angle,
+      double &w, double &wt, double &k, double &cos_angle, double &sin_angle)
+    {
+      w = 2.0 * M_PI / period;
+      wt = w * t;
+      k = Physics::DeepWaterDispersionToWavenumber(w);
+      cos_angle = std::cos(wave_angle);
+      sin_angle = std::sin(wave_angle);
+    }
+
+    bool use_vectorised_{true};
+
+    // elevation and pressure grid params
+    Index nx_{2};
+    Index ny_{2};
+    Index nz_{1};
+    double lx_{1.0};
+    double ly_{1.0};
+    double lz_{0.0};
+
+    // wave params
+    // double wave_angle_{0.0};
+    // double amplitude_{1.0};
+    // double period_{1.0};
+    // double time_{0.0};
+
+    // derived
+    double dx_{0.0};
+    double dy_{0.0};
+    double lx_max_{0.0};
+    double lx_min_{0.0};
+    double ly_max_{0.0};
+    double ly_min_{0.0};
+
+    // vectorised
+    Eigen::ArrayXd x_;
+    Eigen::ArrayXd y_;
+    Eigen::ArrayXXd x_grid_;
+    Eigen::ArrayXXd y_grid_;
+    Eigen::ArrayXd z_;
+  };
+  
+  //////////////////////////////////////////////////
+  LinearRandomWaveSimulation::Impl::~Impl() = default;
+
+  //////////////////////////////////////////////////
+  LinearRandomWaveSimulation::Impl::Impl(
+    double lx, double ly, Index nx, Index ny) :
+    lx_(lx),
+    ly_(ly),
+    nx_(nx),
+    ny_(ny)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  LinearRandomWaveSimulation::Impl::Impl(
+    double lx, double ly, double lz, Index nx, Index ny, Index nz) :
+    lx_(lx),
+    ly_(ly),
+    lz_(lz),
+    nx_(nx),
+    ny_(ny),
+    nz_(nz)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::SetTime(double time)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::DisplacementAt(
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::DisplacementDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::ElevationAt(
+      Index ix, Index iy,
+      double &eta)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::DisplacementAt(
+      Index ix, Index iy,
+      double &sx, double &sy)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::PressureAt(
+      Index ix, Index iy, Index iz,
+      double &pressure)
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::InitWaveNumbers()
+  {
+    kx_fft_  = Eigen::ArrayXd::Zero(nx_);
+    ky_fft_  = Eigen::ArrayXd::Zero(ny_);
+
+    // wavenumbers in fft and math ordering
+    for(Index ikx = 0; ikx < nx_; ++ikx)
+    {
+      double kx = (ikx - nx_/2) * kx_f_;
+      kx_fft_((ikx + nx_/2) % nx_) = kx;
+    }
+
+    for(Index iky = 0; iky < ny_; ++iky)
+    {
+      double ky = (iky - ny_/2) * ky_f_;
+      ky_fft_((iky + ny_/2) % ny_) = ky;
+    }
+  }
+
+ //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::Impl::InitPressureGrid()
+  {
+    // pressure sample points (z is below the free surface)
+    Eigen::ArrayXd zr = Eigen::ArrayXd::Zero(nz_);
+    if (nz_ > 1)
+    {
+      // first element is zero - fill nz - 1 remaining elements
+      Eigen::ArrayXd ln_z = Eigen::ArrayXd::LinSpaced(
+          nz_ - 1, -std::log(lz_), std::log(lz_));
+      zr(Eigen::seq(1, nz_ - 1)) = -1 * Eigen::exp(ln_z);
+    }
+    z_ = zr.reverse();
+  }
+
+  //////////////////////////////////////////////////
+  //////////////////////////////////////////////////
+  LinearRandomWaveSimulation::~LinearRandomWaveSimulation() = default;
+
+  //////////////////////////////////////////////////
+  LinearRandomWaveSimulation::LinearRandomWaveSimulation(
+      double lx, double ly, Index nx, Index ny) :
+    impl_(new LinearRandomWaveSimulation::Impl(lx, ly, nx, ny))
+  {
+  }
+
+  //////////////////////////////////////////////////
+  LinearRandomWaveSimulation::LinearRandomWaveSimulation(
+      double lx, double ly, double lz, Index nx, Index ny, Index nz) :
+    impl_(new LinearRandomWaveSimulation::Impl(lx, ly, lz, nx, ny, nz))
+  {
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::SetTime(double value)
+  {
+    impl_->SetTime(value);
+  }
+
+  //////////////////////////////////////////////////
+  Index LinearRandomWaveSimulation::SizeX() const
+  {
+    return impl_->nx_;
+  }
+
+  //////////////////////////////////////////////////
+  Index LinearRandomWaveSimulation::SizeY() const
+  {
+    return impl_->ny_;
+  }
+
+  //////////////////////////////////////////////////
+  Index LinearRandomWaveSimulation::SizeZ() const
+  {
+    return impl_->nz_;
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h)
+  {
+    impl_->ElevationAt(h);
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy)
+    {
+      impl_->ElevationDerivAt(dhdx, dhdy);
+    }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::DisplacementAt(
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy)
+    {
+      impl_->DisplacementAt(sx, sy);
+    }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::DisplacementDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+    {
+      impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
+    }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::DisplacementAndDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> h,
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy,
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+    {
+      impl_->ElevationAt(h);
+      impl_->ElevationDerivAt(dhdx, dhdy);
+      impl_->DisplacementAt(sx, sy);
+      impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
+    }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure)
+  {
+    impl_->PressureAt(iz, pressure);
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::ElevationAt(
+      Index ix, Index iy,
+      double &eta)
+  {
+    impl_->ElevationAt(ix, iy, eta);
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::DisplacementAt(
+      Index ix, Index iy,
+      double &sx, double &sy)
+  {
+    impl_->DisplacementAt(ix, iy, sx, sy);
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::PressureAt(
+      Index ix, Index iy, Index iz,
+      double &pressure)
+  {
+    impl_->PressureAt(ix, iy, iz, pressure);
+  }
+
+}
+}

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -181,13 +181,17 @@ namespace waves
   {
     ComputeAmplitudes();
 
-    double xx = x * std::cos(wave_angle_) + y * std::sin(wave_angle_);
+    double cd = std::cos(wave_angle_);
+    double sd = std::sin(wave_angle_);
+    double xd = x * cd + y * sd;
 
     double h = 0;
     for (Index ik = 0; ik < num_waves_; ++ik)
     {
       double wt = w_(ik) * time_;
-      h += amplitude_(ik) * std::cos(k_(ik) * xx - wt + phase_(ik));
+      double a  = k_(ik) * xd - wt + phase_(ik);
+      double ca = std::cos(a);
+      h += amplitude_(ik) * ca;
     }
     eta = h;
   }
@@ -201,14 +205,14 @@ namespace waves
 
     double cd = std::cos(wave_angle_);
     double sd = std::sin(wave_angle_);
-    double xx  = x * cd + y * sd;
+    double xd  = x * cd + y * sd;
 
     double dhdx = 0;
     double dhdy = 0;
     for (Index ik = 0; ik < num_waves_; ++ik)
     {
       double wt = w_(ik) * time_;
-      double a  = k_(ik) * xx - wt + phase_(ik);
+      double a  = k_(ik) * xd - wt + phase_(ik);
       double sa = std::sin(a);
       double dadx = k_(ik) * cd;
       double dady = k_(ik) * sd;
@@ -238,13 +242,26 @@ namespace waves
 
   //////////////////////////////////////////////////
   void LinearRandomWaveSimulation::Impl::Pressure(
-      double /*x*/, double /*y*/, double /*z*/,
+      double x, double y, double z,
       double &pressure)
   {
     ComputeAmplitudes();
 
-    /// \todo(srmainwaring) implement
-    pressure = 0.0;
+    double cd = std::cos(wave_angle_);
+    double sd = std::sin(wave_angle_);
+    double xd = x * cd + y * sd;
+
+    double p = 0;
+    for (Index ik = 0; ik < num_waves_; ++ik)
+    {
+      double wt = w_(ik) * time_;
+      double a  = k_(ik) * xd - wt + phase_(ik);
+      double ca = std::cos(a);
+      double h1 = amplitude_(ik) * ca;
+      double e  = std::exp(k_(ik) * z);
+      p += e * h1;
+    }
+    pressure = p;
   }
 
   //////////////////////////////////////////////////

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -30,10 +30,6 @@ namespace gz
 {
 namespace waves
 {
-
-  constexpr Index DEFAULT_N_PHASES{30};
-  constexpr double MAX_FREQ{0.3};  // Hz
-
   //////////////////////////////////////////////////
   class LinearRandomWaveSimulation::Impl
   {
@@ -114,7 +110,8 @@ namespace waves
     double fluid_rho_{1025.0};
 
     // parameters
-    Index num_waves_{DEFAULT_N_PHASES};
+    Index num_waves_{30};
+    double max_w_{6.0};
     double u19_{5.0};
     double wave_angle_{0.0};
 
@@ -414,7 +411,7 @@ namespace waves
     spectrum.SetU19(u19_);
 
     // angular frequency step size
-    double dw = MAX_FREQ * 2 * M_PI / num_waves_;
+    double dw = max_w_ / num_waves_;
 
     // random uniforms for phase
     auto seed = std::default_random_engine::default_seed;
@@ -459,9 +456,28 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
+  Index LinearRandomWaveSimulation::NumWaves() const
+  {
+    return impl_->num_waves_;
+  }
+
+  //////////////////////////////////////////////////
   void LinearRandomWaveSimulation::SetNumWaves(Index value)
   {
     impl_->num_waves_ = value;
+    impl_->needs_update_ = true;
+  }
+
+  //////////////////////////////////////////////////
+  double LinearRandomWaveSimulation::MaxOmega() const
+  {
+    return impl_->max_w_;
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomWaveSimulation::SetMaxOmega(double value)
+  {
+    impl_->max_w_ = value;
     impl_->needs_update_ = true;
   }
 

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -44,7 +44,7 @@ namespace waves
 
     Impl(double lx, double ly, double lz, Index nx, Index ny, Index nz);
 
-    void InitGrid();
+    void InitPressureGrid();
 
     void SetTime(double value);
 
@@ -98,16 +98,16 @@ namespace waves
         Index iz,
         Eigen::Ref<Eigen::ArrayXXd> pressure);
 
-    static inline void PreComputeCoeff(
-      double period, double t, double wave_angle,
-      double &w, double &wt, double &k, double &cos_angle, double &sin_angle)
-    {
-      w = 2.0 * M_PI / period;
-      wt = w * t;
-      k = Physics::DeepWaterDispersionToWavenumber(w);
-      cos_angle = std::cos(wave_angle);
-      sin_angle = std::sin(wave_angle);
-    }
+    // static inline void PreComputeCoeff(
+    //   double period, double t, double wave_angle,
+    //   double &w, double &wt, double &k, double &cos_angle, double &sin_angle)
+    // {
+    //   w = 2.0 * M_PI / period;
+    //   wt = w * t;
+    //   k = Physics::DeepWaterDispersionToWavenumber(w);
+    //   cos_angle = std::cos(wave_angle);
+    //   sin_angle = std::sin(wave_angle);
+    // }
 
     bool use_vectorised_{true};
 
@@ -185,21 +185,6 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::DisplacementAt(
-      Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy)
-  {
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::DisplacementDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-      Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-  {
-  }
-
-  //////////////////////////////////////////////////
   void LinearRandomWaveSimulation::Impl::PressureAt(
       Index iz,
       Eigen::Ref<Eigen::ArrayXXd> pressure)
@@ -214,37 +199,10 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::DisplacementAt(
-      Index ix, Index iy,
-      double &sx, double &sy)
-  {
-  }
-
-  //////////////////////////////////////////////////
   void LinearRandomWaveSimulation::Impl::PressureAt(
       Index ix, Index iy, Index iz,
       double &pressure)
   {
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::InitWaveNumbers()
-  {
-    kx_fft_  = Eigen::ArrayXd::Zero(nx_);
-    ky_fft_  = Eigen::ArrayXd::Zero(ny_);
-
-    // wavenumbers in fft and math ordering
-    for(Index ikx = 0; ikx < nx_; ++ikx)
-    {
-      double kx = (ikx - nx_/2) * kx_f_;
-      kx_fft_((ikx + nx_/2) % nx_) = kx;
-    }
-
-    for(Index iky = 0; iky < ny_; ++iky)
-    {
-      double ky = (iky - ny_/2) * ky_f_;
-      ky_fft_((iky + ny_/2) % ny_) = ky;
-    }
   }
 
  //////////////////////////////////////////////////
@@ -315,43 +273,41 @@ namespace waves
   void LinearRandomWaveSimulation::ElevationDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dhdx,
       Eigen::Ref<Eigen::ArrayXXd> dhdy)
-    {
-      impl_->ElevationDerivAt(dhdx, dhdy);
-    }
+  {
+    impl_->ElevationDerivAt(dhdx, dhdy);
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomWaveSimulation::DisplacementAt(
-      Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy)
-    {
-      impl_->DisplacementAt(sx, sy);
-    }
+      Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
+      Eigen::Ref<Eigen::ArrayXXd> /*sy*/)
+  {
+    // no xy-displacement
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomWaveSimulation::DisplacementDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-      Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-    {
-      impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
-    }
+      Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
+      Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
+      Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+  {
+    // no xy-displacement
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomWaveSimulation::DisplacementAndDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> h,
-      Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy,
+      Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
+      Eigen::Ref<Eigen::ArrayXXd> /*sy*/,
       Eigen::Ref<Eigen::ArrayXXd> dhdx,
       Eigen::Ref<Eigen::ArrayXXd> dhdy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-      Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-    {
-      impl_->ElevationAt(h);
-      impl_->ElevationDerivAt(dhdx, dhdy);
-      impl_->DisplacementAt(sx, sy);
-      impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
-    }
+      Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
+      Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
+      Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+  {
+    impl_->ElevationAt(h);
+    impl_->ElevationDerivAt(dhdx, dhdy);
+  }
 
   //////////////////////////////////////////////////
   void LinearRandomWaveSimulation::PressureAt(
@@ -371,10 +327,10 @@ namespace waves
 
   //////////////////////////////////////////////////
   void LinearRandomWaveSimulation::DisplacementAt(
-      Index ix, Index iy,
-      double &sx, double &sy)
+      Index /*ix*/, Index /*iy*/,
+      double &/*sx*/, double &/*sy*/)
   {
-    impl_->DisplacementAt(ix, iy, sx, sy);
+    // no xy-displacement
   }
 
   //////////////////////////////////////////////////

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -98,19 +98,6 @@ namespace waves
         Index iz,
         Eigen::Ref<Eigen::ArrayXXd> pressure);
 
-    // static inline void PreComputeCoeff(
-    //   double period, double t, double wave_angle,
-    //   double &w, double &wt, double &k, double &cos_angle, double &sin_angle)
-    // {
-    //   w = 2.0 * M_PI / period;
-    //   wt = w * t;
-    //   k = Physics::DeepWaterDispersionToWavenumber(w);
-    //   cos_angle = std::cos(wave_angle);
-    //   sin_angle = std::sin(wave_angle);
-    // }
-
-    bool use_vectorised_{true};
-
     // elevation and pressure grid params
     Index nx_{2};
     Index ny_{2};
@@ -118,12 +105,6 @@ namespace waves
     double lx_{1.0};
     double ly_{1.0};
     double lz_{0.0};
-
-    // wave params
-    // double wave_angle_{0.0};
-    // double amplitude_{1.0};
-    // double period_{1.0};
-    // double time_{0.0};
 
     // derived
     double dx_{0.0};
@@ -260,6 +241,37 @@ namespace waves
   Index LinearRandomWaveSimulation::SizeZ() const
   {
     return impl_->nz_;
+  }
+
+  void LinearRandomWaveSimulation::Elevation(
+      double x, double y,
+      double &eta)
+  {
+    impl_->Elevation(x, y, eta);
+  }
+
+  void LinearRandomWaveSimulation::Elevation(
+      const Eigen::Ref<const Eigen::ArrayXd> &x,
+      const Eigen::Ref<const Eigen::ArrayXd> &y,
+      Eigen::Ref<Eigen::ArrayXd> eta)
+  {
+    impl_->Elevation(x, y, eta);
+  }
+
+  void LinearRandomWaveSimulation::Pressure(
+      double x, double y, double z,
+      double &pressure)
+  {
+    impl_->Pressure(x, y, z, pressure);
+  }
+
+  void LinearRandomWaveSimulation::Pressure(
+      const Eigen::Ref<const Eigen::ArrayXd> &x,
+      const Eigen::Ref<const Eigen::ArrayXd> &y,
+      const Eigen::Ref<const Eigen::ArrayXd> &z,
+      Eigen::Ref<Eigen::ArrayXd> pressure)
+  {
+    impl_->Pressure(x, y, z, pressure);
   }
 
   //////////////////////////////////////////////////

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -110,7 +110,7 @@ namespace waves
     double fluid_rho_{1025.0};
 
     // parameters
-    Index num_waves_{30};
+    Index num_waves_{100};
     double max_w_{6.0};
     double u19_{5.0};
     double wave_angle_{0.0};

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -31,7 +31,7 @@ namespace gz
 namespace waves
 {
 
-  constexpr Index DEFAULT_N_PHASES{300};
+  constexpr Index DEFAULT_N_PHASES{30};
   constexpr double MAX_FREQ{0.3};  // Hz
 
   //////////////////////////////////////////////////
@@ -260,7 +260,10 @@ namespace waves
       {
         double h1{0.0};
         ElevationAt(ix, iy, h1);
-        h(ix, iy) = h1;
+
+        // column major
+        Index idx = iy * nx_ + ix;
+        h(idx, 0) = h1;
       }
     }
   }
@@ -286,7 +289,10 @@ namespace waves
       {
         double p1{0.0};
         PressureAt(ix, iy, iz, p1);
-        pressure(ix, iy) = p1;
+
+        // column major
+        Index idx = iy * nx_ + ix;
+        pressure(idx, 0) = p1;
       }
     }
   }

--- a/gz-waves/src/LinearRegularWaveSimulation.cc
+++ b/gz-waves/src/LinearRegularWaveSimulation.cc
@@ -155,16 +155,14 @@ namespace waves
 
     bool use_vectorised_{true};
 
-    // elevation grid params
+    // elevation and pressure grid params
     Index nx_{2};
     Index ny_{2};
+    Index nz_{1};
     double lx_{1.0};
     double ly_{1.0};
-    
-    // pressure grid params
-    Index nz_{1};
     double lz_{0.0};
-
+    
     // wave params
     double wave_angle_{0.0};
     double amplitude_{1.0};
@@ -208,9 +206,9 @@ namespace waves
       double lx, double ly, double lz, Index nx, Index ny, Index nz) :
     nx_(nx),
     ny_(ny),
+    nz_(nz),
     lx_(lx),
     ly_(ly),
-    nz_(nz),
     lz_(lz)
   {
     InitGrid();
@@ -488,11 +486,11 @@ namespace waves
 
   //////////////////////////////////////////////////
   void LinearRegularWaveSimulation::Impl::ElevationAt(
-      Index ix, Index iy, double &eta)
+      Index ix, Index iy, double &h)
   {
-    double y = iy * dy_ + ly_min_;
     double x = ix * dx_ + lx_min_;
-    Elevation(x, y, eta);
+    double y = iy * dy_ + ly_min_;
+    Elevation(x, y, h);
   }
 
   //////////////////////////////////////////////////
@@ -500,8 +498,8 @@ namespace waves
     Index ix, Index iy, Index iz,
     double &pressure)
   {
-    double y = iy * dy_ + ly_min_;
     double x = ix * dx_ + lx_min_;
+    double y = iy * dy_ + ly_min_;
     double z = z_(iz);
     Pressure(x, y, z, pressure);
   }

--- a/gz-waves/src/LinearRegularWaveSimulation.cc
+++ b/gz-waves/src/LinearRegularWaveSimulation.cc
@@ -92,7 +92,7 @@ namespace waves
 
     void SetTime(double value);
 
-    ///// interpolation interface
+    // interpolation interface
     void Elevation(
         double x, double y,
         double &eta);

--- a/gz-waves/test/plots/CMakeLists.txt
+++ b/gz-waves/test/plots/CMakeLists.txt
@@ -42,6 +42,16 @@ target_include_directories(PLOT_LinearRandomFFTWaves
 )
 
 
+add_executable(PLOT_LinearRandomWaves PLOT_LinearRandomWaves.cc)
+target_link_libraries(PLOT_LinearRandomWaves
+  ${PROJECT_LIBRARY_TARGET_NAME}
+  Boost::iostreams
+)
+target_include_directories(PLOT_LinearRandomWaves
+  PUBLIC ${gnuplot-iostream_INCLUDE_DIRS}
+)
+
+
 add_executable(PLOT_LinearRegularWaves PLOT_LinearRegularWaves.cc)
 target_link_libraries(PLOT_LinearRegularWaves
   ${PROJECT_LIBRARY_TARGET_NAME}
@@ -69,6 +79,7 @@ install(
   TARGETS
     PLOT_GnuPlotExample
     PLOT_LinearRandomFFTWaves
+    PLOT_LinearRandomWaves
     PLOT_LinearRegularWaves
     PLOT_WaveSpectrum
   RUNTIME DESTINATION bin

--- a/gz-waves/test/plots/PLOT_LinearRandomWaves.cc
+++ b/gz-waves/test/plots/PLOT_LinearRandomWaves.cc
@@ -47,6 +47,8 @@ int main(int /*argc*/, const char **/*argv*/)
     { // wave elevation vs time
       std::unique_ptr<LinearRandomWaveSimulation> wave_sim(
           new LinearRandomWaveSimulation(lx, ly, nx, ny));
+      wave_sim->SetNumWaves(300);
+      wave_sim->SetMaxOmega(6.0);
       wave_sim->SetWindVelocity(10.0, 0.0);
       wave_sim->SetTime(5.0);
       
@@ -75,6 +77,8 @@ int main(int /*argc*/, const char **/*argv*/)
     { // wave elevation vs position
       std::unique_ptr<LinearRandomWaveSimulation> wave_sim(
           new LinearRandomWaveSimulation(lx, ly, nx, ny));
+      wave_sim->SetNumWaves(300);
+      wave_sim->SetMaxOmega(6.0);
       wave_sim->SetWindVelocity(10.0, 0.0);
       wave_sim->SetTime(5.0);
 
@@ -115,6 +119,8 @@ int main(int /*argc*/, const char **/*argv*/)
 
       std::unique_ptr<LinearRandomWaveSimulation> wave_sim(
           new LinearRandomWaveSimulation(lx, ly, lz, nx, ny, nz));
+      wave_sim->SetNumWaves(300);
+      wave_sim->SetMaxOmega(6.0);
       wave_sim->SetWindVelocity(10.0, 0.0);
       wave_sim->SetTime(5.0);
 

--- a/gz-waves/test/plots/PLOT_LinearRandomWaves.cc
+++ b/gz-waves/test/plots/PLOT_LinearRandomWaves.cc
@@ -1,0 +1,166 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+ #include <Eigen/Dense>
+
+#include <gnuplot-iostream.h>
+
+#include <gz/waves/WaveSimulation.hh>
+#include <gz/waves/LinearRandomWaveSimulation.hh>
+
+using namespace gz;
+using namespace waves;
+
+int main(int /*argc*/, const char **/*argv*/)
+{
+  try
+  {
+    std::cout << "PLOT_LinearRandomFFTWaves\n";
+
+    {
+      std::string s = "pkill gnuplot_qt";
+      std::system(s.c_str());
+    }
+
+    double lx = 256.0;
+    double ly = 256.0;
+    Index nx = 128;
+    Index ny = 128;
+
+    { // wave elevation vs time
+      std::unique_ptr<LinearRandomWaveSimulation> wave_sim(
+          new LinearRandomWaveSimulation(lx, ly, nx, ny));
+      wave_sim->SetWindVelocity(10.0, 0.0);
+      wave_sim->SetTime(5.0);
+      
+      double sample_time = 60.0;
+      std::vector<double> pts_t;
+      std::vector<double> pts_eta;
+      for (double t = 0.0; t < sample_time; t += 0.1)
+      {
+        double eta;
+        wave_sim->SetTime(t);
+        wave_sim->ElevationAt(0, 0, eta);
+
+        pts_t.push_back(t);
+        pts_eta.push_back(eta);
+      }
+      Gnuplot gp;
+      gp << "set term qt title 'Linear Random Wave Elevation at Origin'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'time (s)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << "plot '-' w l title 'eta'"
+         << "\n";
+      gp.send1d(std::make_tuple(pts_t, pts_eta));
+    }
+
+    { // wave elevation vs position
+      std::unique_ptr<LinearRandomWaveSimulation> wave_sim(
+          new LinearRandomWaveSimulation(lx, ly, nx, ny));
+      wave_sim->SetWindVelocity(10.0, 0.0);
+      wave_sim->SetTime(5.0);
+
+      Eigen::ArrayXXd h(nx * ny, 1);
+      wave_sim->ElevationAt(h);
+
+      std::vector<double> pts_x;
+      std::vector<double> pts_eta1;
+      std::vector<double> pts_eta2;
+      for (Index ix = 0; ix < nx; ++ix)
+      {
+        Index iy = ny / 2;
+        Index idx = iy * nx + ix;
+        double eta1 = 0.0;
+        double eta2 = h(idx, 0);
+        wave_sim->ElevationAt(ix, iy, eta1);
+
+        double x = -0.5 * lx + ix * lx / nx;
+        pts_x.push_back(x);
+        pts_eta1.push_back(eta1);
+        pts_eta2.push_back(eta2);
+      }
+      Gnuplot gp;
+      gp << "set term qt title 'Linear Random Wave Elevation'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'x (m)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << "plot '-' w l title 'eta1'"
+         << ",'-' w l title 'eta2'"
+         << "\n";
+      gp.send1d(std::make_tuple(pts_x, pts_eta1));
+      gp.send1d(std::make_tuple(pts_x, pts_eta2));
+    }
+
+    { // wave pressure vs position
+      Index nz = 10;
+      double lz = 50.0;
+
+      std::unique_ptr<LinearRandomWaveSimulation> wave_sim(
+          new LinearRandomWaveSimulation(lx, ly, lz, nx, ny, nz));
+      wave_sim->SetWindVelocity(10.0, 0.0);
+      wave_sim->SetTime(5.0);
+
+      std::vector<double> pts_x;
+      std::vector<std::vector<double>> pts_p(nz);
+      for (Index ix = 0; ix < nx; ++ix)
+      {
+        Index iy = ny / 2;
+        for (Index iz = 0; iz < nz; ++iz)
+        {
+          double p;
+          wave_sim->PressureAt(ix, iy, iz, p);
+          pts_p[iz].push_back(p);
+        }
+        double x = -0.5 * lx + ix * lx / nx;
+        pts_x.push_back(x);
+      }
+
+      // assume we always have at least one plot
+      std::string plot_str("plot '-' w l title 'p0'");
+      for (Index iz = 1; iz < nz; ++iz)
+      {
+        plot_str.append(",'-' w l title 'p")
+          .append(std::to_string(iz)).append("'");
+      }
+      plot_str.append("\n");
+
+      Gnuplot gp;
+      gp << "set term qt title 'Linear Random Wave Pressure'\n";
+      gp << "set grid\n";
+      gp << "set xlabel 'x (m)'\n";
+      gp << "set ylabel '(m)'\n";
+      gp << plot_str;
+
+      for (Index iz = 0; iz < nz; ++iz)
+      {
+        gp.send1d(std::make_tuple(pts_x, pts_p[iz]));
+      }
+    }
+
+  }
+  catch(...)
+  {
+    std::cerr << "Unknown exception\n";
+    return -1;
+  }
+  return 0;
+}
+


### PR DESCRIPTION
This PR adds a non-FFT variant of a linear random wave model for comparison and benchmarking.

Simulations for wave energy devices usually have some variant of a wave model comprised of a sum over linear waves with randomised phases. The sums are typically computed by simple loops over the components and the amplitudes are drawn from a suitable wave spectrum. While not efficient for simulating a wave field where samples must be taken at many points, the models is practical for simulating linear wave body interactions where the field is evaluated at the origin at each time step.

## Details

- Superposition of num_waves waves.
- Sampled at constant angular frequency: max_omega / num_waves.
- Amplitudes determined by the Pierson-Moskowitz spectrum.
- Wave direction may be set.
- Waves do not spread, all waves propagate in the same direction.
- Waves are assigned random phases.
- Plots of wave elevation and pressure. 

## Other

- Minor formatting changes to LinearRegularWaveSimulation for consistency.

## Usage

A limited set of parameters may be configured for the model and visual plugins.

```xml
<plugin
    filename="gz-waves1-waves-model-system"
    name="gz::sim::systems::WavesModel">
  <static>0</static>
  <update_rate>30</update_rate>
  <wave>
    <algorithm>linear_random</algorithm>
    <tile_size>256</tile_size>
    <cell_count>128</cell_count>
    <wind_speed>5.0</wind_speed>
    <wind_angle_deg>135</wind_angle_deg>
  </wave>
</plugin>
``` 

```xml
<plugin
    filename="gz-waves1-waves-visual-system"
    name="gz::sim::systems::WavesVisual">
  <static>0</static>
  <mesh_deformation_method>DYNAMIC_GEOMETRY</mesh_deformation_method>
  <tiles_x>-0 0</tiles_x>
  <tiles_y>-0 0</tiles_y>
  <wave>
    <algorithm>linear_random</algorithm>
    <tile_size>256</tile_size>
    <cell_count>128</cell_count>
    <wind_speed>5.0</wind_speed>
    <wind_angle_deg>135</wind_angle_deg>
  </wave>
</plugin>
```

### Future work

- Provide configuration for remaining parameters (num waves, frequency bounds, spectrum choice).
- Provide more comprehensive test suite - check realised elevation variance vs. expectation from spectrum. 
- Improve visuals (appears to be some lighting artefacts - possibly tangent space calc).
- Improve tiling - same issue as simple regular wave models - the tile skirt does not appear to be treated correctly.