### PR TITLE
Style: apply cpplint to headers and source in core lib

### DIFF
--- a/.github/workflows/ccplint.yml
+++ b/.github/workflows/ccplint.yml
@@ -1,0 +1,40 @@
+# GitHub Action to run cpplint recursively on all pushes and pull requests
+# https://github.com/cpplint/GitHub-Action-for-cpplint
+
+# The cpplint configuration file is:
+#
+#   ./CPPLINT.cfg
+#
+# Equivalent command line check:
+# 
+# 1. core library headers
+# 
+#   cpplint ./gz-waves/include/gz/waves/*.hh
+# 
+# 2. core library source
+# 
+#   cpplint ./gz-waves/src/*.cc ./gz-waves/src/*.hh
+# 
+
+name: Cpplint
+
+on: [push, pull_request]
+
+jobs:
+  cpplint:
+    runs-on: ubuntu-latest
+    name: Cpplint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install Cpplint
+        run: |
+          pip install cpplint
+      - name: Cpplint
+        run: |
+          cpplint ./gz-waves/include/gz/waves/*.hh
+          cpplint ./gz-waves/src/*.cc ./gz-waves/src/*.hh

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,4 @@
+set noparent
+filter=-whitespace/braces,-runtime/references,-build/c++11,+build/c++14,-build/include_subdir
+linelength=80
+root=gz-waves/include

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Ubuntu Jammy CI](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ubuntu-jammy-ci.yml/badge.svg)](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ubuntu-jammy-ci.yml)
 [![macOS Monterey CI](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/macos-monterey-ci.yml/badge.svg)](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/macos-monterey-ci.yml)
+[![Cpplint](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ccplint.yml/badge.svg)](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ccplint.yml)
 
 This package contains plugins that support the simulation of waves and surface vessels in [Gazebo](https://gazebosim.org/home).
 

--- a/gz-waves/include/gz/waves/Algorithm.hh
+++ b/gz-waves/include/gz/waves/Algorithm.hh
@@ -24,6 +24,8 @@
 #include <numeric>
 #include <vector>
 
+#include "gz/waves/Types.hh"
+
 namespace gz
 {
 namespace waves
@@ -46,15 +48,15 @@ namespace waves
     /// \param[in] _v   The array to be indexed.
     /// \return         A vector of indexes in to the input array.
     template <typename T>
-    std::vector<size_t> sort_indexes(const std::vector<T>& _v)
+    std::vector<Index> sort_indexes(const std::vector<T>& _v)
     {
       // initialize original index locations
-      std::vector<size_t> idx(_v.size());
+      std::vector<Index> idx(_v.size());
       std::iota(idx.begin(), idx.end(), 0);
 
       // sort indexes based on comparing values in _v
       std::sort(idx.begin(), idx.end(),
-          [&_v](size_t i1, size_t i2) {return _v[i1] > _v[i2];});
+          [&_v](Index i1, Index i2) {return _v[i1] > _v[i2];});
 
       return idx;
     }
@@ -65,15 +67,15 @@ namespace waves
     /// \param[in] _v   The array to be indexed.
     /// \return         An array of indexes in to the input array.
     template <typename T, std::size_t N>
-    std::array<size_t, N> sort_indexes(const std::array<T, N>& _v)
+    std::array<Index, N> sort_indexes(const std::array<T, N>& _v)
     {
       // initialize original index locations
-      std::array<size_t, N> idx;
+      std::array<Index, N> idx;
       std::iota(idx.begin(), idx.end(), 0);
 
       // sort indexes based on comparing values in _v
       std::sort(idx.begin(), idx.end(),
-          [&_v](size_t i1, size_t i2) {return _v[i1] > _v[i2];});
+          [&_v](Index i1, Index i2) {return _v[i1] > _v[i2];});
 
       return idx;
     }

--- a/gz-waves/include/gz/waves/Algorithm.hh
+++ b/gz-waves/include/gz/waves/Algorithm.hh
@@ -30,58 +30,57 @@ namespace gz
 {
 namespace waves
 {
-  /// \brief A small collection of static template methods for sorting arrays and vectors.
-  namespace algorithm
-  {
-    /// \brief Sort and keep track of indexes (largest first)
-    ///
-    /// See:
-    /// <https://stackoverflow.com/questions/1577475/c-sorting-and-keeping-track-of-indexes>
-    ///
-    /// Usage:
-    /// \code
-    /// for (auto i: sort_indexes(v)) {
-    ///   cout << v[i] << endl;
-    /// }
-    /// \endcode
-    ///
-    /// \param[in] _v   The array to be indexed.
-    /// \return         A vector of indexes in to the input array.
-    template <typename T>
-    std::vector<Index> sort_indexes(const std::vector<T>& _v)
-    {
-      // initialize original index locations
-      std::vector<Index> idx(_v.size());
-      std::iota(idx.begin(), idx.end(), 0);
+/// \brief Collection of static template methods for sorting arrays and vectors.
+namespace algorithm
+{
+/// \brief Sort and keep track of indexes (largest first)
+///
+/// See:
+/// <https://stackoverflow.com/questions/1577475/c-sorting-and-keeping-track-of-indexes>
+///
+/// Usage:
+/// \code
+/// for (auto i: sort_indexes(v)) {
+///   cout << v[i] << endl;
+/// }
+/// \endcode
+///
+/// \param[in] v   The array to be indexed.
+/// \return         A vector of indexes in to the input array.
+template <typename T>
+std::vector<Index> sort_indexes(const std::vector<T>& v)
+{
+  // initialize original index locations
+  std::vector<Index> idx(v.size());
+  std::iota(idx.begin(), idx.end(), 0);
 
-      // sort indexes based on comparing values in _v
-      std::sort(idx.begin(), idx.end(),
-          [&_v](Index i1, Index i2) {return _v[i1] > _v[i2];});
+  // sort indexes based on comparing values in v
+  std::sort(idx.begin(), idx.end(),
+      [&v](Index i1, Index i2) {return v[i1] > v[i2];});
 
-      return idx;
-    }
-
-    /// \brief Sort and keep track of indexes (largest first)
-    ///
-    /// This version is for sorting std::array<T, N>
-    /// \param[in] _v   The array to be indexed.
-    /// \return         An array of indexes in to the input array.
-    template <typename T, std::size_t N>
-    std::array<Index, N> sort_indexes(const std::array<T, N>& _v)
-    {
-      // initialize original index locations
-      std::array<Index, N> idx;
-      std::iota(idx.begin(), idx.end(), 0);
-
-      // sort indexes based on comparing values in _v
-      std::sort(idx.begin(), idx.end(),
-          [&_v](Index i1, Index i2) {return _v[i1] > _v[i2];});
-
-      return idx;
-    }
-
-  } 
-}
+  return idx;
 }
 
-#endif
+/// \brief Sort and keep track of indexes (largest first)
+///
+/// This version is for sorting std::array<T, N>
+/// \param[in] v    The array to be indexed.
+/// \return         An array of indexes in to the input array.
+template <typename T, std::size_t N>
+std::array<Index, N> sort_indexes(const std::array<T, N>& v) {
+  // initialize original index locations
+  std::array<Index, N> idx;
+  std::iota(idx.begin(), idx.end(), 0);
+
+  // sort indexes based on comparing values in v
+  std::sort(idx.begin(), idx.end(),
+      [&v](Index i1, Index i2) {return v[i1] > v[i2];});
+
+  return idx;
+}
+
+}  // namespace algorithm
+}  // namespace waves
+}  // namespace gz
+
+#endif  // GZ_WAVES_ALGORITHM_HH_

--- a/gz-waves/include/gz/waves/CGALTypes.hh
+++ b/gz-waves/include/gz/waves/CGALTypes.hh
@@ -31,34 +31,34 @@ namespace gz
 {
 namespace cgal
 {
-///////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////
 // CGAL Typedefs
 
-  // 2D/3D Linear Geometry
-  typedef CGAL::Simple_cartesian<double>  Kernel;
-  typedef Kernel::Direction_2             Direction2;
-  typedef Kernel::Direction_3             Direction3;
-  typedef Kernel::Point_3                 Point3;
-  typedef Kernel::Line_3                  Line;
-  typedef Kernel::Ray_3                   Ray;
-  typedef Kernel::Triangle_3              Triangle;
-  typedef Kernel::Vector_2                Vector2;
-  typedef Kernel::Vector_3                Vector3;
+// 2D/3D Linear Geometry
+typedef CGAL::Simple_cartesian<double>  Kernel;
+typedef Kernel::Direction_2             Direction2;
+typedef Kernel::Direction_3             Direction3;
+typedef Kernel::Point_3                 Point3;
+typedef Kernel::Line_3                  Line;
+typedef Kernel::Ray_3                   Ray;
+typedef Kernel::Triangle_3              Triangle;
+typedef Kernel::Vector_2                Vector2;
+typedef Kernel::Vector_3                Vector3;
 
-  // SurfaceMesh
-  typedef CGAL::Surface_mesh<Point3>      Mesh;
-  typedef Mesh::Face_index                FaceIndex;
-  typedef Mesh::Halfedge_index            HalfedgeIndex; 
-  typedef Mesh::Vertex_index              VertexIndex; 
+// SurfaceMesh
+typedef CGAL::Surface_mesh<Point3>      Mesh;
+typedef Mesh::Face_index                FaceIndex;
+typedef Mesh::Halfedge_index            HalfedgeIndex;
+typedef Mesh::Vertex_index              VertexIndex;
 
-  // AABB Tree
-  typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
-  typedef CGAL::AABB_traits<Kernel, Primitive> Traits;
-  typedef CGAL::AABB_tree<Traits> AABBTree;
+// AABB Tree
+typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
+typedef CGAL::AABB_traits<Kernel, Primitive> Traits;
+typedef CGAL::AABB_tree<Traits> AABBTree;
 
-  // Pointers
-  typedef std::shared_ptr<Mesh>           MeshPtr;
-}
-}
+// Pointers
+typedef std::shared_ptr<Mesh>           MeshPtr;
+}  // namespace cgal
+}  // namespace gz
 
-#endif
+#endif  // GZ_WAVES_CGALTYPES_HH_

--- a/gz-waves/include/gz/waves/Convert.hh
+++ b/gz-waves/include/gz/waves/Convert.hh
@@ -28,42 +28,37 @@ namespace gz
 {
 namespace waves
 {
+/// \brief Convert a CGAL Point3 to a gazebo Vector3d
+/// \param[in] point    The point to convert
+/// \return             The converted point
+gz::math::Vector3d ToGz(const cgal::Point3& point);
 
-///////////////////////////////////////////////////////////////////////////////
-// Conversions
+/// \brief Convert a CGAL Vector2 to a gazebo Vector2d
+/// \param[in] vector   The vector to convert
+/// \return             The converted vector
+gz::math::Vector2d ToGz(const cgal::Vector2& vector);
 
-  /// \brief Convert a CGAL Point3 to a gazebo Vector3d
-  /// \param[in] _point   The point to convert
-  /// \return             The converted point 
-  gz::math::Vector3d ToGz(const cgal::Point3& _point);
+/// \brief Convert a CGAL Vector3 to a gazebo Vector3d
+/// \param[in] vector   The vector to convert
+/// \return             The converted vector
+gz::math::Vector3d ToGz(const cgal::Vector3& vector);
 
-  /// \brief Convert a CGAL Vector2 to a gazebo Vector2d
-  /// \param[in] _vector  The vector to convert
-  /// \return             The converted vector 
-  gz::math::Vector2d ToGz(const cgal::Vector2& _vector);
+/// \brief Convert a gazebo Vector3d to a CGAL Point3
+/// \param[in] vector   The vector to convert
+/// \return             The converted point
+cgal::Point3 ToPoint3(const gz::math::Vector3d& vector);
 
-  /// \brief Convert a CGAL Vector3 to a gazebo Vector3d
-  /// \param[in] _vector  The vector to convert
-  /// \return             The converted vector 
-  gz::math::Vector3d ToGz(const cgal::Vector3& _vector);
+/// \brief Convert a gazebo Vector2d to a CGAL Vector2
+/// \param[in] vector   The vector to convert
+/// \return             The converted vector
+cgal::Vector2 ToVector2(const gz::math::Vector2d& vector);
 
-  /// \brief Convert a gazebo Vector3d to a CGAL Point3
-  /// \param[in] _vector  The vector to convert
-  /// \return             The converted point
-  cgal::Point3 ToPoint3(const gz::math::Vector3d& _vector);
+/// \brief Convert a gazebo Vector3d to a CGAL Vector3
+/// \param[in] vector   The vector to convert
+/// \return             The converted vector
+cgal::Vector3 ToVector3(const gz::math::Vector3d& vector);
 
-  /// \brief Convert a gazebo Vector2d to a CGAL Vector2
-  /// \param[in] _vector  The vector to convert
-  /// \return             The converted vector
-  cgal::Vector2 ToVector2(const gz::math::Vector2d& _vector);
+}  // namespace waves
+}  // namespace gz
 
-  /// \brief Convert a gazebo Vector3d to a CGAL Vector3
-  /// \param[in] _vector  The vector to convert
-  /// \return             The converted vector
-  cgal::Vector3 ToVector3(const gz::math::Vector3d& _vector);
-
-///////////////////////////////////////////////////////////////////////////////
-}
-} 
-
-#endif
+#endif  // GZ_WAVES_CONVERT_HH_

--- a/gz-waves/include/gz/waves/Geometry.hh
+++ b/gz-waves/include/gz/waves/Geometry.hh
@@ -14,242 +14,241 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /// \file Geometry.hh
-/// \brief This file contains methods to calculate properties of simple geometrical objects.
+/// \brief This file contains methods to calculate properties of simple
+///        geometrical objects.
 
 #ifndef GZ_WAVES_GEOMETRY_HH_
 #define GZ_WAVES_GEOMETRY_HH_
 
-#include "gz/waves/CGALTypes.hh"
-
 #include <array>
+#include <memory>
+
+#include "gz/waves/CGALTypes.hh"
 
 namespace gz
 {
 namespace waves
 {
-  class Grid;
+class Grid;
 
-///////////////////////////////////////////////////////////////////////////////
-// Geometry
+/// \brief A collection of static methods concerning linear geometry.
+class Geometry
+{
+ public:
+  /// \brief Calculate the area of a triangle.
+  ///
+  /// \param[in] _p0    Point at the first vertex.
+  /// \param[in] _p1    Point at the second vertex.
+  /// \param[in] _p2    Point at the third vertex.
+  /// \return           The triangle area
+  static double TriangleArea(
+    const cgal::Point3& _p0,
+    const cgal::Point3& _p1,
+    const cgal::Point3& _p2);
 
-  /// \brief A collection of static methods concerning linear geometry.
-  class Geometry
-  {
-    /// \brief Calculate the area of a triangle.
-    ///
-    /// \param[in] _p0    Point at the first vertex.
-    /// \param[in] _p1    Point at the second vertex.
-    /// \param[in] _p2    Point at the third vertex.
-    /// \return           The triangle area
-    public: static double TriangleArea(
-      const cgal::Point3& _p0,
-      const cgal::Point3& _p1,
-      const cgal::Point3& _p2
-    );
+  /// \brief Calculate the area of a triangle.
+  ///
+  /// \param[in] _tri   A triangle.
+  /// \return           The triangle area
+  static double TriangleArea(
+    const cgal::Triangle& _tri);
 
-    /// \brief Calculate the area of a triangle.
-    ///
-    /// \param[in] _tri   A triangle.
-    /// \return           The triangle area
-    public: static double TriangleArea(
-      const cgal::Triangle& _tri
-    );
+  /// \brief Calculate the centroid of a triangle.
+  ///
+  /// \param[in] _p0    Point at the first vertex.
+  /// \param[in] _p1    Point at the second vertex.
+  /// \param[in] _p2    Point at the third vertex.
+  /// \return           The triangle centroid
+  static cgal::Point3 TriangleCentroid(
+    const cgal::Point3& _p0,
+    const cgal::Point3& _p1,
+    const cgal::Point3& _p2);
 
-    /// \brief Calculate the centroid of a triangle.
-    ///
-    /// \param[in] _p0    Point at the first vertex.
-    /// \param[in] _p1    Point at the second vertex.
-    /// \param[in] _p2    Point at the third vertex.
-    /// \return           The triangle centroid
-    public: static cgal::Point3 TriangleCentroid(
-      const cgal::Point3& _p0,
-      const cgal::Point3& _p1,
-      const cgal::Point3& _p2
-    );
+  /// \brief Calculate the centroid of a triangle.
+  ///
+  /// \param[in] _tri   A triangle.
+  /// \return           The triangle centroid
+  static cgal::Point3 TriangleCentroid(
+    const cgal::Triangle& _tri);
 
-    /// \brief Calculate the centroid of a triangle.
-    ///
-    /// \param[in] _tri   A triangle.
-    /// \return           The triangle centroid
-    public: static cgal::Point3 TriangleCentroid(
-      const cgal::Triangle& _tri
-    );
+  /// \brief Find the mid-point of a line between points _p0 and _p1.
+  ///
+  /// \param[in] _p0    First point.
+  /// \param[in] _p1    Second point.
+  /// \return           The midpoint
+  static cgal::Point3 MidPoint(
+    const cgal::Point3& _p0,
+    const cgal::Point3& _p1);
 
-    /// \brief Find the mid-point of a line between points _p0 and _p1.
-    ///
-    /// \param[in] _p0    First point.
-    /// \param[in] _p1    Second point.
-    /// \return           The midpoint
-    public: static cgal::Point3 MidPoint(
-      const cgal::Point3& _p0,
-      const cgal::Point3& _p1
-    );
+  /// \brief Calculate the point on a line from the origin passing through _p
+  /// such that the vector from the origin to returned point has unit length.
+  ///
+  /// \param[in] _p     A point.
+  /// \return           The point that normalises the vector from
+  ///                   the origin to _p.
+  static cgal::Point3 Normalize(const cgal::Point3& _p);
 
-    /// \brief Calculate the point on a line from the origin passing through _p
-    /// such that the vector from the origin to returned point has unit length.
-    ///
-    /// \param[in] _p     A point.
-    /// \return           The point that normalises the vector from the origin to _p.
-    public: static cgal::Point3 Normalize(const cgal::Point3& _p);
+  /// \brief Normalise a Vector2 (i.e. ensure it has unit length)
+  ///
+  /// \param[in] _v     The vector to normalise.
+  /// \return           The normalized vector.
+  static cgal::Vector2 Normalize(const cgal::Vector2& _v);
 
-    /// \brief Normalise a Vector2 (i.e. ensure it has unit length)
-    ///
-    /// \param[in] _v     The vector to normalise.
-    /// \return           The normalized vector.
-    public: static cgal::Vector2 Normalize(const cgal::Vector2& _v);
+  /// \brief Normalise a Vector3 (i.e. ensure it has unit length)
+  ///
+  /// \param[in] _v     The vector to normalise.
+  /// \return           The normalized vector.
+  static cgal::Vector3 Normalize(const cgal::Vector3& _v);
 
-    /// \brief Normalise a Vector3 (i.e. ensure it has unit length)
-    ///
-    /// \param[in] _v     The vector to normalise.
-    /// \return           The normalized vector.
-    public: static cgal::Vector3 Normalize(const cgal::Vector3& _v);
+  /// \brief Compute the (normalised) normal to the plane defined
+  ///        by a triangle.
+  ///
+  /// \param[in] _p0    Point at the first vertex.
+  /// \param[in] _p1    Point at the second vertex.
+  /// \param[in] _p2    Point at the third vertex.
+  /// \return           The normal vector.
+  static cgal::Vector3 Normal(
+    const cgal::Point3& _v0,
+    const cgal::Point3& _v1,
+    const cgal::Point3& _v2);
 
-    /// \brief Compute the (normalised) normal to the plane defined by a triangle.
-    ///
-    /// \param[in] _p0    Point at the first vertex.
-    /// \param[in] _p1    Point at the second vertex.
-    /// \param[in] _p2    Point at the third vertex.
-    /// \return           The normal vector.
-    public: static cgal::Vector3 Normal(
-      const cgal::Point3& _v0,
-      const cgal::Point3& _v1,
-      const cgal::Point3& _v2
-    );
+  /// \brief Compute the (normalized) normal to the plane defined
+  ///        by a triangle.
+  ///
+  /// \param[in] _tri   A triangle.
+  /// \return           The normal vector.
+  static cgal::Vector3 Normal(
+    const cgal::Triangle& _tri);
 
-    /// \brief Compute the (normalized) normal to the plane defined by a triangle.
-    ///
-    /// \param[in] _tri   A triangle.
-    /// \return           The normal vector.
-    public: static cgal::Vector3 Normal(
-      const cgal::Triangle& _tri
-    );
+  /// \brief Compute the (normalized) normal to the plane defined
+  ///        by a triangle face.
+  ///
+  /// \param[in] _mesh  A surface mesh.
+  /// \param[in] _face  A face index for the surface mesh.
+  /// \return           The normal vector.
+  static cgal::Vector3 Normal(
+    const cgal::Mesh& _mesh,
+    cgal::FaceIndex _face);
 
-    /// \brief Compute the (normalized) normal to the plane defined by a triangle face.
-    ///
-    /// \param[in] _mesh  A surface mesh.
-    /// \param[in] _face  A face index for the surface mesh.
-    /// \return           The normal vector.
-    public: static cgal::Vector3 Normal(
-      const cgal::Mesh& _mesh,
-      cgal::FaceIndex _face
-    );
+  /// Given a triangle (_high, _mid, _low) with
+  /// _low.z() <= _mid.z() <= _high.z(), find the intercept of a line
+  /// from _mid, normal to z and the line between vertex _low and
+  /// vertex _mid.
+  ///
+  /// \param[in] _high  The point with greatest z-component _high.z().
+  /// \param[in] _mid   The point with z-component lying between _high.z()
+  ///                    and _low.z().
+  /// \param[in] _low   The point with least z-component _low.z().
+  /// \return           The intercept point.
+  static cgal::Point3 HorizontalIntercept(
+    const cgal::Point3& _high,
+    const cgal::Point3& _mid,
+    const cgal::Point3& _low);
 
-    /// Given a triangle (_high, _mid, _low) with _low.z() <= _mid.z() <= _high.z(), find the intercept of a line 
-    /// from _mid, normal to z and the line between vertex _low and vertex _mid.
-    ///
-    /// \param[in] _high  The point with greatest z-component _high.z().
-    /// \param[in] _mid   The point with z-component lying between _high.z() and _low.z().
-    /// \param[in] _low   The point with least z-component _low.z().
-    /// \return           The intercept point.
-    public: static cgal::Point3 HorizontalIntercept(
-      const cgal::Point3& _high,
-      const cgal::Point3& _mid,
-      const cgal::Point3& _low
-    );
+  /// \brief Fast Minimum Storage Ray-Triangle Interesection
+  /// <http://webserver2.tecgraf.puc-rio.br/~mgattass/cg/trbRR/Fast%20MinimumStorage%20RayTriangle%20Intersection.pdf>
+  ///
+  /// Möller–Trumbore intersection algorithm
+  /// <https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm>
+  ///
+  /// \param[in] _origin          The origin of the ray.
+  /// \param[in] _direction       The direction of the ray.
+  /// \param[in] _tri             A triangle.
+  /// \param[out] _intersection   The intersection point.
+  static bool RayIntersectsTriangle(
+    const cgal::Point3& _origin,
+    const cgal::Direction3& _direction,
+    const cgal::Triangle& _tri,
+    cgal::Point3& _intersection);
 
-    /// \brief Fast Minimum Storage Ray-Triangle Interesection
-    /// <http://webserver2.tecgraf.puc-rio.br/~mgattass/cg/trbRR/Fast%20MinimumStorage%20RayTriangle%20Intersection.pdf>
-    ///
-    /// Möller–Trumbore intersection algorithm
-    /// <https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm>
-    ///
-    /// \param[in] _origin          The origin of the ray.
-    /// \param[in] _direction       The direction of the ray.
-    /// \param[in] _tri             A triangle.
-    /// \param[out] _intersection   The intersection point.
-    public: static bool RayIntersectsTriangle(
-      const cgal::Point3& _origin,
-      const cgal::Direction3& _direction,
-      const cgal::Triangle& _tri,
-      cgal::Point3& _intersection
-    );
+  /// \brief Fast Minimum Storage Ray-Triangle Interesection
+  /// <http://webserver2.tecgraf.puc-rio.br/~mgattass/cg/trbRR/Fast%20MinimumStorage%20RayTriangle%20Intersection.pdf>
+  ///
+  /// Möller–Trumbore intersection algorithm
+  /// <https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm>
+  ///
+  /// The same algorithm as above, but omitting the last check for
+  /// the sign of t.
+  ///
+  /// \param[in] _origin          The origin of the ray.
+  /// \param[in] _direction       The direction of the ray.
+  /// \param[in] _tri             A triangle.
+  /// \param[out] _intersection   The intersection point.
+  static bool LineIntersectsTriangle(
+    const cgal::Point3& _origin,
+    const cgal::Direction3& _direction,
+    const cgal::Triangle& _tri,
+    cgal::Point3& _intersection);
 
-    /// \brief Fast Minimum Storage Ray-Triangle Interesection
-    /// <http://webserver2.tecgraf.puc-rio.br/~mgattass/cg/trbRR/Fast%20MinimumStorage%20RayTriangle%20Intersection.pdf>
-    ///
-    /// Möller–Trumbore intersection algorithm
-    /// <https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm>
-    ///
-    /// The same algorithm as above, but omitting the last check for the sign of t.
-    ///
-    /// \param[in] _origin          The origin of the ray.
-    /// \param[in] _direction       The direction of the ray.
-    /// \param[in] _tri             A triangle.
-    /// \param[out] _intersection   The intersection point.
-    public: static bool LineIntersectsTriangle(
-      const cgal::Point3& _origin,
-      const cgal::Direction3& _direction,
-      const cgal::Triangle& _tri,
-      cgal::Point3& _intersection
-    );
+  /// \brief Fast Minimum Storage Ray-Triangle Interesection
+  /// <http://webserver2.tecgraf.puc-rio.br/~mgattass/cg/trbRR/Fast%20MinimumStorage%20RayTriangle%20Intersection.pdf>
+  ///
+  /// Möller–Trumbore intersection algorithm
+  /// <https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm>
+  ///
+  /// The same algorithm as above, but using a triangle's points.
+  ///
+  /// \param[in] _origin          The origin of the ray.
+  /// \param[in] _direction       The direction of the ray.
+  /// \param[in] _p0              Point at the first vertex.
+  /// \param[in] _p1              Point at the second vertex.
+  /// \param[in] _p2              Point at the third vertex.
+  /// \param[out] _intersection   The intersection point.
+  static bool LineIntersectsTriangle(
+    const cgal::Point3& _origin,
+    const cgal::Direction3& _direction,
+    const cgal::Point3& _p0,
+    const cgal::Point3& _p1,
+    const cgal::Point3& _p2,
+    cgal::Point3& _intersection);
 
-    /// \brief Fast Minimum Storage Ray-Triangle Interesection
-    /// <http://webserver2.tecgraf.puc-rio.br/~mgattass/cg/trbRR/Fast%20MinimumStorage%20RayTriangle%20Intersection.pdf>
-    ///
-    /// Möller–Trumbore intersection algorithm
-    /// <https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm>
-    ///
-    /// The same algorithm as above, but using a triangle's points.
-    ///
-    /// \param[in] _origin          The origin of the ray.
-    /// \param[in] _direction       The direction of the ray.
-    /// \param[in] _p0              Point at the first vertex.
-    /// \param[in] _p1              Point at the second vertex.
-    /// \param[in] _p2              Point at the third vertex.
-    /// \param[out] _intersection   The intersection point.
-    public: static bool LineIntersectsTriangle(
-      const cgal::Point3& _origin,
-      const cgal::Direction3& _direction,
-      const cgal::Point3& _p0,
-      const cgal::Point3& _p1,
-      const cgal::Point3& _p2,
-      cgal::Point3& _intersection
-    );
+  /// \brief Utility to make a triangle given a mesh and face index.
+  ///
+  /// \param[in] _mesh    A surface mesh.
+  /// \param[in] _face    A face index for the surface mesh.
+  /// \return             A triangle.
+  static cgal::Triangle MakeTriangle(const cgal::Mesh& _mesh,
+      cgal::FaceIndex _face);
 
-    /// \brief Utility to make a triangle given a mesh and face index.
-    ///
-    /// \param[in] _mesh    A surface mesh.
-    /// \param[in] _face    A face index for the surface mesh.
-    /// \return             A triangle.
-    public: static cgal::Triangle MakeTriangle(const cgal::Mesh& _mesh, cgal::FaceIndex _face);
+  /// \brief Create an AABB tree for the input mesh.
+  ///
+  /// \param[in] _mesh            The mesh to search.
+  /// \return                     The built AABB tree.
+  static std::shared_ptr<cgal::AABBTree> MakeAABBTree(
+      const cgal::Mesh& _mesh);
 
-    /// \brief Create an AABB tree for the input mesh.
-    ///
-    /// \param[in] _mesh            The mesh to search.
-    /// \return                     The built AABB tree.
-    public: static std::shared_ptr<cgal::AABBTree> MakeAABBTree(const cgal::Mesh& _mesh);
+  /// \brief Search a mesh for an intersection with the line defined by
+  ///        origin and direction.
+  /// NOTE: This version is slow because it builds a AABB tree for each query.
+  ///
+  /// \param[in] _mesh            The mesh to search.
+  /// \param[in] _origin          The origin of the line.
+  /// \param[in] _direction       The direction of the line (both directions
+  ///                             are searched).
+  /// \param[out] _intersection   The intersection point if found.
+  static bool SearchMesh(
+    const cgal::Mesh& _mesh,
+    const cgal::Point3& _origin,
+    const cgal::Direction3& _direction,
+    cgal::Point3& _intersection);
 
-    /// \brief Search a mesh for an intersection with the line defined by origin and direction.
-    /// NOTE: This version is slow because it builds a AABB tree for each query.
-    ///
-    /// \param[in] _mesh            The mesh to search.
-    /// \param[in] _origin          The origin of the line.
-    /// \param[in] _direction       The direction of the line (both directions are searched).
-    /// \param[out] _intersection   The intersection point if found.
-    public: static bool SearchMesh(
-      const cgal::Mesh& _mesh,
-      const cgal::Point3& _origin,
-      const cgal::Direction3& _direction,
-      cgal::Point3& _intersection
-    );
-  
-    /// \brief Search a mesh for an intersection with the line defined by origin and direction.
-    /// NOTE: This version is fast because it uses a pre-built AABB tree.
-    ///
-    /// \param[in] _tree            The AABB tree for the mesh being searched.
-    /// \param[in] _origin          The origin of the line.
-    /// \param[in] _direction       The direction of the line (both directions are searched).
-    /// \param[out] _intersection   The intersection point if found.
-    public: static bool SearchMesh(
-      const cgal::AABBTree& _tree,
-      const cgal::Point3& _origin,
-      const cgal::Direction3& _direction,
-      cgal::Point3& _intersection
-    );
+  /// \brief Search a mesh for an intersection with the line defined by
+  ///       origin and direction.
+  /// NOTE: This version is fast because it uses a pre-built AABB tree.
+  ///
+  /// \param[in] _tree            The AABB tree for the mesh being searched.
+  /// \param[in] _origin          The origin of the line.
+  /// \param[in] _direction       The direction of the line (both directions
+  ///                             are searched).
+  /// \param[out] _intersection   The intersection point if found.
+  static bool SearchMesh(
+    const cgal::AABBTree& _tree,
+    const cgal::Point3& _origin,
+    const cgal::Direction3& _direction,
+    cgal::Point3& _intersection);
+};
 
-  };
+}  // namespace waves
+}  // namespace gz
 
-}
-}
-
-#endif
+#endif  // GZ_WAVES_GEOMETRY_HH_

--- a/gz-waves/include/gz/waves/Grid.hh
+++ b/gz-waves/include/gz/waves/Grid.hh
@@ -21,6 +21,7 @@
 #define GZ_WAVES_GRID_HH_
 
 #include "gz/waves/CGALTypes.hh"
+#include "gz/waves/Types.hh"
 
 #include <array>
 #include <memory>
@@ -46,7 +47,7 @@ namespace waves
     /// \param[in] _cellCount   The number of cells in each direction.
     public: Grid(
       const std::array<double, 2>& _size,
-      const std::array<size_t, 2>& _cellCount
+      const std::array<Index, 2>& _cellCount
     );
 
     /// \brief Copy constructor. Performs a deep copy.
@@ -83,28 +84,28 @@ namespace waves
     /// \brief Get the number of cells the partioning the grid.
     ///
     /// \return             An array containing the number of grid cells.
-    public: const std::array<size_t, 2>& GetCellCount() const;
+    public: const std::array<Index, 2>& GetCellCount() const;
 
     /// \brief Get the number of vertices (and points).
     ///
     /// \return             The number of grid vertices.
-    public: size_t GetVertexCount() const;
+    public: Index GetVertexCount() const;
 
     /// \brief Get the number of faces (and triangles, normals).
     ///
     /// \return             The number of grid faces (triangles).
-    public: size_t GetFaceCount() const;
+    public: Index GetFaceCount() const;
 
     /// \brief Get the _i-th point.
     ///
     /// \return             A point.
-    public: const cgal::Point3& GetPoint(size_t _i) const;
+    public: const cgal::Point3& GetPoint(Index _i) const;
 
     /// \brief Set the _i-th point. 
     ///
     /// \param[in] _i       Index to the i-th point. Must be less than GetVertexCount().
     /// \param[in] _point   The point to set.
-    public: void SetPoint(size_t _i, const cgal::Point3& _point);
+    public: void SetPoint(Index _i, const cgal::Point3& _point);
 
     /// \brief Get the _k-th Triangle in cell(_ix, _iy), _k = 0, 1. 
     ///
@@ -112,7 +113,7 @@ namespace waves
     /// \param[in] _iy      Index to the iy-th grid cell.
     /// \param[in] _k       Index to the k-th face in cell (ix, iy).
     /// \return             A triangle.
-    public: cgal::Triangle GetTriangle(size_t _ix, size_t _iy, size_t _k) const;
+    public: cgal::Triangle GetTriangle(Index _ix, Index _iy, Index _k) const;
 
     /// \brief Get the _k-th Face (triangle) in cell(_ix, _iy), _k = 0, 1. 
     ///
@@ -120,7 +121,7 @@ namespace waves
     /// \param[in] _iy      Index to the iy-th grid cell.
     /// \param[in] _k       Index to the k-th face in cell (ix, iy).
     /// \return             A face index.
-    public: cgal::FaceIndex GetFace(size_t _ix, size_t _iy, size_t _k) const;
+    public: cgal::FaceIndex GetFace(Index _ix, Index _iy, Index _k) const;
 
     /// \brief Get the _k-th Triangle normal in cell(_ix, _iy), _k = 0, 1. 
     ///
@@ -128,13 +129,13 @@ namespace waves
     /// \param[in] _iy      Index to the iy-th grid cell.
     /// \param[in] _k       Index to the k-th face in cell (ix, iy).
     /// \return             The face normal vector.
-    public: const cgal::Vector3& GetNormal(size_t _ix, size_t _iy, size_t _k) const;
+    public: const cgal::Vector3& GetNormal(Index _ix, Index _iy, Index _k) const;
 
     /// \brief Get the Triangle normal in face _idx (face indexing).
     ///
     /// \param[in] _idx     A face index.
     /// \return             The face normal vector.
-    public: const cgal::Vector3& GetNormal(size_t _idx) const;
+    public: const cgal::Vector3& GetNormal(Index _idx) const;
 
     /// \brief Recalculate the normals. 
     public: void RecalculateNormals();
@@ -173,7 +174,7 @@ namespace waves
     public: static bool FindIntersectionIndex(
       const Grid& _grid,
       double _x, double _y,
-      std::array<size_t, 3>& _index
+      std::array<Index, 3>& _index
     );
 
     /// \brief Search one triangle for an intersection with the line defined by origin and direction. 
@@ -188,7 +189,7 @@ namespace waves
       const Grid& _grid,
       const cgal::Point3& _origin,
       const cgal::Direction3& _direction,
-      const std::array<size_t, 3>& _index,
+      const std::array<Index, 3>& _index,
       cgal::Point3& _intersection
     );
 
@@ -205,7 +206,7 @@ namespace waves
       const Grid& _grid,
       const cgal::Point3& _origin,
       const cgal::Direction3& _direction,
-      std::array<size_t, 3>& _index,
+      std::array<Index, 3>& _index,
       cgal::Point3& _intersection
     );
 
@@ -224,7 +225,7 @@ namespace waves
       const Grid& _grid,
       const cgal::Point3& _origin,
       const cgal::Direction3& _direction,
-      std::array<size_t, 3>& _index,
+      std::array<Index, 3>& _index,
       cgal::Point3& _intersection
     );
   };

--- a/gz-waves/include/gz/waves/Grid.hh
+++ b/gz-waves/include/gz/waves/Grid.hh
@@ -14,225 +14,225 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /// \file Grid.hh
-/// \brief This file contains classes to construct planar meshes and to 
+/// \brief This file contains classes to construct planar meshes and to
 /// find line intersections with them.
 
 #ifndef GZ_WAVES_GRID_HH_
 #define GZ_WAVES_GRID_HH_
 
-#include "gz/waves/CGALTypes.hh"
-#include "gz/waves/Types.hh"
-
 #include <array>
 #include <memory>
+
+#include "gz/waves/CGALTypes.hh"
+#include "gz/waves/Types.hh"
 
 namespace gz
 {
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////
-// Grid
+//////////////////////////////////////////////////
+/// \internal Class to hold private data for Grid.
+class GridPrivate;
 
-  /// \internal
-  /// \brief Class to hold private data for Grid.
-  class GridPrivate;
+/// \brief An accessing / partitioning scheme for a planar SurfaceMesh.
+class Grid
+{
+ public:
+  /// \brief Constructor. Initialise the SurfaceMesh comprising the grid.
+  ///
+  /// \param[in] _size        The size of the grid in the x, y directions.
+  /// \param[in] _cellCount   The number of cells in each direction.
+  Grid(
+    const std::array<double, 2>& _size,
+    const std::array<Index, 2>& _cellCount);
 
-  /// \brief An accessing / partitioning scheme for a planar SurfaceMesh.
-  class Grid
-  {
-    /// \brief Constructor. Initialise the SurfaceMesh comprising the grid.
-    ///
-    /// \param[in] _size        The size of the grid in the x, y directions.
-    /// \param[in] _cellCount   The number of cells in each direction.
-    public: Grid(
-      const std::array<double, 2>& _size,
-      const std::array<Index, 2>& _cellCount
-    );
+  /// \brief Copy constructor. Performs a deep copy.
+  ///
+  /// \param[in] _other   The source grid to copy.
+  Grid(const Grid& _other);
 
-    /// \brief Copy constructor. Performs a deep copy.
-    ///
-    /// \param[in] _other   The source grid to copy.
-    public: Grid(const Grid& _other);
+  /// \brief Copy assignment. Performs a deep copy.
+  ///
+  /// \param[in] _other   The source grid to copy.
+  /// \return             A reference to this, the copy.
+  Grid& operator=(const Grid& _other);
 
-    /// \brief Copy assignment. Performs a deep copy.
-    ///
-    /// \param[in] _other   The source grid to copy.
-    /// \return             A reference to this, the copy. 
-    public: Grid& operator=(const Grid& _other);
+  /// \brief Get the CGAL SurfaceMesh comprising the grid.
+  ///
+  /// \return             A pointer to the mesh.
+  std::shared_ptr<const cgal::Mesh> GetMesh() const;
 
-    /// \brief Get the CGAL SurfaceMesh comprising the grid.
-    ///
-    /// \return             A pointer to the mesh.
-    public: std::shared_ptr<const cgal::Mesh> GetMesh() const;
+  /// \brief Get the CGAL SurfaceMesh comprising the grid (mutable).
+  ///
+  /// \return             A mutable pointer to the mesh.
+  std::shared_ptr<cgal::Mesh> GetMesh();
 
-    /// \brief Get the CGAL SurfaceMesh comprising the grid (mutable).
-    ///
-    /// \return             A mutable pointer to the mesh.
-    public: std::shared_ptr<cgal::Mesh> GetMesh();
+  /// \brief Get the CGAL SurfaceMesh comprising the grid.
+  ///
+  /// \return             An immutable reference to the mesh.
+  const cgal::Mesh& GetMeshByRef() const;
 
-    /// \brief Get the CGAL SurfaceMesh comprising the grid.
-    ///
-    /// \return             An immutable reference to the mesh.
-    public: const cgal::Mesh& GetMeshByRef() const;
+  /// \brief Get the size of the grid in each direction.
+  ///
+  /// \return             An array containing the grid size.
+  const std::array<double, 2>& GetSize() const;
 
-    /// \brief Get the size of the grid in each direction.
-    ///
-    /// \return             An array containing the grid size.
-    public: const std::array<double, 2>& GetSize() const;
+  /// \brief Get the number of cells the partioning the grid.
+  ///
+  /// \return             An array containing the number of grid cells.
+  const std::array<Index, 2>& GetCellCount() const;
 
-    /// \brief Get the number of cells the partioning the grid.
-    ///
-    /// \return             An array containing the number of grid cells.
-    public: const std::array<Index, 2>& GetCellCount() const;
+  /// \brief Get the number of vertices (and points).
+  ///
+  /// \return             The number of grid vertices.
+  Index GetVertexCount() const;
 
-    /// \brief Get the number of vertices (and points).
-    ///
-    /// \return             The number of grid vertices.
-    public: Index GetVertexCount() const;
+  /// \brief Get the number of faces (and triangles, normals).
+  ///
+  /// \return             The number of grid faces (triangles).
+  Index GetFaceCount() const;
 
-    /// \brief Get the number of faces (and triangles, normals).
-    ///
-    /// \return             The number of grid faces (triangles).
-    public: Index GetFaceCount() const;
+  /// \brief Get the _i-th point.
+  ///
+  /// \return             A point.
+  const cgal::Point3& GetPoint(Index _i) const;
 
-    /// \brief Get the _i-th point.
-    ///
-    /// \return             A point.
-    public: const cgal::Point3& GetPoint(Index _i) const;
+  /// \brief Set the _i-th point.
+  ///
+  /// \param[in] _i       Index to the i-th point. Must be less than
+  ///                     GetVertexCount().
+  /// \param[in] _point   The point to set.
+  void SetPoint(Index _i, const cgal::Point3& _point);
 
-    /// \brief Set the _i-th point. 
-    ///
-    /// \param[in] _i       Index to the i-th point. Must be less than GetVertexCount().
-    /// \param[in] _point   The point to set.
-    public: void SetPoint(Index _i, const cgal::Point3& _point);
+  /// \brief Get the _k-th Triangle in cell(_ix, _iy), _k = 0, 1.
+  ///
+  /// \param[in] _ix      Index to the ix-th grid cell.
+  /// \param[in] _iy      Index to the iy-th grid cell.
+  /// \param[in] _k       Index to the k-th face in cell (ix, iy).
+  /// \return             A triangle.
+  cgal::Triangle GetTriangle(Index _ix, Index _iy, Index _k) const;
 
-    /// \brief Get the _k-th Triangle in cell(_ix, _iy), _k = 0, 1. 
-    ///
-    /// \param[in] _ix      Index to the ix-th grid cell.
-    /// \param[in] _iy      Index to the iy-th grid cell.
-    /// \param[in] _k       Index to the k-th face in cell (ix, iy).
-    /// \return             A triangle.
-    public: cgal::Triangle GetTriangle(Index _ix, Index _iy, Index _k) const;
+  /// \brief Get the _k-th Face (triangle) in cell(_ix, _iy), _k = 0, 1.
+  ///
+  /// \param[in] _ix      Index to the ix-th grid cell.
+  /// \param[in] _iy      Index to the iy-th grid cell.
+  /// \param[in] _k       Index to the k-th face in cell (ix, iy).
+  /// \return             A face index.
+  cgal::FaceIndex GetFace(Index _ix, Index _iy, Index _k) const;
 
-    /// \brief Get the _k-th Face (triangle) in cell(_ix, _iy), _k = 0, 1. 
-    ///
-    /// \param[in] _ix      Index to the ix-th grid cell.
-    /// \param[in] _iy      Index to the iy-th grid cell.
-    /// \param[in] _k       Index to the k-th face in cell (ix, iy).
-    /// \return             A face index.
-    public: cgal::FaceIndex GetFace(Index _ix, Index _iy, Index _k) const;
+  /// \brief Get the _k-th Triangle normal in cell(_ix, _iy), _k = 0, 1.
+  ///
+  /// \param[in] _ix      Index to the ix-th grid cell.
+  /// \param[in] _iy      Index to the iy-th grid cell.
+  /// \param[in] _k       Index to the k-th face in cell (ix, iy).
+  /// \return             The face normal vector.
+  const cgal::Vector3& GetNormal(Index _ix, Index _iy, Index _k) const;
 
-    /// \brief Get the _k-th Triangle normal in cell(_ix, _iy), _k = 0, 1. 
-    ///
-    /// \param[in] _ix      Index to the ix-th grid cell.
-    /// \param[in] _iy      Index to the iy-th grid cell.
-    /// \param[in] _k       Index to the k-th face in cell (ix, iy).
-    /// \return             The face normal vector.
-    public: const cgal::Vector3& GetNormal(Index _ix, Index _iy, Index _k) const;
+  /// \brief Get the Triangle normal in face _idx (face indexing).
+  ///
+  /// \param[in] _idx     A face index.
+  /// \return             The face normal vector.
+  const cgal::Vector3& GetNormal(Index _idx) const;
 
-    /// \brief Get the Triangle normal in face _idx (face indexing).
-    ///
-    /// \param[in] _idx     A face index.
-    /// \return             The face normal vector.
-    public: const cgal::Vector3& GetNormal(Index _idx) const;
+  /// \brief Recalculate the normals.
+  void RecalculateNormals();
 
-    /// \brief Recalculate the normals. 
-    public: void RecalculateNormals();
+  /// \brief Get the position of the grid center.
+  const cgal::Point3& GetCenter() const;
 
-    /// \brief Get the position of the grid center.
-    public: const cgal::Point3& GetCenter() const;
+  /// \brief Set the position of the grid center.
+  ///
+  /// \param[in] _center  Set the location of the center
+  ///                     of the grid (xy-plane only).
+  void SetCenter(const cgal::Point3& _center);
 
-    /// \brief Set the position of the grid center.
-    ///
-    /// \param[in] _center  Set the location of the center of the grid (xy-plane only).
-    public: void SetCenter(const cgal::Point3& _center);
+  /// \brief Output the grid properties to std::cout.
+  ///
+  void DebugPrint() const;
 
-    /// \brief Output the grid properties to std::cout.
-    ///
-    public: void DebugPrint() const;
+ private:
+  /// \internal Private implementation.
+  std::shared_ptr<GridPrivate> data;
+};
 
-    /// \internal
-    /// \brief Pointer to the class private data.
-    private: std::shared_ptr<GridPrivate> data;
-  };
+//////////////////////////////////////////////////
+/// \brief A collection of methods for finding line intersections with a Grid.
+class GridTools
+{
+ public:
+  /// \brief Find the index of a grid cell and triangle that contains the
+  /// coordinate (_x, _y)
+  ///
+  /// \param[in] _grid          The grid to search.
+  /// \param[in] _x             The x coordinate.
+  /// \param[in] _y             The y coordinate.
+  /// \param[out] _index        The grid cell and face index (ix, iy, k).
+  /// \return                   True if an intersection is found.
+  static bool FindIntersectionIndex(
+    const Grid& _grid,
+    double _x, double _y,
+    std::array<Index, 3>& _index);
 
-///////////////////////////////////////////////////////////////////////////////
-// GridTools
+  /// \brief Search one triangle for an intersection with the line
+  ///        defined by origin and direction.
+  ///
+  /// \param[in] _grid          The grid to search.
+  /// \param[in] _origin        The origin of the line.
+  /// \param[in] _direction     The direction of the line.
+  /// \param[in] _index         The grid cell and face/triangle
+  ///                           index (ix, iy, k).
+  /// \param[out] _intersection The intersection point if found.
+  /// \return                   True if an intersection is found.
+  static bool FindIntersectionTriangle(
+    const Grid& _grid,
+    const cgal::Point3& _origin,
+    const cgal::Direction3& _direction,
+    const std::array<Index, 3>& _index,
+    cgal::Point3& _intersection);
 
-  /// \brief A collection of static methods for finding line intersections with a Grid
-  class GridTools
-  {
-    /// \brief Find the index of a grid cell and triangle that contains the
-    /// coordinate (_x, _y)
-    ///
-    /// \param[in] _grid          The grid to search.
-    /// \param[in] _x             The x coordinate.
-    /// \param[in] _y             The y coordinate.
-    /// \param[out] _index        The grid cell and face index (ix, iy, k).
-    /// \return                   True if an intersection is found.
-    public: static bool FindIntersectionIndex(
-      const Grid& _grid,
-      double _x, double _y,
-      std::array<Index, 3>& _index
-    );
+  /// \brief Search the two triangles in a cell for an intersection with
+  ///        the line defined by origin and direction.
+  ///
+  /// \param[in] _grid          The grid to search.
+  /// \param[in] _origin        The origin of the line.
+  /// \param[in] _direction     The direction of the line.
+  /// \param[in, out] _index    [in] The initial (ix, iy, k) indices of
+  ///                           the cell,
+  ///                           [out] The index of the face where the
+  ///                           intersection occurred.
+  /// \param[out] _intersection The intersection point if found.
+  /// \return                   True if an intersection is found.
+  static bool FindIntersectionCell(
+    const Grid& _grid,
+    const cgal::Point3& _origin,
+    const cgal::Direction3& _direction,
+    std::array<Index, 3>& _index,
+    cgal::Point3& _intersection);
 
-    /// \brief Search one triangle for an intersection with the line defined by origin and direction. 
-    ///
-    /// \param[in] _grid          The grid to search.
-    /// \param[in] _origin        The origin of the line.
-    /// \param[in] _direction     The direction of the line.
-    /// \param[in] _index         The grid cell and face/triangle index (ix, iy, k).
-    /// \param[out] _intersection The intersection point if found.
-    /// \return                   True if an intersection is found.
-    public: static bool FindIntersectionTriangle(
-      const Grid& _grid,
-      const cgal::Point3& _origin,
-      const cgal::Direction3& _direction,
-      const std::array<Index, 3>& _index,
-      cgal::Point3& _intersection
-    );
+  /// Search a grid for an intersection with the line defined by origin
+  /// and direction. The search starts with a initial guess cell, then
+  /// expands in shells one cell wide about the initial cell
+  /// (adjusted for boundaries).
+  //
+  /// \param[in] _grid          The grid to search.
+  /// \param[in] _origin        The origin of the line.
+  /// \param[in] _direction     The direction of the line.
+  /// \param[in, out] _index    [in] The initial (ix, iy, k) indices
+  ///                           of the cell,
+  ///                           [out] The index of the face where the
+  ///                           intersection occurred.
+  /// \param[out] _intersection The intersection point if found.
+  /// \return                   True if an intersection is found.
+  static bool FindIntersectionGrid(
+    const Grid& _grid,
+    const cgal::Point3& _origin,
+    const cgal::Direction3& _direction,
+    std::array<Index, 3>& _index,
+    cgal::Point3& _intersection);
+};
 
-    /// \brief Search the two triangles in a cell for an intersection with the line defined by origin and direction. 
-    ///
-    /// \param[in] _grid          The grid to search.
-    /// \param[in] _origin        The origin of the line.
-    /// \param[in] _direction     The direction of the line.
-    /// \param[in, out] _index    [in] The initial (ix, iy, k) indices of the cell,
-    ///                           [out] The index of the face where the intersection occurred.
-    /// \param[out] _intersection The intersection point if found.
-    /// \return                   True if an intersection is found.
-    public: static bool FindIntersectionCell(
-      const Grid& _grid,
-      const cgal::Point3& _origin,
-      const cgal::Direction3& _direction,
-      std::array<Index, 3>& _index,
-      cgal::Point3& _intersection
-    );
+}  // namespace waves
+}  // namespace gz
 
-    /// Search a grid for an intersection with the line defined by origin and direction.
-    /// The search starts with a initial guess cell, then expands in expanding shells
-    /// one cell wide about the initial cell (adjusted for boundaries).  
-    //
-    /// \param[in] _grid          The grid to search.
-    /// \param[in] _origin        The origin of the line.
-    /// \param[in] _direction     The direction of the line.
-    /// \param[in, out] _index    [in] The initial (ix, iy, k) indices of the cell,
-    ///                           [out] The index of the face where the intersection occurred.
-    /// \param[out] _intersection The intersection point if found.
-    /// \return                   True if an intersection is found.
-    public: static bool FindIntersectionGrid(
-      const Grid& _grid,
-      const cgal::Point3& _origin,
-      const cgal::Direction3& _direction,
-      std::array<Index, 3>& _index,
-      cgal::Point3& _intersection
-    );
-  };
-
-///////////////////////////////////////////////////////////////////////////////
-
-}
-}
-
-#endif
+#endif  // GZ_WAVES_GRID_HH_

--- a/gz-waves/include/gz/waves/LinearRandomFFTWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomFFTWaveSimulation.hh
@@ -18,7 +18,9 @@
 
 #include <memory>
 
-#include "WaveSimulation.hh"
+#include <Eigen/Dense> // NOLINT - cpplint false positive.
+
+#include "gz/waves/WaveSimulation.hh"
 
 using Eigen::ArrayXXd;
 
@@ -26,104 +28,105 @@ namespace gz
 {
 namespace waves
 {
-  class LinearRandomFFTWaveSimulation :
-      public IWaveSimulation
-  {
-  public:
-    virtual ~LinearRandomFFTWaveSimulation();
+class LinearRandomFFTWaveSimulation :
+    public IWaveSimulation
+{
+ public:
+  virtual ~LinearRandomFFTWaveSimulation();
 
-    LinearRandomFFTWaveSimulation(double lx, double ly,
-        Index nx, Index ny);
+  LinearRandomFFTWaveSimulation(double lx, double ly,
+      Index nx, Index ny);
 
-    LinearRandomFFTWaveSimulation(double lx, double ly, double lz,
-        Index nx, Index ny, Index nz);
+  LinearRandomFFTWaveSimulation(double lx, double ly, double lz,
+      Index nx, Index ny, Index nz);
 
-    /// \brief Set lambda which controls the horizontal wave displacement.
-    void SetLambda(double lambda);
+  /// \brief Set lambda which controls the horizontal wave displacement.
+  void SetLambda(double lambda);
 
-    virtual void SetWindVelocity(double ux, double uy) override;
+  void SetWindVelocity(double ux, double uy) override;
 
-    virtual void SetTime(double value) override;
+  void SetTime(double value) override;
 
-    virtual Index SizeX() const override;
+  Index SizeX() const override;
 
-    virtual Index SizeY() const override;
+  Index SizeY() const override;
 
-    virtual Index SizeZ() const override;
+  Index SizeZ() const override;
 
-    // IWaveField - interface not supported for FFT.
-    #if 0
-    virtual void Elevation(
-        double x, double y,
-        double &eta) override;
+  // IWaveField - interface not supported for FFT.
+  #if 0
+  void Elevation(
+      double x, double y,
+      double& eta) override;
 
-    virtual void Elevation(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        Eigen::Ref<Eigen::ArrayXd> eta) override;
+  void Elevation(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      Eigen::Ref<Eigen::ArrayXd> eta) override;
 
-    virtual void Pressure(
-        double x, double y, double z,
-        double &pressure) override;
+  void Pressure(
+      double x, double y, double z,
+      double& pressure) override;
 
-    virtual void Pressure(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        const Eigen::Ref<const Eigen::ArrayXd> &z,
-        Eigen::Ref<Eigen::ArrayXd> pressure) override;
-    #endif
+  void Pressure(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      const Eigen::Ref<const Eigen::ArrayXd>& z,
+      Eigen::Ref<Eigen::ArrayXd> pressure) override;
+  #endif
 
-    // lookup interface - array
-    virtual void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> h) override;
+  // lookup interface - array
+  void ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h) override;
 
-    virtual void ElevationDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+  void ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
 
-    virtual void DisplacementAt(
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy) override;
+  void DisplacementAt(
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy) override;
 
-    virtual void DisplacementDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+  void DisplacementDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-    virtual void DisplacementAndDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> h,
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy,
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+  void DisplacementAndDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> h,
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy,
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-    virtual void PressureAt(
-        Index iz,
-        Eigen::Ref<Eigen::ArrayXXd> pressure) override;
+  void PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure) override;
 
-    // lookup interface - scalar
-    virtual void ElevationAt(
-        Index ix, Index iy,
-        double &eta) override;
+  // lookup interface - scalar
+  void ElevationAt(
+      Index ix, Index iy,
+      double& eta) override;
 
-    virtual void DisplacementAt(
-        Index ix, Index iy,
-        double &sx, double &sy) override;
+  void DisplacementAt(
+      Index ix, Index iy,
+      double& sx, double& sy) override;
 
-    virtual void PressureAt(
-        Index ix, Index iy, Index iz,
-        double &pressure) override;
+  void PressureAt(
+      Index ix, Index iy, Index iz,
+      double& pressure) override;
 
-    // public class declaration - for testing
-    class Impl;
+  // public class declaration - for testing
+  class Impl;
 
-  private:
-    std::unique_ptr<Impl> impl_;
-  };
-}
-}
+ private:
+  std::unique_ptr<Impl> impl_;
+};
 
-#endif
+}  // namespace waves
+}  // namespace gz
+
+#endif  // GZ_WAVES_LINEARRANDOMFFTWAVESIMULATION_HH_

--- a/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
@@ -18,7 +18,9 @@
 
 #include <memory>
 
-#include "WaveSimulation.hh"
+#include <Eigen/Dense> // NOLINT - cpplint false positive.
+
+#include "gz/waves/WaveSimulation.hh"
 
 using Eigen::ArrayXXd;
 
@@ -26,128 +28,129 @@ namespace gz
 {
 namespace waves
 {
-  /// \brief A non-FFT linear random wave simulation.
-  ///
-  /// The model is provided for comparison with the LinearIncidentWave model
-  /// used in buoy_sim when the wave spectrum type is set to Pierson-Moskowitz.
-  ///
-  /// Properties:
-  ///   - Superposition of num_waves waves.
-  ///   - Sampled at constant angular frequency: MaxOmega / NumWaves.
-  ///   - Amplitudes determined by the Pierson-Moskowitz spectrum.
-  ///   - Wave direction may be set.
-  ///   - Waves do not spread, all waves propagate in the same direction.
-  ///   - Waves are assigned random phases.
-  ///
-  /// Performance estimates for various grid sizes:
-  ///   num waves       nx x ny         RTF
-  ///   100             128 x 128         6
-  ///   300             128 x 128         2
-  ///
-  class LinearRandomWaveSimulation :
-      public IWaveSimulation,
-      public IWaveField
-  {
-  public:
-    virtual ~LinearRandomWaveSimulation();
+/// \brief A non-FFT linear random wave simulation.
+///
+/// The model is provided for comparison with the LinearIncidentWave model
+/// used in buoy_sim when the wave spectrum type is set to Pierson-Moskowitz.
+///
+/// Properties:
+///   - Superposition of num_waves waves.
+///   - Sampled at constant angular frequency: MaxOmega / NumWaves.
+///   - Amplitudes determined by the Pierson-Moskowitz spectrum.
+///   - Wave direction may be set.
+///   - Waves do not spread, all waves propagate in the same direction.
+///   - Waves are assigned random phases.
+///
+/// Performance estimates for various grid sizes:
+///   num waves       nx x ny         RTF
+///   100             128 x 128         6
+///   300             128 x 128         2
+///
+class LinearRandomWaveSimulation :
+    public IWaveSimulation,
+    public IWaveField
+{
+ public:
+  virtual ~LinearRandomWaveSimulation();
 
-    LinearRandomWaveSimulation(double lx, double ly,
-        Index nx, Index ny);
+  LinearRandomWaveSimulation(double lx, double ly,
+      Index nx, Index ny);
 
-    LinearRandomWaveSimulation(double lx, double ly, double lz,
-        Index nx, Index ny, Index nz);
+  LinearRandomWaveSimulation(double lx, double ly, double lz,
+      Index nx, Index ny, Index nz);
 
-    /// \brief The number of wave components.
-    Index NumWaves() const; 
+  /// \brief The number of wave components.
+  Index NumWaves() const;
 
-    /// \brief Set the number of wave components (has default = 100).
-    void SetNumWaves(Index value);
+  /// \brief Set the number of wave components (has default = 100).
+  void SetNumWaves(Index value);
 
-    /// \brief The maximum angular frequency rad/s).
-    double MaxOmega() const;
+  /// \brief The maximum angular frequency rad/s).
+  double MaxOmega() const;
 
-    /// \brief Set the maximum angular frequency (has default = 6.0 (rad/s)).
-    void SetMaxOmega(double value);
+  /// \brief Set the maximum angular frequency (has default = 6.0 (rad/s)).
+  void SetMaxOmega(double value);
 
-    virtual void SetWindVelocity(double ux, double uy) override;
+  void SetWindVelocity(double ux, double uy) override;
 
-    virtual void SetTime(double value) override;
+  void SetTime(double value) override;
 
-    virtual Index SizeX() const override;
+  Index SizeX() const override;
 
-    virtual Index SizeY() const override;
+  Index SizeY() const override;
 
-    virtual Index SizeZ() const override;
+  Index SizeZ() const override;
 
-    // IWaveField - interface.
-    virtual void Elevation(
-        double x, double y,
-        double &eta) override;
+  // IWaveField - interface.
+  void Elevation(
+      double x, double y,
+      double &eta) override;
 
-    virtual void Elevation(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        Eigen::Ref<Eigen::ArrayXd> eta) override;
+  void Elevation(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      Eigen::Ref<Eigen::ArrayXd> eta) override;
 
-    virtual void Pressure(
-        double x, double y, double z,
-        double &pressure) override;
+  void Pressure(
+      double x, double y, double z,
+      double& pressure) override;
 
-    virtual void Pressure(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        const Eigen::Ref<const Eigen::ArrayXd> &z,
-        Eigen::Ref<Eigen::ArrayXd> pressure) override;
+  void Pressure(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      const Eigen::Ref<const Eigen::ArrayXd>& z,
+      Eigen::Ref<Eigen::ArrayXd> pressure) override;
 
-    // lookup interface - array
-    virtual void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> h) override;
+  // lookup interface - array
+  void ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h) override;
 
-    virtual void ElevationDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+  void ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
 
-    virtual void DisplacementAt(
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy) override;
+  void DisplacementAt(
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy) override;
 
-    virtual void DisplacementDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+  void DisplacementDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-    virtual void DisplacementAndDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> h,
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy,
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+  void DisplacementAndDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> h,
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy,
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-    virtual void PressureAt(
-        Index iz,
-        Eigen::Ref<Eigen::ArrayXXd> pressure) override;
+  void PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure) override;
 
-    // lookup interface - scalar
-    virtual void ElevationAt(
-        Index ix, Index iy,
-        double &eta) override;
+  // lookup interface - scalar
+  void ElevationAt(
+      Index ix, Index iy,
+      double& eta) override;
 
-    virtual void DisplacementAt(
-        Index ix, Index iy,
-        double &sx, double &sy) override;
+  void DisplacementAt(
+      Index ix, Index iy,
+      double& sx, double& sy) override;
 
-    virtual void PressureAt(
-        Index ix, Index iy, Index iz,
-        double &pressure) override;
+  void PressureAt(
+      Index ix, Index iy, Index iz,
+      double& pressure) override;
 
-  private:
-    class Impl;
-    std::unique_ptr<Impl> impl_;
-  };
-}
-}
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
 
-#endif
+}  // namespace waves
+}  // namespace gz
+
+#endif  // GZ_WAVES_LINEARRANDOMWAVESIMULATION_HH_

--- a/gz-waves/include/gz/waves/LinearRegularWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRegularWaveSimulation.hh
@@ -18,9 +18,9 @@
 
 #include <memory>
 
-#include <Eigen/Dense>
+#include <Eigen/Dense> // NOLINT - cpplint false positive.
 
-#include "WaveSimulation.hh"
+#include "gz/waves/WaveSimulation.hh"
 
 using Eigen::ArrayXXd;
 
@@ -28,118 +28,119 @@ namespace gz
 {
 namespace waves
 {
-  /// The grid has sides with lengths lx and ly.
-  ///
-  /// There are nx, ny vertices in each direction.
-  ///
-  /// The simulation updates nx x ny vertices.
-  ///
-  /// The distance between vertices is dx = lx / nx and dy = ly / ny.
-  ///
-  /// All storage is assumed to be sized to nx x ny and the
-  /// vertices are traversed in column major order:
-  /// i.e. the innermost loop is over the x direction.
-  ///
-  class LinearRegularWaveSimulation :
-      public IWaveSimulation,
-      public IWaveField
-  {
-  public:
-    ~LinearRegularWaveSimulation();
+/// The grid has sides with lengths lx and ly.
+///
+/// There are nx, ny vertices in each direction.
+///
+/// The simulation updates nx x ny vertices.
+///
+/// The distance between vertices is dx = lx / nx and dy = ly / ny.
+///
+/// All storage is assumed to be sized to nx x ny and the
+/// vertices are traversed in column major order:
+/// i.e. the innermost loop is over the x direction.
+///
+class LinearRegularWaveSimulation :
+    public IWaveSimulation,
+    public IWaveField
+{
+ public:
+  ~LinearRegularWaveSimulation();
 
-    LinearRegularWaveSimulation(double lx, double ly,
-        Index nx, Index ny);
+  LinearRegularWaveSimulation(double lx, double ly,
+      Index nx, Index ny);
 
-    LinearRegularWaveSimulation(double lx, double ly, double lz,
-        Index nx, Index ny, Index nz);
+  LinearRegularWaveSimulation(double lx, double ly, double lz,
+      Index nx, Index ny, Index nz);
 
-    void SetUseVectorised(bool value);
+  void SetUseVectorised(bool value);
 
-    void SetDirection(double dir_x, double dir_y);
+  void SetDirection(double dir_x, double dir_y);
 
-    void SetAmplitude(double value);
+  void SetAmplitude(double value);
 
-    void SetPeriod(double value);
+  void SetPeriod(double value);
 
-    virtual void SetWindVelocity(double ux, double uy) override;
+  void SetWindVelocity(double ux, double uy) override;
 
-    virtual void SetTime(double value) override;
+  void SetTime(double value) override;
 
-    virtual Index SizeX() const override;
+  Index SizeX() const override;
 
-    virtual Index SizeY() const override;
+  Index SizeY() const override;
 
-    virtual Index SizeZ() const override;
+  Index SizeZ() const override;
 
-    // interpolation interface
-    virtual void Elevation(
-        double x, double y,
-        double &eta) override;
+  // interpolation interface
+  void Elevation(
+      double x, double y,
+      double& eta) override;
 
-    virtual void Elevation(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        Eigen::Ref<Eigen::ArrayXd> eta) override;
+  void Elevation(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      Eigen::Ref<Eigen::ArrayXd> eta) override;
 
-    virtual void Pressure(
-        double x, double y, double z,
-        double &pressure) override;
+  void Pressure(
+      double x, double y, double z,
+      double& pressure) override;
 
-    virtual void Pressure(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        const Eigen::Ref<const Eigen::ArrayXd> &z,
-        Eigen::Ref<Eigen::ArrayXd> pressure) override;
+  void Pressure(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      const Eigen::Ref<const Eigen::ArrayXd>& z,
+      Eigen::Ref<Eigen::ArrayXd> pressure) override;
 
-    // lookup interface - array
-    virtual void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> h) override;
+  // lookup interface - array
+  void ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h) override;
 
-    virtual void ElevationDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+  void ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
 
-    virtual void DisplacementAt(
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy) override;
+  void DisplacementAt(
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy) override;
 
-    virtual void DisplacementDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+  void DisplacementDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-    virtual void DisplacementAndDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> h,
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy,
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+  void DisplacementAndDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> h,
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy,
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-    virtual void PressureAt(
-        Index iz,
-        Eigen::Ref<Eigen::ArrayXXd> pressure) override;
+  void PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure) override;
 
-    // lookup interface - scalar
-    virtual void ElevationAt(
-        Index ix, Index iy,
-        double &eta) override;
+  // lookup interface - scalar
+  void ElevationAt(
+      Index ix, Index iy,
+      double &eta) override;
 
-    virtual void DisplacementAt(
-        Index ix, Index iy,
-        double &sx, double &sy) override;
+  void DisplacementAt(
+      Index ix, Index iy,
+      double& sx, double& sy) override;
 
-    virtual void PressureAt(
-        Index ix, Index iy, Index iz,
-        double &pressure) override;
+  void PressureAt(
+      Index ix, Index iy, Index iz,
+      double& pressure) override;
 
-  private:
-    class Impl;
-    std::unique_ptr<Impl> impl_;
-  };
-}
-}
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
 
-#endif
+}  // namespace waves
+}  // namespace gz
+
+#endif  // GZ_WAVES_LINEARREGULARWAVESIMULATION_HH_

--- a/gz-waves/include/gz/waves/MeshTools.hh
+++ b/gz-waves/include/gz/waves/MeshTools.hh
@@ -15,51 +15,50 @@
 
 /// \file MeshTools.hh
 /// \brief This file defines methods used to convert between CGAL
-/// and Gazebo meshes.     
+/// and Gazebo meshes.
 
 #ifndef GZ_WAVES_MESHTOOLS_HH_
 #define GZ_WAVES_MESHTOOLS_HH_
+
+#include <memory>
+#include <vector>
 
 #include "gz/waves/CGALTypes.hh"
 
 #include <gz/common.hh>
 #include <gz/common/Mesh.hh>
 
-#include <memory>
-
 namespace gz
 {
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////
-// MeshTools
+/// \brief A collection of static methods for switching between
+///        Gazebo and CGAL meshes.
+class MeshTools
+{
+ public:
+  /// \brief Wrapper around gz::sim::common::Mesh::FillArrays
+  ///        to populate vectors instead of raw arrays.
+  ///
+  /// \param[in] _source      The source mesh (a Gazebo Mesh).
+  /// \param[out] _vertices   The vector of vertices to populate.
+  /// \param[out] _indices    The vector of indices to populate.
+  static void FillArrays(
+    const gz::common::Mesh& _source,
+    std::vector<float>& _vertices,
+    std::vector<int>& _indices);
 
-  /// \brief A collection of static methods for switching between Gazebo and CGAL meshes.
-  class MeshTools
-  {
-    /// \brief Wrapper around gz::sim::common::Mesh::FillArrays to populate vectors instead of raw arrays.
-    ///
-    /// \param[in] _source      The source mesh (a Gazebo Mesh).
-    /// \param[out] _vertices   The vector of vertices to populate.
-    /// \param[out] _indices    The vector of indices to populate.
-    public: static void FillArrays(
-      const gz::common::Mesh& _source,
-      std::vector<float>& _vertices,
-      std::vector<int>& _indices
-    );
+  /// \brief Make a SurfaceMesh from a Gazebo Mesh.
+  ///
+  /// \param[in] _source      The source mesh (a Gazebo Mesh).
+  /// \param[out] _target     The target mesg (a CGAL SurfaceMesh).
+  static void MakeSurfaceMesh(
+    const gz::common::Mesh& _source,
+    cgal::Mesh& _target);
+};
 
-    /// \brief Make a SurfaceMesh from a Gazebo Mesh.
-    /// 
-    /// \param[in] _source      The source mesh (a Gazebo Mesh).
-    /// \param[out] _target     The target mesg (a CGAL SurfaceMesh).
-    public: static void MakeSurfaceMesh(
-      const gz::common::Mesh& _source,
-      cgal::Mesh& _target
-    );
-  };
+}  // namespace waves
+}  // namespace gz
 
-}
-}
-
-#endif
+#endif  // GZ_WAVES_MESHTOOLS_HH_

--- a/gz-waves/include/gz/waves/OceanTile.hh
+++ b/gz-waves/include/gz/waves/OceanTile.hh
@@ -17,6 +17,7 @@
 #define GZ_WAVES_OCEANTILE_HH_
 
 #include <memory>
+#include <vector>
 
 #include <gz/math.hh>
 #include <gz/common.hh>
@@ -26,70 +27,70 @@
 #include "gz/waves/Types.hh"
 #include "gz/waves/WaveParameters.hh"
 
-
 namespace gz
 {
 namespace waves
 {
-  template <typename Vector3>
-  class OceanTilePrivate;
+template <typename Vector3>
+class OceanTilePrivate;
 
-  template <typename Vector3>
-  class OceanTileT
-  {
-  public:
-    virtual ~OceanTileT();
+template <typename Vector3>
+class OceanTileT
+{
+ public:
+  virtual ~OceanTileT();
 
-    OceanTileT(Index nx, double lx, bool has_visuals=true);
+  explicit OceanTileT(Index nx, double lx, bool has_visuals = true);
 
-    OceanTileT(WaveParametersPtr params, bool has_visuals=true);
+  explicit OceanTileT(WaveParametersPtr params, bool has_visuals = true);
 
-    /// \brief The tile size (or length) lx. 
-    double TileSize() const;
+  /// \brief The tile size (or length) lx.
+  double TileSize() const;
 
-    /// \brief The tile resolution (nx). The tile contains (nx + 1)**2 vertices. 
-    Index Resolution() const;
+  /// \brief The tile resolution (nx). The tile contains (nx + 1)**2 vertices.
+  Index Resolution() const;
 
-    void SetWindVelocity(double ux, double uy);
+  void SetWindVelocity(double ux, double uy);
 
-    void Create();
+  void Create();
 
-    // Returns a new gz::common::Mesh. The caller must take ownership.
-    gz::common::Mesh* CreateMesh();
+  // Returns a new gz::common::Mesh. The caller must take ownership.
+  gz::common::Mesh* CreateMesh();
 
-    void Update(double time);
+  void Update(double time);
 
-    void UpdateMesh(double time, gz::common::Mesh *mesh);
+  void UpdateMesh(double time, gz::common::Mesh* mesh);
 
-    ////////////////////////////////////////
-    // Access to vertices, texture coordinates and faces
-    Index VertexCount() const;
-    
-    Vector3 Vertex(Index index) const;
+  // Access to vertices, texture coordinates and faces
+  Index VertexCount() const;
 
-    gz::math::Vector2d UV0(Index index) const;
+  Vector3 Vertex(Index index) const;
 
-    Index FaceCount() const;
-    
-    gz::math::Vector3i Face(Index index) const;
+  gz::math::Vector2d UV0(Index index) const;
 
-    const std::vector<Vector3>& Vertices() const;
+  Index FaceCount() const;
 
-  private:
-    std::unique_ptr<OceanTilePrivate<Vector3>> impl_;
-  };
+  gz::math::Vector3i Face(Index index) const;
 
-  namespace visual
-  {
-    typedef OceanTileT<gz::math::Vector3d> OceanTile;
-    typedef std::shared_ptr<OceanTile> OceanTilePtr;
-  }
-  namespace physics
-  {
-    typedef OceanTileT<cgal::Point3>   OceanTile;
-    typedef std::shared_ptr<OceanTile> OceanTilePtr;
-  }
-}
-}
+  const std::vector<Vector3>& Vertices() const;
 
-#endif
+ private:
+  std::unique_ptr<OceanTilePrivate<Vector3>> impl_;
+};
+
+namespace visual
+{
+typedef OceanTileT<gz::math::Vector3d> OceanTile;
+typedef std::shared_ptr<OceanTile> OceanTilePtr;
+}  // namespace visual
+
+namespace physics
+{
+typedef OceanTileT<cgal::Point3>   OceanTile;
+typedef std::shared_ptr<OceanTile> OceanTilePtr;
+}  // namespace physics
+
+}  // namespace waves
+}  // namespace gz
+
+#endif  // GZ_WAVES_OCEANTILE_HH_

--- a/gz-waves/include/gz/waves/OceanTile.hh
+++ b/gz-waves/include/gz/waves/OceanTile.hh
@@ -16,14 +16,16 @@
 #ifndef GZ_WAVES_OCEANTILE_HH_
 #define GZ_WAVES_OCEANTILE_HH_
 
-#include "gz/waves/CGALTypes.hh"
-#include "gz/waves/WaveParameters.hh"
+#include <memory>
 
 #include <gz/math.hh>
 #include <gz/common.hh>
 #include <gz/common/Mesh.hh>
 
-#include <memory>
+#include "gz/waves/CGALTypes.hh"
+#include "gz/waves/Types.hh"
+#include "gz/waves/WaveParameters.hh"
+
 
 namespace gz
 {
@@ -35,40 +37,46 @@ namespace waves
   template <typename Vector3>
   class OceanTileT
   {
-    public: virtual ~OceanTileT();
+  public:
+    virtual ~OceanTileT();
 
-    public: OceanTileT(unsigned int _N, double _L, bool _hasVisuals=true);
+    OceanTileT(Index nx, double lx, bool has_visuals=true);
 
-    public: OceanTileT(WaveParametersPtr _params, bool _hasVisuals=true);
+    OceanTileT(WaveParametersPtr params, bool has_visuals=true);
 
-    /// \brief The tile size (or length) L. 
+    /// \brief The tile size (or length) lx. 
     double TileSize() const;
 
-    /// \brief The tile resolution (N). The tile contains (N + 1)**2 vertices. 
-    unsigned int Resolution() const;
+    /// \brief The tile resolution (nx). The tile contains (nx + 1)**2 vertices. 
+    Index Resolution() const;
 
-    public: void SetWindVelocity(double _ux, double _uy);
+    void SetWindVelocity(double ux, double uy);
 
-    public: void Create();
+    void Create();
 
     // Returns a new gz::common::Mesh. The caller must take ownership.
-    public: gz::common::Mesh* CreateMesh();
+    gz::common::Mesh* CreateMesh();
 
-    public: void Update(double _time);
+    void Update(double time);
 
-    public: void UpdateMesh(double _time, gz::common::Mesh *_mesh);
-
+    void UpdateMesh(double time, gz::common::Mesh *mesh);
 
     ////////////////////////////////////////
     // Access to vertices, texture coordinates and faces
-    public: unsigned int VertexCount() const;
-    public: Vector3 Vertex(unsigned int _index) const;
-    public: gz::math::Vector2d UV0(unsigned int _index) const;
-    public: unsigned int FaceCount() const;
-    public: gz::math::Vector3i Face(unsigned int _index) const;
-    public: const std::vector<Vector3>& Vertices() const;
+    Index VertexCount() const;
+    
+    Vector3 Vertex(Index index) const;
 
-    private: std::unique_ptr<OceanTilePrivate<Vector3>> dataPtr;
+    gz::math::Vector2d UV0(Index index) const;
+
+    Index FaceCount() const;
+    
+    gz::math::Vector3i Face(Index index) const;
+
+    const std::vector<Vector3>& Vertices() const;
+
+  private:
+    std::unique_ptr<OceanTilePrivate<Vector3>> impl_;
   };
 
   namespace visual

--- a/gz-waves/include/gz/waves/PhysicalConstants.hh
+++ b/gz-waves/include/gz/waves/PhysicalConstants.hh
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /// \file PhysicalConstants.hh
-/// \brief This file contains definitions of some physical constants used 
+/// \brief This file contains definitions of some physical constants used
 /// in the physics calculations.
 
 #ifndef GZ_WAVES_PHYSICALCONSTANTS_HH_
@@ -25,37 +25,36 @@ namespace gz
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////
-// PhysicalConstants
+/// \brief A collection of static methods to retrieve physical constants.
+class PhysicalConstants
+{
+ public:
+  /// \brief Uniform acceleration due to gravity at earth's surface
+  ///        (orientation is z-up).
+  ///
+  /// \return     -9.8 [m s-2].
+  static double Gravity();
 
-  /// \brief A collection of static methods to retrieve physical constants.
-  class PhysicalConstants
-  {
-    /// \brief Uniform acceleration due to gravity at earth's surface (orientation is z-up).
-    ///
-    /// \return     -9.8 [m s-2].
-    public: static double Gravity(); 
-    
-    /// \brief Universal gravitational constant.
-    ///
-    /// \return     6.67408E-11 [m3 kg-1 s-2].
-    public: static double G();
-    
-    /// \brief Density of water.
-    ///
-    /// \return     998.6 [kg m-3].
-    public: static double WaterDensity();
+  /// \brief Universal gravitational constant.
+  ///
+  /// \return     6.67408E-11 [m3 kg-1 s-2].
+  static double G();
 
-    /// \brief Kinematic viscosity of water at 18 dgree C.
-    ///
-    /// Source:
-    /// <https://www.engineeringtoolbox.com/water-dynamic-kinematic-viscosity-d_596.html>
-    ///
-    /// \return     1.0533E-6 [m2 s-1].
-    public: static double WaterKinematicViscosity();
-  };
+  /// \brief Density of water.
+  ///
+  /// \return     998.6 [kg m-3].
+  static double WaterDensity();
 
-}
-}
+  /// \brief Kinematic viscosity of water at 18 dgree C.
+  ///
+  /// Source:
+  /// <https://www.engineeringtoolbox.com/water-dynamic-kinematic-viscosity-d_596.html>
+  ///
+  /// \return     1.0533E-6 [m2 s-1].
+  static double WaterKinematicViscosity();
+};
 
-#endif
+}  // namespace waves
+}  // namespace gz
+
+#endif  // GZ_WAVES_PHYSICALCONSTANTS_HH_

--- a/gz-waves/include/gz/waves/Physics.hh
+++ b/gz-waves/include/gz/waves/Physics.hh
@@ -15,10 +15,10 @@
 
 /// \file Physics.hh
 /// \brief This file contains definitions for the physics models used
-/// to calculate hydrostatic and hydrodynamic forces. 
+/// to calculate hydrostatic and hydrodynamic forces.
 ///
-/// The hydrostatic and hydrodynamic calculations provided here follow the methods
-/// described by Jacques Kerner in his blog series:
+/// The hydrostatic and hydrodynamic calculations provided here follow the
+///  methods described by Jacques Kerner in his blog series:
 ///
 /// <http://www.gamasutra.com/view/news/237528/Water_interaction_model_for_boats_in_video_games.php>
 /// <http://www.gamasutra.com/view/news/263237/Water_interaction_model_for_boats_in_video_games_Part_2.php>
@@ -28,19 +28,25 @@
 /// <https://archive.codeplex.com/?p=simship>
 /// <https://www.youtube.com/watch?v=6NNfmfSMwKs>
 ///
-/// The accuracy of the buoyancy calculations is determined by the accuracy of the mesh used
-/// for the collision and the grid resolution used in the wave field. There is of course a trade-off
-/// between a accuracy and performance: A collision mesh containing between 200 - 1000 vertices
+/// The accuracy of the buoyancy calculations is determined by the accuracy of
+/// the mesh used for the collision and the grid resolution used in the
+/// wave field. There is of course a trade-off between a accuracy and
+/// performance: A collision mesh containing between 200 - 1000 vertices
 /// should run in real time in Gazebo.
 ///
-/// The other forces modelled are less physically accurate and use game developer techniques
-/// designed to provide a reasonably realistic simulation of motion without excessive overhead.    
+/// The other forces modelled are less physically accurate and use game
+/// developer techniques designed to provide a reasonably realistic simulation
+/// of motion without excessive overhead.
 ///
-/// Parameters are provided that allow these additional forces to be toggled on or off.
+/// Parameters are provided that allow these additional forces to be
+/// toggled on or off.
 ///
 
 #ifndef GZ_WAVES_PHYSICS_HH_
 #define GZ_WAVES_PHYSICS_HH_
+
+#include <memory>
+#include <vector>
 
 #include "gz/waves/CGALTypes.hh"
 
@@ -48,360 +54,356 @@
 #include <gz/msgs.hh>
 #include <sdf/sdf.hh>
 
-#include <memory>
-#include <vector>
-
 namespace gz
 {
 namespace waves
 {
 
-  // class Grid;
-  class WavefieldSampler;
+// class Grid;
+class WavefieldSampler;
 
-///////////////////////////////////////////////////////////////////////////////
-// Physics
+/// \brief A collection of static methods for various physics calculations.
+class Physics
+{
+ public:
+  /// \brief Compute the center of force for two parallel forces.
+  ///
+  /// Given two parallel forces with magnitudes fA and fB applied at
+  /// points A and B, find the centre of force about which there is zero moment
+  /// (i.e. mA + mB = (A - out) x FA + (B - out) x FB = 0).
+  ///
+  /// \param[in] _fA    The magnitude of the force at point A.
+  /// \param[in] _fB    The magnitude of the force at point B.
+  /// \param[in] _A     The point of application of force A.
+  /// \param[in] _B     The point of application of force B.
+  /// \return           The point at which the resultant force is applied
+  ///                   with no moment.
+  static cgal::Point3 CenterOfForce(
+    double _fA, double _fB,
+    const cgal::Point3& _A,
+    const cgal::Point3& _B);
 
-  /// \brief A collection of static methods for various physics calculations.
-  class Physics
-  {
-    /// \brief Compute the center of force for two parallel forces.
-    ///
-    /// Given two parallel forces with magnitudes fA and fB applied at points A and B,
-    /// find the centre of force about which there is zero moment
-    /// (i.e. mA + mB = (A - out) x FA + (B - out) x FB = 0).
-    ///
-    /// \param[in] _fA    The magnitude of the force at point A. 
-    /// \param[in] _fB    The magnitude of the force at point B.
-    /// \param[in] _A     The point of application of force A.
-    /// \param[in] _B     The point of application of force B.
-    /// \return           The point at which the resultant force is applied with no moment.
-    public: static cgal::Point3 CenterOfForce(
-      double _fA, double _fB,
-      const cgal::Point3& _A,
-      const cgal::Point3& _B
-    );
+  /// \brief Compute the deep water dispersion.
+  ///
+  /// \param[in] _wavenumber  The wavenumber: k = 2 PI / wavelength.
+  /// \return                 The angular frequency omega.
+  static double DeepWaterDispersionToOmega(double _wavenumber);
 
-    /// \brief Compute the deep water dispersion.
-    ///
-    /// \param[in] _wavenumber  The wavenumber: k = 2 PI / wavelength.
-    /// \return                 The angular frequency omega.
-    public: static double DeepWaterDispersionToOmega(double _wavenumber);
+  /// \brief Compute the deep water dispersion.
+  ///
+  /// \param[in] _omega       The angular frequency: omega = 2 PI / T.
+  /// \return                 The wavenumber k.
+  static double DeepWaterDispersionToWavenumber(double _omega);
 
-    /// \brief Compute the deep water dispersion.
-    ///
-    /// \param[in] _omega       The angular frequency: omega = 2 PI / T.
-    /// \return                 The wavenumber k.
-    public: static double DeepWaterDispersionToWavenumber(double _omega);
+  /// \brief Compute the viscous drag coefficient CF(Rn) using the
+  ///        1957 ITTC formula.
+  ///
+  /// Set a lower limit on Rn to 1.0E+3 since the 1957 ITTC formula
+  /// has a pole at Rn = 1.0E+2. For a 10m boat in salt water this
+  /// corresponds to a velocity ~ 1.0E-5.
+  ///
+  /// \param[in] _Rn  The Reynolds number.
+  /// return          The viscous drag coefficient.
+  static double ViscousDragCoefficient(double _Rn);
 
-    /// \brief Compute the viscous drag coefficient CF(Rn) using the 1957 ITTC formula.
-    ///
-    /// Set a lower limit on Rn to 1.0E+3 since the 1957 ITTC formula
-    /// has a pole at Rn = 1.0E+2. For a 10m boat in salt water this 
-    /// corresponds to a velocity ~ 1.0E-5.
-    ///
-    /// \param[in] _Rn  The Reynolds number.
-    /// return          The viscous drag coefficient.
-    public: static double ViscousDragCoefficient(double _Rn);
+  /// \brief Compute the centre of pressure for a triangle with horizontal
+  ///        base and apex up.
+  ///
+  /// \param[in] _z0  The depth at H.z.
+  /// \param[in] _H   The vertex with the greatest z-component.
+  /// \param[in] _M   A base vertex with M.z < H.z.
+  /// \param[in] _B   The midpoint of the base B.z = M.z.
+  /// \return         The center of pressure.
+  static cgal::Point3 CenterOfPressureApexUp(
+    double _z0,
+    const cgal::Point3& _H,
+    const cgal::Point3& _M,
+    const cgal::Point3& _B);
 
-    /// \brief Compute the centre of pressure for a triangle with horizontal base and apex up. 
-    ///
-    /// \param[in] _z0  The depth at H.z.
-    /// \param[in] _H   The vertex with the greatest z-component.
-    /// \param[in] _M   A base vertex with M.z < H.z.
-    /// \param[in] _B   The midpoint of the base B.z = M.z.
-    /// \return         The center of pressure.
-    public: static cgal::Point3 CenterOfPressureApexUp(
-      double _z0,
-      const cgal::Point3& _H,
-      const cgal::Point3& _M,
-      const cgal::Point3& _B
-    );
+  /// \brief Compute the centre of pressure for a triangle with horizontal
+  ///        base and apex down.
+  ///
+  /// \param[in] _z0  The depth at H.z.
+  /// \param[in] _L   The vertex with the least z-component.
+  /// \param[in] _M   A base vertex with L.z < M.z.
+  /// \param[in] _B   The midpoint of the base B.z = M.z.
+  /// \return         The center of pressure.
+  static cgal::Point3 CenterOfPressureApexDn(
+    double _z0,
+    const cgal::Point3& _L,
+    const cgal::Point3& _M,
+    const cgal::Point3& _B);
 
-    /// \brief Compute the centre of pressure for a triangle with horizontal base and apex down. 
-    ///
-    /// \param[in] _z0  The depth at H.z.
-    /// \param[in] _L   The vertex with the least z-component.
-    /// \param[in] _M   A base vertex with L.z < M.z.
-    /// \param[in] _B   The midpoint of the base B.z = M.z.
-    /// \return         The center of pressure.
-    public: static cgal::Point3 CenterOfPressureApexDn(
-      double _z0,
-      const cgal::Point3& _L,
-      const cgal::Point3& _M,
-      const cgal::Point3& _B
-    );
+  /// \brief Calculate the buoyancy force for a submerged triangle (H, M, L).
+  //
+  /// Note: depthC > 0 for submerged triangle.
+  /// \param[in] _depthC  The depthC at the centroid C.
+  /// \param[in] _C       The centroid of the triangle (H, M, L).
+  /// \param[in] _H       High vertex.
+  /// \param[in] _M       Mid vertex.
+  /// \param[in] _L       Low vertex.
+  /// \param[in] _normal  The triangle outward normal.
+  /// \param[out] _center The resultant centre of pressure.
+  /// \param[out] _force  The resultant force.
+  static void BuoyancyForceAtCenterOfPressure(
+    double _depthC,
+    const cgal::Point3& _C,
+    const cgal::Point3& _H,
+    const cgal::Point3& _M,
+    const cgal::Point3& _L,
+    const cgal::Vector3& _normal,
+    cgal::Point3& _center,
+    cgal::Vector3& _force);
 
-    /// \brief Calculate the buoyancy force for a submerged triangle (H, M, L).
-    //
-    /// Note: depthC > 0 for submerged triangle.
-    /// \param[in] _depthC  The depthC at the centroid C.
-    /// \param[in] _C       The centroid of the triangle (H, M, L).
-    /// \param[in] _H       High vertex.
-    /// \param[in] _M       Mid vertex.
-    /// \param[in] _L       Low vertex.
-    /// \param[in] _normal  The triangle outward normal.
-    /// \param[out] _center The resultant centre of pressure.
-    /// \param[out] _force  The resultant force.
-    public: static void BuoyancyForceAtCenterOfPressure(
-      double _depthC,
-      const cgal::Point3& _C,
-      const cgal::Point3& _H,
-      const cgal::Point3& _M,
-      const cgal::Point3& _L,
-      const cgal::Vector3& _normal,
-      cgal::Point3& _center, 
-      cgal::Vector3& _force
-    );
+  /// \brief Calculate the buoyancy force at the centroid for a
+  ///        submerged triangle.
+  ///
+  /// \param[in] _wavefieldSampler  A reference to a WaveSampler.
+  /// \param[in] _triangle          The triangle for which the buoyancy is
+  ///                               being calculated.
+  /// \param[out] _center           The centroid, where the force is applied.
+  /// \param[out] _force            The buoyancy force applied at the center.
+  static void BuoyancyForceAtCentroid(
+    const WavefieldSampler& _wavefieldSampler,
+    const cgal::Triangle& _triangle,
+    cgal::Point3& _center,
+    cgal::Vector3& _force);
 
-    /// \brief Calculate the buoyancy force at the centroid for a submerged triangle.
-    ///
-    /// \param[in] _wavefieldSampler  A reference to a WaveSampler.
-    /// \param[in] _triangle          The triangle for which the buoyancy is being calculated.
-    /// \param[out] _center           The centroid, where the force is applied.
-    /// \param[out] _force            The buoyancy force applied at the center.
-    public: static void BuoyancyForceAtCentroid(
-      const WavefieldSampler& _wavefieldSampler,
-      const cgal::Triangle& _triangle,
-      cgal::Point3& _center,
-      cgal::Vector3& _force
-    );
+  /// \brief Calculate the buoyancy force and center of pressure for
+  ///        a submerged triangle.
+  ///
+  /// \param[in] _wavefieldSampler  A reference to a WaveSampler.
+  /// \param[in] _triangle          The triangle for which the buoyancy is
+  ///                               being calculated.
+  /// \param[out] _center           The center of pressure, where the force
+  ///                               is applied.
+  /// \param[out] _force            The buoyancy force applied at the center.
+  static void BuoyancyForceAtCenterOfPressure(
+    const WavefieldSampler& _wavefieldSampler,
+    const cgal::Triangle& _triangle,
+    cgal::Point3& _center,
+    cgal::Vector3& _force);
 
-    /// \brief Calculate the buoyancy force and center of pressure for a submerged triangle.
-    ///
-    /// \param[in] _wavefieldSampler  A reference to a WaveSampler.
-    /// \param[in] _triangle          The triangle for which the buoyancy is being calculated.
-    /// \param[out] _center           The center of pressure, where the force is applied.
-    /// \param[out] _force            The buoyancy force applied at the center.
-    public: static void BuoyancyForceAtCenterOfPressure(
-      const WavefieldSampler& _wavefieldSampler,
-      const cgal::Triangle& _triangle,
-      cgal::Point3& _center,
-      cgal::Vector3& _force
-    );
+  /// \brief Calculate the height map for each triangle vertex for a wavefield.
+  ///
+  /// \param[in] _wavefieldSampler  A reference to a WaveSampler.
+  /// \param[in] _triangle          The triangle used to compute the height map.
+  /// \return                       An array of three doubles, the height for
+  ///                               each vertex.
+  static std::array<double, 3> ComputeHeightMap(
+    const WavefieldSampler& _wavefieldSampler,
+    const cgal::Triangle& _triangle);
+};
 
-    /// \brief Calculate the height map for each triangle vertex given a wavefield.
-    ///
-    /// \param[in] _wavefieldSampler  A reference to a WaveSampler.
-    /// \param[in] _triangle          The triangle used to compute the height map.
-    /// \return                       An array of three doubles, the height for each vertex.
-    public: static std::array<double, 3> ComputeHeightMap(
-      const WavefieldSampler& _wavefieldSampler,
-      const cgal::Triangle& _triangle
-    );
+//////////////////////////////////////////////////
+/// \internal Hold private data for HydrodynamicsParameters.
+class HydrodynamicsParametersPrivate;
 
-  };
+/// \brief A class to manage the parameters used in hydrodynamics calculations.
+class HydrodynamicsParameters
+{
+ public:
+  /// \brief Destructor.
+  ~HydrodynamicsParameters();
 
-///////////////////////////////////////////////////////////////////////////////
-// HydrodynamicsParameters
+  /// \brief Constructor.
+  HydrodynamicsParameters();
+
+  /// \brief True if damping is enabled.
+  bool DampingOn() const;
+
+  /// \brief True if viscous drag is enabled.
+  bool ViscousDragOn() const;
+
+  /// \brief True if pressure drag is enabled.
+  bool PressureDragOn() const;
+
+  /// \brief The linear damping coefficient for linear montion.
+  double CDampL1() const;
+
+  /// \brief The quadratic damping coefficient for linear montion.
+  double CDampL2() const;
+
+  /// \brief The linear damping coefficient for angular montion.
+  double CDampR1() const;
+
+  /// \brief The quadratic damping coefficient for angular montion.
+  double CDampR2() const;
+
+  /// \brief The linear coefficient for positive pressure drag.
+  double CPDrag1() const;
+
+  /// \brief The quadratic coefficient for positive pressure drag.
+  double CPDrag2() const;
+
+  /// \brief The exponent coefficient for positive pressure drag.
+  double FPDrag() const;
+
+  /// \brief The linear coefficient for negative pressure drag.
+  double CSDrag1() const;
+
+  /// \brief The quadratic coefficient for negative pressure drag.
+  double CSDrag2() const;
+
+  /// \brief The exponent coefficient for negative pressure drag.
+  double FSDrag() const;
+
+  /// \brief The reference speed for pressure drag.
+  double VRDrag() const;
+
+  /// \brief Set the parameters from a message.
+  ///
+  /// \param[in] _msg   The message containing the hydrodynamics parameters.
+  void SetFromMsg(const msgs::Param_V& _msg);
+
+  /// \brief Set parameters from a SDF tree.
+  ///
+  /// \param[in] _sdf   A reference to a SDF element.
+  void SetFromSDF(sdf::Element& _sdf);
+
+  /// \brief Print a summary of the hydrodynamics parameters to the msg stream.
+  void DebugPrint() const;
+
+ private:
+  /// \internal Private implementation.
+  std::shared_ptr<HydrodynamicsParametersPrivate> data;
+};
+
+typedef std::shared_ptr<HydrodynamicsParameters> HydrodynamicsParametersPtr;
+
+//////////////////////////////////////////////////
+/// \internal Hold triangle data for hydrodynamics calculations.
+class TriangleProperties;
+
+/// \internal
+/// \brief Class to hold private data for Hydrodynamics.
+class HydrodynamicsPrivate;
+
+/// \brief A class to manage hydrodynamics calculation for a rigid body
+///        defined by a mesh.
+class Hydrodynamics
+{
+ public:
+  /// \brief Constructor
+  ///
+  /// \param[in] _params            The hydrodynamics parameters.
+  /// \param[in] _linkMesh          The surface mesh for the rigid body.
+  /// \param[in] _wavefieldSampler  An object for sampling the wave field.
+  Hydrodynamics(
+    std::shared_ptr<const HydrodynamicsParameters> _params,
+    std::shared_ptr<const cgal::Mesh> _linkMesh,
+    std::shared_ptr<const WavefieldSampler> _wavefieldSampler);
+
+  /// \brief Update the wavefield sampler given the motion of the rigid body.
+  ///
+  /// The position, linear velocity and angular velocity of the rigid body
+  /// center of mass must all be specified in the world frame.
+  ///
+  /// \param[in] _wavefieldSampler  An object for sampling the wave field.
+  /// \param[in] _position          The position of the center of mass.
+  /// \param[in] _linVelocity       The linear velocity of the center of mass.
+  /// \param[in] _angVelocity       The angular velocity of the center of mass.
+  void Update(
+    std::shared_ptr<const WavefieldSampler> _wavefieldSampler,
+    const math::Pose3d& _pose,
+    const cgal::Vector3& _linVelocity,
+    const cgal::Vector3& _angVelocity);
+
+  /// \brief Compute the hydrostatic and hydrodynamic forces.
+  ///
+  /// \return The force in the world frame.
+  const cgal::Vector3& Force() const;
+
+  /// \brief Compute the hydrostatic and hydrodynamic torques.
+  ///
+  /// \return The torque in the world frame.
+  const cgal::Vector3& Torque() const;
+
+  /// \brief The current waterline.
+  ///
+  /// \return A vector containing Line elements that comnprise the waterline.
+  const std::vector<cgal::Line>& GetWaterline() const;
+
+  /// \brief The current list of submerged triangles.
+  ///
+  /// \return A vector containing the trianges that are under water.
+  const std::vector<cgal::Triangle>& GetSubmergedTriangles() const;
+
+ private:
+  /// \internal
+  /// \brief Update the list of submerged triangles.
+  void UpdateSubmergedTriangles();
+
+  /// internal
+  /// \brief Determine the submerged sub-triangle of a triangle given a
+  ///        height map for it's vertices.
+  ///
+  /// \param[in] _triangle  The triangle to test whether it is submerged
+  ///                       and split if needed.
+  /// \param[out] _triProps The computed properties for the input triangle.
+  void PopulateSubmergedTriangle(
+    const cgal::Triangle& _triangle,
+    TriangleProperties& _triProps);
+
+  /// internal
+  /// \brief Split a triangle with one submerged vertex.
+  ///
+  /// \param[in] _triProps The properties for the partially submerged triangle.
+  void SplitPartiallySubmergedTriangle1(TriangleProperties& _triProps);
+
+  /// internal
+  /// \brief Split a triangle with two submerged vertices.
+  ///
+  /// \param[in] _triProps The properties for the partially submerged triangle.
+  void SplitPartiallySubmergedTriangle2(TriangleProperties& _triProps);
+
+  /// internal
+  /// \brief Add a fully submerged triangle.
+  ///
+  /// \param[in] _triProps The properties for the fully submerged triangle.
+  void AddFullySubmergedTriangle(TriangleProperties& _triProps);
+
+  /// internal
+  /// \brief Surface and submerged surface area.
+  void ComputeAreas();
+
+  /// internal
+  /// \brief Waterline length calculation.
+  void ComputeWaterlineLength();
+
+  /// internal
+  /// \brief Calculate normal and tangential velocities for
+  ///        each submerged triangle.
+  void ComputePointVelocities();
+
+  /// internal
+  // \breif Compute the Reynolds number.
+  double ComputeReynoldsNumber() const;
+
+  /// internal
+  /// \brief Buoyancy force calculation.
+  void ComputeBuoyancyForce();
+
+  /// internal
+  /// \brief Damping force calculation.
+  void ComputeDampingForce();
+
+  /// internal
+  /// \brief Viscous drag force calculation.
+  void ComputeViscousDragForce();
+
+  /// internal
+  /// \brief 'Pressure drag' force calculation.
+  void ComputePressureDragForce();
 
   /// \internal
-  /// \brief Class to hold private data for HydrodynamicsParameters.
-  class HydrodynamicsParametersPrivate;
+  /// \brief Pointer to the class private data.
+  std::shared_ptr<HydrodynamicsPrivate> data;
+};
 
-  /// \brief A class to manage the parameters used in hydrodynamics calculations.
-  class HydrodynamicsParameters
-  {
-    /// \brief Destructor.
-    public: ~HydrodynamicsParameters();
+typedef std::shared_ptr<Hydrodynamics> HydrodynamicsPtr;
 
-    /// \brief Constructor.
-    public: HydrodynamicsParameters();
+}  // namespace waves
+}  // namespace gz
 
-    /// \brief True if damping is enabled.
-    bool DampingOn() const;
-
-    /// \brief True if viscous drag is enabled.
-    bool ViscousDragOn() const;
-
-    /// \brief True if pressure drag is enabled.
-    bool PressureDragOn() const;
-
-    /// \brief The linear damping coefficient for linear montion.
-    public: double CDampL1() const;
-
-    /// \brief The quadratic damping coefficient for linear montion.
-    public: double CDampL2() const;
-
-    /// \brief The linear damping coefficient for angular montion.
-    public: double CDampR1() const;
-
-    /// \brief The quadratic damping coefficient for angular montion.
-    public: double CDampR2() const;
-
-    /// \brief The linear coefficient for positive pressure drag.
-    public: double CPDrag1() const;
-    
-    /// \brief The quadratic coefficient for positive pressure drag.
-    public: double CPDrag2() const;
-
-    /// \brief The exponent coefficient for positive pressure drag.
-    public: double FPDrag() const;
-
-    /// \brief The linear coefficient for negative pressure drag.
-    public: double CSDrag1() const;
-
-    /// \brief The quadratic coefficient for negative pressure drag.
-    public: double CSDrag2() const;
-
-    /// \brief The exponent coefficient for negative pressure drag.
-    public: double FSDrag() const;
-    
-    /// \brief The reference speed for pressure drag.
-    public: double VRDrag() const;
-
-    /// \brief Set the parameters from a message.
-    ///
-    /// \param[in] _msg   The message containing the hydrodynamics parameters.
-    public: void SetFromMsg(const msgs::Param_V& _msg);
-
-    /// \brief Set parameters from a SDF tree.
-    ///
-    /// \param[in] _sdf   A reference to a SDF element.
-    public: void SetFromSDF(sdf::Element& _sdf);
-
-    /// \brief Print a summary of the hydrodynamics parameters to the msg stream.
-    public: void DebugPrint() const;
-
-    /// \internal
-    /// \brief Pointer to the class private data.
-    private: std::shared_ptr<HydrodynamicsParametersPrivate> data;
-  };
-
-  typedef std::shared_ptr<HydrodynamicsParameters> HydrodynamicsParametersPtr;
-
-///////////////////////////////////////////////////////////////////////////////
-// Hydrodynamics
-
-  /// \internal
-  /// \brief Class to hold triangle data for hydrodynamics calculations.
-  class TriangleProperties;
-
-  /// \internal
-  /// \brief Class to hold private data for Hydrodynamics.
-  class HydrodynamicsPrivate;
-
-  /// \brief A class to manage hydrodynamics calculation for a rigid body defined by a mesh.
-  class Hydrodynamics
-  { 
-    /// \brief Constructor
-    ///
-    /// \param[in] _params            The hydrodynamics parameters.
-    /// \param[in] _linkMesh          The surface mesh for the rigid body.
-    /// \param[in] _wavefieldSampler  An object for sampling the wave field.
-    public: Hydrodynamics(
-      std::shared_ptr<const HydrodynamicsParameters> _params,
-      std::shared_ptr<const cgal::Mesh> _linkMesh,
-      std::shared_ptr<const WavefieldSampler> _wavefieldSampler
-    );
-
-    /// \brief Update the wavefield sampler given the motion of the rigid body.
-    ///
-    /// The position, linear velocity and angular velocity of the rigid body
-    /// center of mass must all be specified in the world frame.
-    ///
-    /// \param[in] _wavefieldSampler  An object for sampling the wave field.
-    /// \param[in] _position          The position of the center of mass.
-    /// \param[in] _linVelocity       The linear velocity of the center of mass.
-    /// \param[in] _angVelocity       The angular velocity of the center of mass.
-    public: void Update(
-      std::shared_ptr<const WavefieldSampler> _wavefieldSampler,
-      const math::Pose3d& _pose,
-      const cgal::Vector3& _linVelocity,
-      const cgal::Vector3& _angVelocity
-    );
-
-    /// \brief Compute the hydrostatic and hydrodynamic forces.
-    ///
-    /// \return The force in the world frame.
-    public: const cgal::Vector3& Force() const;
-
-    /// \brief Compute the hydrostatic and hydrodynamic torques.
-    ///
-    /// \return The torque in the world frame.
-    public: const cgal::Vector3& Torque() const;
-
-    /// \brief The current waterline.
-    ///
-    /// \return A vector containing Line elements that comnprise the waterline.
-    public: const std::vector<cgal::Line>& GetWaterline() const;
-  
-    /// \brief The current list of submerged triangles.
-    ///
-    /// \return A vector containing the trianges that are under water.
-    public: const std::vector<cgal::Triangle>& GetSubmergedTriangles() const;
-
-    /// \internal
-    /// \brief Update the list of submerged triangles.
-    private: void UpdateSubmergedTriangles();
-
-    /// internal
-    /// \brief Determine the submerged sub-triangle of a triangle given a height map for it's vertices.
-    ///
-    /// \param[in] _triangle  The triangle to test whether it is submerged and split if needed.
-    /// \param[out] _triProps The computed properties for the input triangle.
-    private: void PopulateSubmergedTriangle(
-      const cgal::Triangle& _triangle,
-      TriangleProperties& _triProps);
-
-    /// internal
-    /// \brief Split a triangle with one submerged vertex.
-    ///
-    /// \param[in] _triProps The properties for the partially submerged triangle.
-    private: void SplitPartiallySubmergedTriangle1(TriangleProperties& _triProps);
-
-    /// internal
-    /// \brief Split a triangle with two submerged vertices.
-    ///
-    /// \param[in] _triProps The properties for the partially submerged triangle.
-    private: void SplitPartiallySubmergedTriangle2(TriangleProperties& _triProps);
-
-    /// internal
-    /// \brief Add a fully submerged triangle.
-    ///
-    /// \param[in] _triProps The properties for the fully submerged triangle.
-    private: void AddFullySubmergedTriangle(TriangleProperties& _triProps);
-
-    /// internal
-    /// \brief Surface and submerged surface area.
-    private: void ComputeAreas();
-
-    /// internal
-    /// \brief Waterline length calculation.
-    private: void ComputeWaterlineLength();
-
-    /// internal
-    /// \brief Calculate normal and tangential velocities for each submerged triangle.
-    private: void ComputePointVelocities();
-
-    /// internal
-    // \breif Compute the Reynolds number.
-    private: double ComputeReynoldsNumber() const;
-
-    /// internal
-    /// \brief Buoyancy force calculation.
-    private: void ComputeBuoyancyForce();
-
-    /// internal
-    /// \brief Damping force calculation.
-    private: void ComputeDampingForce();
-
-    /// internal
-    /// \brief Viscous drag force calculation.
-    private: void ComputeViscousDragForce();
-
-    /// internal
-    /// \brief 'Pressure drag' force calculation.
-    private: void ComputePressureDragForce();
-
-    /// \internal
-    /// \brief Pointer to the class private data.
-    private: std::shared_ptr<HydrodynamicsPrivate> data;
-  };
-
-  typedef std::shared_ptr<Hydrodynamics> HydrodynamicsPtr;
-
-}
-}
-
-#endif
+#endif  // GZ_WAVES_PHYSICS_HH_

--- a/gz-waves/include/gz/waves/TriangulatedGrid.hh
+++ b/gz-waves/include/gz/waves/TriangulatedGrid.hh
@@ -18,63 +18,58 @@
 #ifndef GZ_WAVES_TRIANGULATEDGRID_HH_
 #define GZ_WAVES_TRIANGULATEDGRID_HH_
 
+#include <memory>
+#include <vector>
+
 #include "gz/waves/CGALTypes.hh"
 #include "gz/waves/Types.hh"
 
 #include <gz/math.hh>
-
-#include <memory>
-#include <vector>
 
 namespace gz
 {
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////
-// TriangulatedGrid
-  
-  
-  typedef std::array<int64_t, 3>    Index3;
-  typedef std::vector<cgal::Point3> Point3Range;
-  typedef std::vector<Index3>       Index3Range;
+typedef std::array<int64_t, 3>    Index3;
+typedef std::vector<cgal::Point3> Point3Range;
+typedef std::vector<Index3>       Index3Range;
 
-  class TriangulatedGrid {
-   public:
+class TriangulatedGrid
+{
+ public:
+  virtual ~TriangulatedGrid();
+  TriangulatedGrid(Index num_segments, double length);
+  void CreateMesh();
+  void CreateTriangulation();
+  static std::unique_ptr<TriangulatedGrid> Create(
+      Index num_segments, double length);
 
-    virtual ~TriangulatedGrid();    
-    TriangulatedGrid(Index num_segments, double length);
-    void CreateMesh();
-    void CreateTriangulation();
-    static std::unique_ptr<TriangulatedGrid> Create(Index num_segments, double length);
+  bool Locate(const cgal::Point3& query, int64_t& faceIndex) const;
+  bool Height(const cgal::Point3& query, double& height) const;
+  bool Height(const std::vector<cgal::Point3>& queries,
+      std::vector<double>& heights) const;
 
-    bool Locate(const cgal::Point3& query, int64_t& faceIndex) const;
-    bool Height(const cgal::Point3& query, double& height) const;
-    bool Height(const std::vector<cgal::Point3>& queries, std::vector<double>& heights) const;
-    
-    bool Interpolate(TriangulatedGrid& patch) const;
+  bool Interpolate(TriangulatedGrid& patch) const;
 
-    const Point3Range& Points() const;
-    const Index3Range& Indices() const;
-    const cgal::Point3& Origin() const;
-    void ApplyPose(const math::Pose3d& pose);
+  const Point3Range& Points() const;
+  const Index3Range& Indices() const;
+  const cgal::Point3& Origin() const;
+  void ApplyPose(const math::Pose3d& pose);
 
-    bool IsValid(bool verbose=false) const;
-    void DebugPrintMesh() const;
-    void DebugPrintTriangulation() const;
-    void UpdatePoints(const std::vector<cgal::Point3>& from);
-    void UpdatePoints(const std::vector<math::Vector3d>& from);
-    // void UpdatePoints(const std::vector<Ogre::Vector3>& from);
-    void UpdatePoints(const cgal::Mesh& from);
+  bool IsValid(bool verbose = false) const;
+  void DebugPrintMesh() const;
+  void DebugPrintTriangulation() const;
+  void UpdatePoints(const std::vector<cgal::Point3>& from);
+  void UpdatePoints(const std::vector<math::Vector3d>& from);
+  void UpdatePoints(const cgal::Mesh& from);
 
-   private:
-    class Private;
-    std::unique_ptr<Private> impl_;
-  };
+ private:
+  class Private;
+  std::unique_ptr<Private> impl_;
+};
 
-///////////////////////////////////////////////////////////////////////////////
+}  // namespace waves
+}  // namespace gz
 
-}
-}
-
-#endif
+#endif  // GZ_WAVES_TRIANGULATEDGRID_HH_

--- a/gz-waves/include/gz/waves/TriangulatedGrid.hh
+++ b/gz-waves/include/gz/waves/TriangulatedGrid.hh
@@ -19,6 +19,7 @@
 #define GZ_WAVES_TRIANGULATEDGRID_HH_
 
 #include "gz/waves/CGALTypes.hh"
+#include "gz/waves/Types.hh"
 
 #include <gz/math.hh>
 
@@ -42,10 +43,10 @@ namespace waves
    public:
 
     virtual ~TriangulatedGrid();    
-    TriangulatedGrid(int num_segments, double length);
+    TriangulatedGrid(Index num_segments, double length);
     void CreateMesh();
     void CreateTriangulation();
-    static std::unique_ptr<TriangulatedGrid> Create(int num_segments, double length);
+    static std::unique_ptr<TriangulatedGrid> Create(Index num_segments, double length);
 
     bool Locate(const cgal::Point3& query, int64_t& faceIndex) const;
     bool Height(const cgal::Point3& query, double& height) const;

--- a/gz-waves/include/gz/waves/TrochoidIrregularWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/TrochoidIrregularWaveSimulation.hh
@@ -18,9 +18,9 @@
 
 #include <memory>
 
-#include <Eigen/Dense>
+#include <Eigen/Dense> // NOLINT - cpplint false positive.
 
-#include "WaveSimulation.hh"
+#include "gz/waves/WaveSimulation.hh"
 
 using Eigen::ArrayXXd;
 
@@ -28,78 +28,79 @@ namespace gz
 {
 namespace waves
 {
-  class WaveParameters;
+class WaveParameters;
 
-  class TrochoidIrregularWaveSimulation :
-      public IWaveSimulation
-  {
-  public:
-    virtual ~TrochoidIrregularWaveSimulation();
+class TrochoidIrregularWaveSimulation :
+    public IWaveSimulation
+{
+ public:
+  virtual ~TrochoidIrregularWaveSimulation();
 
-    TrochoidIrregularWaveSimulation(
-        Index nx,
-        double lx,
-        std::shared_ptr<WaveParameters> params);
+  TrochoidIrregularWaveSimulation(
+      Index nx,
+      double lx,
+      std::shared_ptr<WaveParameters> params);
 
-    virtual void SetWindVelocity(double ux, double uy) override;
+  void SetWindVelocity(double ux, double uy) override;
 
-    virtual void SetTime(double time) override;
+  void SetTime(double time) override;
 
-    virtual Index SizeX() const override;
+  Index SizeX() const override;
 
-    virtual Index SizeY() const override;
+  Index SizeY() const override;
 
-    virtual Index SizeZ() const override;
+  Index SizeZ() const override;
 
-    // lookup interface - array
-    virtual void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> h) override;
+  // lookup interface - array
+  void ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h) override;
 
-    virtual void ElevationDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+  void ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
 
-    virtual void DisplacementAt(
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy) override;
+  void DisplacementAt(
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy) override;
 
-    virtual void DisplacementDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+  void DisplacementDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-    virtual void DisplacementAndDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> h,
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy,
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+  void DisplacementAndDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> h,
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy,
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-    virtual void PressureAt(
-        Index iz,
-        Eigen::Ref<Eigen::ArrayXXd> pressure) override;
+  void PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure) override;
 
-    // lookup interface - scalar
-    virtual void ElevationAt(
-        Index ix, Index iy,
-        double &eta) override;
+  // lookup interface - scalar
+  void ElevationAt(
+      Index ix, Index iy,
+      double &eta) override;
 
-    virtual void DisplacementAt(
-        Index ix, Index iy,
-        double &sx, double &sy) override;
+  void DisplacementAt(
+      Index ix, Index iy,
+      double& sx, double& sy) override;
 
-    virtual void PressureAt(
-        Index ix, Index iy, Index iz,
-        double &pressure) override;
+  void PressureAt(
+      Index ix, Index iy, Index iz,
+      double& pressure) override;
 
-  private:
-    class Impl;
-    std::unique_ptr<Impl> impl_;
-  };
-}
-}
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
 
-#endif
+}  // namespace waves
+}  // namespace gz
+
+#endif  // GZ_WAVES_TROCHOIDIRREGULARWAVESIMULATION_HH_

--- a/gz-waves/include/gz/waves/Types.hh
+++ b/gz-waves/include/gz/waves/Types.hh
@@ -1,0 +1,30 @@
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef GZ_WAVES_TYPES_HH_
+#define GZ_WAVES_TYPES_HH_
+
+#include <cstddef>
+
+namespace gz
+{
+namespace waves
+{
+  /// \brief Use gz::waves::Index for counting and indexing.
+  typedef std::ptrdiff_t Index;
+}
+}
+
+#endif

--- a/gz-waves/include/gz/waves/Types.hh
+++ b/gz-waves/include/gz/waves/Types.hh
@@ -22,9 +22,10 @@ namespace gz
 {
 namespace waves
 {
-  /// \brief Use gz::waves::Index for counting and indexing.
-  typedef std::ptrdiff_t Index;
-}
-}
+/// \brief Use Index for counting and indexing.
+typedef std::ptrdiff_t Index;
 
-#endif
+}  // namespace waves
+}  // namespace gz
+
+#endif  // GZ_WAVES_TYPES_HH_

--- a/gz-waves/include/gz/waves/Utilities.hh
+++ b/gz-waves/include/gz/waves/Utilities.hh
@@ -19,152 +19,149 @@
 #ifndef GZ_WAVES_UTILITIES_HH_
 #define GZ_WAVES_UTILITIES_HH_
 
+#include <string>
+
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
 #include <gz/msgs.hh>
 #include <sdf/sdf.hh>
 
-#include <string>
-
 namespace gz
 {
 namespace waves
 {
+/// \brief A collection of static methods for common tasks.
+class Utilities
+{
+ public:
+  /// \brief Extract a named bool parameter from an SDF element.
+  ///
+  /// \param[in] _sdf         A reference to the SDF Element tree.
+  /// \param[in] _paramName   The parameter name as it appears in SDF.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static bool SdfParamBool(const sdf::Element& _sdf,
+    const std::string& _paramName, const bool _defaultVal);
 
-///////////////////////////////////////////////////////////////////////////////
-// Utilities
+  /// \brief Extract a named size_t parameter from an SDF element.
+  ///
+  /// \param[in] _sdf         A reference to the SDF Element tree.
+  /// \param[in] _paramName   The parameter name as it appears in SDF.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static size_t SdfParamSizeT(const sdf::Element& _sdf,
+    const std::string& _paramName, const size_t _defaultVal);
 
-  /// \brief A collection of static methods for common tasks.
-  class Utilities
-  {
-    /// \brief Extract a named bool parameter from an SDF element.
-    ///
-    /// \param[in] _sdf         A reference to the SDF Element tree.
-    /// \param[in] _paramName   The parameter name as it appears in SDF.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static bool SdfParamBool(const sdf::Element& _sdf,
-      const std::string &_paramName, const bool _defaultVal);
+  /// \brief Extract a named double parameter from an SDF element.
+  ///
+  /// \param[in] _sdf         A reference to the SDF Element tree.
+  /// \param[in] _paramName   The parameter name as it appears in SDF.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static double SdfParamDouble(const sdf::Element& _sdf,
+    const std::string& _paramName, const double _defaultVal);
 
-    /// \brief Extract a named size_t parameter from an SDF element.
-    ///
-    /// \param[in] _sdf         A reference to the SDF Element tree.
-    /// \param[in] _paramName   The parameter name as it appears in SDF.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static size_t SdfParamSizeT(const sdf::Element& _sdf,
-      const std::string &_paramName, const size_t _defaultVal);
+  /// \brief Extract a named string parameter from an SDF element.
+  ///
+  /// \param[in] _sdf         A reference to the SDF Element tree.
+  /// \param[in] _paramName   The parameter name as it appears in SDF.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static std::string SdfParamString(const sdf::Element& _sdf,
+    const std::string& _paramName, const std::string _defaultVal);
 
-    /// \brief Extract a named double parameter from an SDF element.
-    ///
-    /// \param[in] _sdf         A reference to the SDF Element tree.
-    /// \param[in] _paramName   The parameter name as it appears in SDF.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static double SdfParamDouble(const sdf::Element& _sdf,
-      const std::string &_paramName, const double _defaultVal);
+  /// \brief Extract a named Vector2d parameter from an SDF element.
+  ///
+  /// \param[in] _sdf         A reference to the SDF Element tree.
+  /// \param[in] _paramName   The parameter name as it appears in SDF.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static gz::math::Vector2d SdfParamVector2d(const sdf::Element& _sdf,
+    const std::string& _paramName, const gz::math::Vector2d _defaultVal);
 
-    /// \brief Extract a named string parameter from an SDF element.
-    ///
-    /// \param[in] _sdf         A reference to the SDF Element tree.
-    /// \param[in] _paramName   The parameter name as it appears in SDF.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static std::string SdfParamString(const sdf::Element& _sdf,
-      const std::string &_paramName, const std::string _defaultVal);
+  /// \brief Extract a named Vector2i parameter from an SDF element.
+  ///
+  /// \param[in] _sdf         A reference to the SDF Element tree.
+  /// \param[in] _paramName   The parameter name as it appears in SDF.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static gz::math::Vector2i SdfParamVector2i(const sdf::Element& _sdf,
+    const std::string& _paramName, const gz::math::Vector2i _defaultVal);
 
-    /// \brief Extract a named Vector2d parameter from an SDF element.
-    ///
-    /// \param[in] _sdf         A reference to the SDF Element tree.
-    /// \param[in] _paramName   The parameter name as it appears in SDF.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static gz::math::Vector2d SdfParamVector2d(const sdf::Element& _sdf,
-      const std::string &_paramName, const gz::math::Vector2d _defaultVal);
+  /// \brief Extract a named Vector3d parameter from an SDF element.
+  ///
+  /// \param[in] _sdf         A reference to the SDF Element tree.
+  /// \param[in] _paramName   The parameter name as it appears in SDF.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static gz::math::Vector3d SdfParamVector3d(const sdf::Element& _sdf,
+    const std::string& _paramName, const gz::math::Vector3d _defaultVal);
 
-    /// \brief Extract a named Vector2i parameter from an SDF element.
-    ///
-    /// \param[in] _sdf         A reference to the SDF Element tree.
-    /// \param[in] _paramName   The parameter name as it appears in SDF.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static gz::math::Vector2i SdfParamVector2i(const sdf::Element& _sdf,
-      const std::string &_paramName, const gz::math::Vector2i _defaultVal);
+  /// \brief Extract a named bool parameter from a Param_V message.
+  ///
+  /// \param[in] _msg         A reference to the Param_V message.
+  /// \param[in] _paramName   The parameter name as it appears in message.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static bool MsgParamBool(const msgs::Param_V& _msg,
+    const std::string& _paramName, const bool _defaultVal);
 
-    /// \brief Extract a named Vector3d parameter from an SDF element.
-    ///
-    /// \param[in] _sdf         A reference to the SDF Element tree.
-    /// \param[in] _paramName   The parameter name as it appears in SDF.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static gz::math::Vector3d SdfParamVector3d(const sdf::Element& _sdf,
-      const std::string &_paramName, const gz::math::Vector3d _defaultVal);
+  /// \brief Extract a named size_t parameter from a Param_V message.
+  ///
+  /// \param[in] _msg         A reference to the Param_V message.
+  /// \param[in] _paramName   The parameter name as it appears in message.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static size_t MsgParamSizeT(const msgs::Param_V& _msg,
+    const std::string& _paramName, const size_t _defaultVal);
 
-    /// \brief Extract a named bool parameter from a Param_V message.
-    ///
-    /// \param[in] _msg         A reference to the Param_V message.
-    /// \param[in] _paramName   The parameter name as it appears in message.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static bool MsgParamBool(const msgs::Param_V& _msg,
-      const std::string &_paramName, const bool _defaultVal);
+  /// \brief Extract a named double parameter from a Param_V message.
+  ///
+  /// \param[in] _msg         A reference to the Param_V message.
+  /// \param[in] _paramName   The parameter name as it appears in message.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static double MsgParamDouble(const msgs::Param_V& _msg,
+    const std::string& _paramName, const double _defaultVal);
 
-    /// \brief Extract a named size_t parameter from a Param_V message.
-    ///
-    /// \param[in] _msg         A reference to the Param_V message.
-    /// \param[in] _paramName   The parameter name as it appears in message.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static size_t MsgParamSizeT(const msgs::Param_V& _msg,
-      const std::string &_paramName, const size_t _defaultVal);
+  /// \brief Extract a named std::string parameter from a Param_V message.
+  ///
+  /// \param[in] _msg         A reference to the Param_V message.
+  /// \param[in] _paramName   The parameter name as it appears in message.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static std::string MsgParamString(const msgs::Param_V& _msg,
+    const std::string& _paramName, const std::string _defaultVal);
 
-    /// \brief Extract a named double parameter from a Param_V message.
-    ///
-    /// \param[in] _msg         A reference to the Param_V message.
-    /// \param[in] _paramName   The parameter name as it appears in message.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static double MsgParamDouble(const msgs::Param_V& _msg,
-      const std::string &_paramName, const double _defaultVal);
+  /// \brief Extract a named Vector2i parameter from a Param_V message.
+  ///
+  /// \param[in] _msg         A reference to the Param_V message.
+  /// \param[in] _paramName   The parameter name as it appears in message.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static gz::math::Vector2i MsgParamVector2i(const msgs::Param_V& _msg,
+    const std::string& _paramName, const gz::math::Vector2i _defaultVal);
 
-    /// \brief Extract a named std::string parameter from a Param_V message.
-    ///
-    /// \param[in] _msg         A reference to the Param_V message.
-    /// \param[in] _paramName   The parameter name as it appears in message.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static std::string MsgParamString(const msgs::Param_V& _msg,
-      const std::string &_paramName, const std::string _defaultVal);
+  /// \brief Extract a named Vector2d parameter from a Param_V message.
+  ///
+  /// \param[in] _msg         A reference to the Param_V message.
+  /// \param[in] _paramName   The parameter name as it appears in message.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static gz::math::Vector2d MsgParamVector2d(const msgs::Param_V& _msg,
+    const std::string& _paramName, const gz::math::Vector2d _defaultVal);
 
-    /// \brief Extract a named Vector2i parameter from a Param_V message.
-    ///
-    /// \param[in] _msg         A reference to the Param_V message.
-    /// \param[in] _paramName   The parameter name as it appears in message.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static gz::math::Vector2i MsgParamVector2i(const msgs::Param_V& _msg,
-      const std::string &_paramName, const gz::math::Vector2i _defaultVal);
+  /// \brief Extract a named Vector3d parameter from a Param_V message.
+  ///
+  /// \param[in] _msg         A reference to the Param_V message.
+  /// \param[in] _paramName   The parameter name as it appears in message.
+  /// \param[in] _defaultVal  A default value for the parameter.
+  /// \return                 The parameter value (or default if not found).
+  static gz::math::Vector3d MsgParamVector3d(const msgs::Param_V& _msg,
+    const std::string& _paramName, const gz::math::Vector3d _defaultVal);
+};
 
-    /// \brief Extract a named Vector2d parameter from a Param_V message.
-    ///
-    /// \param[in] _msg         A reference to the Param_V message.
-    /// \param[in] _paramName   The parameter name as it appears in message.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static gz::math::Vector2d MsgParamVector2d(const msgs::Param_V& _msg,
-      const std::string &_paramName, const gz::math::Vector2d _defaultVal);
+}  // namespace waves
+}  // namespace gz
 
-    /// \brief Extract a named Vector3d parameter from a Param_V message.
-    ///
-    /// \param[in] _msg         A reference to the Param_V message.
-    /// \param[in] _paramName   The parameter name as it appears in message.
-    /// \param[in] _defaultVal  A default value for the parameter.
-    /// \return                 The parameter value (or default value if not found).
-    public: static gz::math::Vector3d MsgParamVector3d(const msgs::Param_V& _msg,
-      const std::string &_paramName, const gz::math::Vector3d _defaultVal);
-  };
-
-}
-}
-
-#endif
+#endif  // GZ_WAVES_UTILITIES_HH_

--- a/gz-waves/include/gz/waves/WaveParameters.hh
+++ b/gz-waves/include/gz/waves/WaveParameters.hh
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
@@ -33,193 +34,193 @@ namespace gz
 namespace waves
 {
 
+/// \internal Private implementation.
+class WaveParametersPrivate;
+
+/// \brief Parameters for generating a wave in a wave field.
+class WaveParameters
+{
+ public:
+  /// \brief Destructor.
+  ~WaveParameters();
+
+  /// \brief Constructor.
+  WaveParameters();
+
+  /// \brief Populate the message with the wave parameters.
+  ///
+  /// \param[out] msg  The message to be populated (a vector of parameters).
+  void FillMsg(msgs::Param_V& msg) const;
+
+  /// \brief Set the parameters from a message.
+  ///
+  /// \param[in] msg   The message containing the wave parameters.
+  void SetFromMsg(const msgs::Param_V& msg);
+
+  /// \brief Set the parameters from an SDF Element tree.
+  ///
+  /// \param[in] sdf   The SDF Element tree containing the wave parameters.
+  void SetFromSDF(sdf::Element& sdf);
+
+  /// \brief The wave algorithm (options are: 'sinusoid', 'trochoid', 'fft').
+  std::string Algorithm() const;
+
+  /// \brief The size of the wave tile (m).
+  double TileSize() const;
+
+  /// \brief The number of cells in the wave tile in each direction (N).
+  Index CellCount() const;
+
+  /// \brief The number of wave components (3 max if visualisation required).
+  Index Number() const;
+
+  /// \brief The angle between the mean wave direction and the
+  ///        largest / smallest component waves.
+  double Angle() const;
+
+  /// \brief The scale between the mean and largest / smallest
+  ///        component waves.
+  double Scale() const;
+
+  /// \brief A parameter in [0, 1] controlling the wave steepness
+  ///        with 1 being steepest.
+  double Steepness() const;
+
+  /// \brief The angular frequency (rad/s)
+  double AngularFrequency() const;
+
+  /// \brief The amplitude of the mean wave (m).
+  double Amplitude() const;
+
+  /// \brief The period of the mean wave (s).
+  double Period() const;
+
+  /// \brief The phase of the mean wave.
+  double Phase() const;
+
+  /// \brief The mean wavelength (m).
+  double Wavelength() const;
+
+  /// \brief The mean angular wavenumber (rad/m).
+  double Wavenumber() const;
+
+  /// \brief A two component vector specifiying the direction
+  ///        of the mean wave.
+  math::Vector2d Direction() const;
+
+  /// \brief A two component vector specifiying the horizontal
+  ///        wind velocity (m/s).
+  math::Vector2d WindVelocity() const;
+
+  /// \brief The scalar wind speed (m/s).
+  double WindSpeed() const;
+
+  /// \brief The wind angle (counter clockwise from
+  ///        positive x-axis) (rad).
+  double WindAngleRad() const;
+
+  /// \brief Set the wave algorithm (options are: 'sinusoid',
+  ///        'trochoid', 'fft').
+  ///
+  /// \param[in] value  The wave algorithm.
+  void SetAlgorithm(const std::string& value);
+
+  /// \brief Set the size of the wave tile (m).
+  ///
+  /// \param[in] value  The size of the wave tile (m).
+  void SetTileSize(double value);
+
+  /// \brief Set the number of cells in the wave tile
+  ///        in each direction.
+  ///
+  /// \param[in] value  The number of cells.
+  void SetCellCount(Index value);
+
+  /// \brief Set the number of wave components (3 max).
+  ///
+  /// \param[in] value  The number of component waves.
+  void SetNumber(Index value);
+
+  /// \brief Set the angle parameter controlling
+  /// the direction of the component waves.
+  ///
+  /// \param[in] value  The angle parameter.
+  void SetAngle(double value);
+
+  /// \brief Set the scale parameter controlling
+  /// the range of amplitudes of the component waves.
+  ///
+  /// \param[in] value  The scale parameter.
+  void SetScale(double value);
+
+  /// \brief Set the steepness parameter controlling
+  /// the steepness of the waves. In [0, 1].
+  ///
+  /// \param[in] value  The steepness parameter.
+  void SetSteepness(double value);
+
+  /// \brief Set the mean wave amplitude (m). Must be positive.
+  ///
+  /// \param[in] value  The amplitude parameter (m).
+  void SetAmplitude(double value);
+
+  /// \brief Set the mean wave period (s). Must be positive.
+  ///
+  /// \param[in] value  The period parameter (s).
+  void SetPeriod(double value);
+
+  /// \brief Set the mean wave phase.
+  ///
+  /// \param[in] value  The phase parameter.
+  void SetPhase(double value);
+
+  /// \brief Set the mean wave direction.
+  ///
+  /// \param[in] value  The direction parameter,
+  ///            a two component vector.
+  void SetDirection(const math::Vector2d& value);
+
+  /// \brief Set the horizontal wind velocity.
+  ///
+  /// \param[in] value  The wind velocity, a two component vector.
+  void SetWindVelocity(const math::Vector2d& value);
+
+  /// \brief Set the scalar wind speed and downwind angle
+  ///        at 10m above MSL (m/s).
+  ///
+  /// \param[in] wind_speed     The wind speed (m/s).
+  /// \param[in] wind_angle_rad The downwind angle (rad).
+  void SetWindSpeedAndAngle(double wind_speed, double wind_angle_rad);
+
+  /// \brief Access the component angular frequencies (rad/s).
+  const std::vector<double>& AngularFrequency_V() const;
+
+  /// \brief Access the component amplitudes (m).
+  const std::vector<double>& Amplitude_V() const;
+
+  /// \brief Access the component phases.
+  const std::vector<double>& Phase_V() const;
+
+  /// \brief Access the steepness components.
+  const std::vector<double>& Steepness_V() const;
+
+  /// \brief Access the component wavenumbers (rad/m).
+  const std::vector<double>& Wavenumber_V() const;
+
+  /// \brief Access the component directions.
+  const std::vector<math::Vector2d>& Direction_V() const;
+
+  /// \brief Print a summary of the wave parameters to the msg stream.
+  void DebugPrint() const;
+
+ private:
   /// \internal Private implementation.
-  class WaveParametersPrivate;
+  std::shared_ptr<WaveParametersPrivate> impl_;
+};
 
-  /// \brief Parameters for generating a wave in a wave field.
-  class WaveParameters
-  {
-  public:
-    /// \brief Destructor.
-    ~WaveParameters();
+typedef std::shared_ptr<WaveParameters> WaveParametersPtr;
 
-    /// \brief Constructor.
-    WaveParameters();
+}  // namespace waves
+}  // namespace gz
 
-    /// \brief Populate the message with the wave parameters.
-    ///
-    /// \param[out] msg  The message to be populated (a vector of parameters).
-    void FillMsg(msgs::Param_V &msg) const;
-
-    /// \brief Set the parameters from a message.
-    ///
-    /// \param[in] msg   The message containing the wave parameters.
-    void SetFromMsg(const msgs::Param_V &msg);
-
-    /// \brief Set the parameters from an SDF Element tree.
-    ///
-    /// \param[in] sdf   The SDF Element tree containing the wave parameters.
-    void SetFromSDF(sdf::Element &sdf);
-
-    /// \brief The wave algorithm (options are: 'sinusoid', 'trochoid', 'fft').
-    std::string Algorithm() const;
-
-    /// \brief The size of the wave tile (m).
-    double TileSize() const;
-
-    /// \brief The number of cells in the wave tile in each direction (N). 
-    Index CellCount() const;
-
-    /// \brief The number of wave components (3 max if visualisation required).
-    Index Number() const;
-
-    /// \brief The angle between the mean wave direction and the
-    ///        largest / smallest component waves.
-    double Angle() const;
-
-    /// \brief The scale between the mean and largest / smallest
-    ///        component waves.
-    double Scale() const;
-
-    /// \brief A parameter in [0, 1] controlling the wave steepness
-    ///        with 1 being steepest.
-    double Steepness() const;
-
-    /// \brief The angular frequency (rad/s) 
-    double AngularFrequency() const;
-
-    /// \brief The amplitude of the mean wave (m).
-    double Amplitude() const;
-
-    /// \brief The period of the mean wave (s).
-    double Period() const;
-
-    /// \brief The phase of the mean wave.
-    double Phase() const;
-
-    /// \brief The mean wavelength (m).
-    double Wavelength() const;
-
-    /// \brief The mean angular wavenumber (rad/m).
-    double Wavenumber() const;
-
-    /// \brief A two component vector specifiying the direction
-    ///        of the mean wave.
-    math::Vector2d Direction() const;
-
-    /// \brief A two component vector specifiying the horizontal
-    ///        wind velocity (m/s).
-    math::Vector2d WindVelocity() const;
-
-    /// \brief The scalar wind speed (m/s).
-    double WindSpeed() const;
-
-    /// \brief The wind angle (counter clockwise from
-    ///        positive x-axis) (rad).
-    double WindAngleRad() const;
-
-    /// \brief Set the wave algorithm (options are: 'sinusoid',
-    ///        'trochoid', 'fft').
-    ///
-    /// \param[in] value  The wave algorithm.
-    void SetAlgorithm(const std::string &value);
-
-    /// \brief Set the size of the wave tile (m).
-    ///
-    /// \param[in] value  The size of the wave tile (m).
-    void SetTileSize(double value);
-
-    /// \brief Set the number of cells in the wave tile
-    ///        in each direction. 
-    ///
-    /// \param[in] value  The number of cells.
-    void SetCellCount(Index value);
-
-    /// \brief Set the number of wave components (3 max).
-    ///
-    /// \param[in] value  The number of component waves.
-    void SetNumber(Index value);
-
-    /// \brief Set the angle parameter controlling 
-    /// the direction of the component waves.
-    ///
-    /// \param[in] value  The angle parameter.
-    void SetAngle(double value);
-
-    /// \brief Set the scale parameter controlling
-    /// the range of amplitudes of the component waves.
-    ///
-    /// \param[in] value  The scale parameter.
-    void SetScale(double value);
-
-    /// \brief Set the steepness parameter controlling
-    /// the steepness of the waves. In [0, 1].
-    ///
-    /// \param[in] value  The steepness parameter.
-    void SetSteepness(double value);
-
-    /// \brief Set the mean wave amplitude (m). Must be positive.
-    ///
-    /// \param[in] value  The amplitude parameter (m).
-    void SetAmplitude(double value);
-
-    /// \brief Set the mean wave period (s). Must be positive.
-    ///
-    /// \param[in] value  The period parameter (s).
-    void SetPeriod(double value);
-
-    /// \brief Set the mean wave phase.
-    ///
-    /// \param[in] value  The phase parameter.
-    void SetPhase(double value);
-
-    /// \brief Set the mean wave direction.
-    ///
-    /// \param[in] value  The direction parameter,
-    ///            a two component vector.
-    void SetDirection(const math::Vector2d &value);
-
-    /// \brief Set the horizontal wind velocity.
-    ///
-    /// \param[in] value  The wind velocity, a two component vector.
-    void SetWindVelocity(const math::Vector2d &value);
-
-    /// \brief Set the scalar wind speed and downwind angle
-    ///        at 10m above MSL (m/s).
-    ///
-    /// \param[in] wind_speed     The wind speed (m/s).
-    /// \param[in] wind_angle_rad The downwind angle (rad).
-    void SetWindSpeedAndAngle(double wind_speed, double wind_angle_rad);
-
-    /// \brief Access the component angular frequencies (rad/s).
-    const std::vector<double>& AngularFrequency_V() const;
-
-    /// \brief Access the component amplitudes (m).
-    const std::vector<double>& Amplitude_V() const;
-
-    /// \brief Access the component phases.
-    const std::vector<double>& Phase_V() const;
-
-    /// \brief Access the steepness components.
-    const std::vector<double>& Steepness_V() const;
-
-    /// \brief Access the component wavenumbers (rad/m).
-    const std::vector<double>& Wavenumber_V() const;
-
-    /// \brief Access the component directions.
-    const std::vector<math::Vector2d>& Direction_V() const;
-
-    /// \brief Print a summary of the wave parameters to the msg stream.
-    void DebugPrint() const;
-
-  private:
-    /// \internal Private implementation.
-    std::shared_ptr<WaveParametersPrivate> impl_;
-  };
-
-  typedef std::shared_ptr<WaveParameters> WaveParametersPtr; 
-
-}
-}
-
-#endif
+#endif  // GZ_WAVES_WAVEPARAMETERS_HH_

--- a/gz-waves/include/gz/waves/WaveParameters.hh
+++ b/gz-waves/include/gz/waves/WaveParameters.hh
@@ -18,209 +18,206 @@
 #ifndef GZ_WAVES_WAVEPARAMETERS_HH_
 #define GZ_WAVES_WAVEPARAMETERS_HH_
 
+#include <memory>
+#include <string>
+
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
 #include <gz/msgs.hh>
 #include <sdf/sdf.hh>
 
-#include <memory>
-#include <string>
+#include "gz/waves/Types.hh"
 
 namespace gz
 {
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////
-// WaveParameters
-
-  /// \internal
-  /// \brief Class to hold private data for WaveParameters.
+  /// \internal Private implementation.
   class WaveParametersPrivate;
 
-  /// \brief A class to manage the parameters for generating a wave in a wave field.
+  /// \brief Parameters for generating a wave in a wave field.
   class WaveParameters
   {
+  public:
     /// \brief Destructor.
-    public: ~WaveParameters();
+    ~WaveParameters();
 
     /// \brief Constructor.
-    public: WaveParameters();
+    WaveParameters();
 
     /// \brief Populate the message with the wave parameters.
     ///
-    /// \param[out] _msg  The message to be populated (a vector of parameters).
-    public: void FillMsg(msgs::Param_V& _msg) const;
+    /// \param[out] msg  The message to be populated (a vector of parameters).
+    void FillMsg(msgs::Param_V &msg) const;
 
     /// \brief Set the parameters from a message.
     ///
-    /// \param[in] _msg   The message containing the wave parameters.
-    public: void SetFromMsg(const msgs::Param_V& _msg);
+    /// \param[in] msg   The message containing the wave parameters.
+    void SetFromMsg(const msgs::Param_V &msg);
 
     /// \brief Set the parameters from an SDF Element tree.
     ///
-    /// \param[in] _sdf   The SDF Element tree containing the wave parameters.
-    public: void SetFromSDF(sdf::Element& _sdf);
+    /// \param[in] sdf   The SDF Element tree containing the wave parameters.
+    void SetFromSDF(sdf::Element &sdf);
 
     /// \brief The wave algorithm (options are: 'sinusoid', 'trochoid', 'fft').
-    public: std::string Algorithm() const;
+    std::string Algorithm() const;
 
     /// \brief The size of the wave tile (m).
-    public: double TileSize() const;
+    double TileSize() const;
 
     /// \brief The number of cells in the wave tile in each direction (N). 
-    public: size_t CellCount() const;
+    Index CellCount() const;
 
     /// \brief The number of wave components (3 max if visualisation required).
-    public: size_t Number() const;
+    Index Number() const;
 
     /// \brief The angle between the mean wave direction and the
     ///        largest / smallest component waves.
-    public: double Angle() const;
+    double Angle() const;
 
     /// \brief The scale between the mean and largest / smallest
     ///        component waves.
-    public: double Scale() const;
+    double Scale() const;
 
     /// \brief A parameter in [0, 1] controlling the wave steepness
     ///        with 1 being steepest.
-    public: double Steepness() const;
+    double Steepness() const;
 
     /// \brief The angular frequency (rad/s) 
-    public: double AngularFrequency() const;
+    double AngularFrequency() const;
 
     /// \brief The amplitude of the mean wave (m).
-    public: double Amplitude() const;
+    double Amplitude() const;
 
     /// \brief The period of the mean wave (s).
-    public: double Period() const;
+    double Period() const;
 
     /// \brief The phase of the mean wave.
-    public: double Phase() const;
+    double Phase() const;
 
     /// \brief The mean wavelength (m).
-    public: double Wavelength() const;
+    double Wavelength() const;
 
     /// \brief The mean angular wavenumber (rad/m).
-    public: double Wavenumber() const;
+    double Wavenumber() const;
 
     /// \brief A two component vector specifiying the direction
     ///        of the mean wave.
-    public: math::Vector2d Direction() const;
+    math::Vector2d Direction() const;
 
     /// \brief A two component vector specifiying the horizontal
     ///        wind velocity (m/s).
-    public: math::Vector2d WindVelocity() const;
+    math::Vector2d WindVelocity() const;
 
     /// \brief The scalar wind speed (m/s).
-    public: double WindSpeed() const;
+    double WindSpeed() const;
 
     /// \brief The wind angle (counter clockwise from
     ///        positive x-axis) (rad).
-    public: double WindAngleRad() const;
+    double WindAngleRad() const;
 
     /// \brief Set the wave algorithm (options are: 'sinusoid',
     ///        'trochoid', 'fft').
     ///
-    /// \param[in] _algorithm    The wave algorithm.
-    public: void SetAlgorithm(const std::string &_algorithm);
+    /// \param[in] value  The wave algorithm.
+    void SetAlgorithm(const std::string &value);
 
     /// \brief Set the size of the wave tile (m).
     ///
-    /// \param[in] _L    The size of the wave tile (m).
-    public: void SetTileSize(double _L);
+    /// \param[in] value  The size of the wave tile (m).
+    void SetTileSize(double value);
 
     /// \brief Set the number of cells in the wave tile
     ///        in each direction. 
     ///
-    /// \param[in] _N    The number of cells.
-    public: void SetCellCount(size_t _N);
+    /// \param[in] value  The number of cells.
+    void SetCellCount(Index value);
 
     /// \brief Set the number of wave components (3 max).
     ///
-    /// \param[in] _number    The number of component waves.
-    public: void SetNumber(size_t _number);
+    /// \param[in] value  The number of component waves.
+    void SetNumber(Index value);
 
     /// \brief Set the angle parameter controlling 
     /// the direction of the component waves.
     ///
-    /// \param[in] _angle     The angle parameter.
-    public: void SetAngle(double _angle);
+    /// \param[in] value  The angle parameter.
+    void SetAngle(double value);
 
     /// \brief Set the scale parameter controlling
     /// the range of amplitudes of the component waves.
     ///
-    /// \param[in] _scale   The scale parameter.
-    public: void SetScale(double _scale);
+    /// \param[in] value  The scale parameter.
+    void SetScale(double value);
 
     /// \brief Set the steepness parameter controlling
     /// the steepness of the waves. In [0, 1].
     ///
-    /// \param[in] _steepness The steepness parameter.
-    public: void SetSteepness(double _steepness);
+    /// \param[in] value  The steepness parameter.
+    void SetSteepness(double value);
 
     /// \brief Set the mean wave amplitude (m). Must be positive.
     ///
-    /// \param[in] _amplitude The amplitude parameter (m).
-    public: void SetAmplitude(double _amplitude);
+    /// \param[in] value  The amplitude parameter (m).
+    void SetAmplitude(double value);
 
     /// \brief Set the mean wave period (s). Must be positive.
     ///
-    /// \param[in] _period The period parameter (s).
-    public: void SetPeriod(double _period);
+    /// \param[in] value  The period parameter (s).
+    void SetPeriod(double value);
 
     /// \brief Set the mean wave phase.
     ///
-    /// \param[in] _phase The phase parameter.
-    public: void SetPhase(double _phase);
+    /// \param[in] value  The phase parameter.
+    void SetPhase(double value);
 
     /// \brief Set the mean wave direction.
     ///
-    /// \param[in] _direction The direction parameter,
+    /// \param[in] value  The direction parameter,
     ///            a two component vector.
-    public: void SetDirection(const math::Vector2d& _direction);
+    void SetDirection(const math::Vector2d &value);
 
     /// \brief Set the horizontal wind velocity.
     ///
-    /// \param[in] _windVelocity The wind velocity, a two component vector.
-    public: void SetWindVelocity(const math::Vector2d& _windVelocity);
+    /// \param[in] value  The wind velocity, a two component vector.
+    void SetWindVelocity(const math::Vector2d &value);
 
     /// \brief Set the scalar wind speed and downwind angle
     ///        at 10m above MSL (m/s).
     ///
-    /// \param[in] _windSpeed    The wind speed (m/s).
-    /// \param[in] _windAngleRad The downwind angle (rad).
-    public: void SetWindSpeedAndAngle(double _windSpeed, double _windAngleRad);
+    /// \param[in] wind_speed     The wind speed (m/s).
+    /// \param[in] wind_angle_rad The downwind angle (rad).
+    void SetWindSpeedAndAngle(double wind_speed, double wind_angle_rad);
 
     /// \brief Access the component angular frequencies (rad/s).
-    public: const std::vector<double>& AngularFrequency_V() const;
+    const std::vector<double>& AngularFrequency_V() const;
 
     /// \brief Access the component amplitudes (m).
-    public: const std::vector<double>& Amplitude_V() const;
+    const std::vector<double>& Amplitude_V() const;
 
     /// \brief Access the component phases.
-    public: const std::vector<double>& Phase_V() const;
+    const std::vector<double>& Phase_V() const;
 
     /// \brief Access the steepness components.
-    public: const std::vector<double>& Steepness_V() const;
+    const std::vector<double>& Steepness_V() const;
 
     /// \brief Access the component wavenumbers (rad/m).
-    public: const std::vector<double>& Wavenumber_V() const;
+    const std::vector<double>& Wavenumber_V() const;
 
     /// \brief Access the component directions.
-    public: const std::vector<math::Vector2d>& Direction_V() const;
+    const std::vector<math::Vector2d>& Direction_V() const;
 
     /// \brief Print a summary of the wave parameters to the msg stream.
-    public: void DebugPrint() const;
+    void DebugPrint() const;
 
-    /// \internal
-    /// \brief Pointer to the class private data.
-    private: std::shared_ptr<WaveParametersPrivate> dataPtr;
+  private:
+    /// \internal Private implementation.
+    std::shared_ptr<WaveParametersPrivate> impl_;
   };
 
   typedef std::shared_ptr<WaveParameters> WaveParametersPtr; 
-
-///////////////////////////////////////////////////////////////////////////////
 
 }
 }

--- a/gz-waves/include/gz/waves/WaveSimulation.hh
+++ b/gz-waves/include/gz/waves/WaveSimulation.hh
@@ -26,96 +26,96 @@ namespace gz
 {
 namespace waves
 {
-  // evaluate wave elevation and fluid pressure
-  class IWaveField
-  {
-  public:
-    virtual ~IWaveField();
+// evaluate wave elevation and fluid pressure
+class IWaveField
+{
+ public:
+  virtual ~IWaveField();
 
-    virtual void Elevation(
-        double x, double y,
-        double &eta) = 0;
+  virtual void Elevation(
+      double x, double y,
+      double& eta) = 0;
 
-    virtual void Elevation(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        Eigen::Ref<Eigen::ArrayXd> eta) = 0;
+  virtual void Elevation(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      Eigen::Ref<Eigen::ArrayXd> eta) = 0;
 
-    virtual void Pressure(
-        double x, double y, double z,
-        double &pressure) = 0;
+  virtual void Pressure(
+      double x, double y, double z,
+      double& pressure) = 0;
 
-    virtual void Pressure(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        const Eigen::Ref<const Eigen::ArrayXd> &z,
-        Eigen::Ref<Eigen::ArrayXd> pressure) = 0;
-  };
+  virtual void Pressure(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      const Eigen::Ref<const Eigen::ArrayXd>& z,
+      Eigen::Ref<Eigen::ArrayXd> pressure) = 0;
+};
 
-  // compute a wave field on a discrete grid
-  class IWaveSimulation
-  {
-  public:
-    virtual ~IWaveSimulation();
+// compute a wave field on a discrete grid
+class IWaveSimulation
+{
+ public:
+  virtual ~IWaveSimulation();
 
-    virtual Index SizeX() const = 0;
+  virtual Index SizeX() const = 0;
 
-    virtual Index SizeY() const = 0;
+  virtual Index SizeY() const = 0;
 
-    virtual Index SizeZ() const = 0;
+  virtual Index SizeZ() const = 0;
 
-    /// \todo(srmainwaring) deprecate or move?
-    virtual void SetWindVelocity(double ux, double uy) = 0;
+  /// \todo(srmainwaring) deprecate or move?
+  virtual void SetWindVelocity(double ux, double uy) = 0;
 
-    /// \todo(srmainwaring) deprecate or move?
-    virtual void SetTime(double value) = 0;
+  /// \todo(srmainwaring) deprecate or move?
+  virtual void SetTime(double value) = 0;
 
-    // lookup interface - scalar
-    virtual void ElevationAt(
-        Index ix, Index iy,
-        double &eta) = 0;
+  // lookup interface - scalar
+  virtual void ElevationAt(
+      Index ix, Index iy,
+      double& eta) = 0;
 
-    virtual void DisplacementAt(
-        Index ix, Index iy,
-        double &sx, double &sy) = 0;
+  virtual void DisplacementAt(
+      Index ix, Index iy,
+      double& sx, double& sy) = 0;
 
-    virtual void PressureAt(
-        Index ix, Index iy, Index iz,
-        double &pressure) = 0;
+  virtual void PressureAt(
+      Index ix, Index iy, Index iz,
+      double& pressure) = 0;
 
-    // lookup interface - array
-    virtual void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> h) = 0;
+  // lookup interface - array
+  virtual void ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h) = 0;
 
-    virtual void ElevationDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy) = 0;
+  virtual void ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) = 0;
 
-    virtual void DisplacementAt(
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy) = 0;
+  virtual void DisplacementAt(
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy) = 0;
 
-    virtual void DisplacementDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) = 0;
+  virtual void DisplacementDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) = 0;
 
-    virtual void DisplacementAndDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> h,
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy,
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) = 0;
+  virtual void DisplacementAndDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> h,
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy,
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) = 0;
 
-    virtual void PressureAt(
-        Index iz,
-        Eigen::Ref<Eigen::ArrayXXd> pressure) = 0;
-  };
+  virtual void PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure) = 0;
+};
 
-}
-}
+}  // namespace waves
+}  // namespace gz
 
-#endif
+#endif  // GZ_WAVES_WAVESIMULATION_HH_

--- a/gz-waves/include/gz/waves/WaveSimulation.hh
+++ b/gz-waves/include/gz/waves/WaveSimulation.hh
@@ -18,15 +18,14 @@
 
 #include <Eigen/Dense>
 
+#include "gz/waves/Types.hh"
+
 using Eigen::ArrayXXd;
 
 namespace gz
 {
 namespace waves
 {
-  /// \todo(srmainwaring) move to separate file.
-  typedef std::ptrdiff_t Index;
-
   // evaluate wave elevation and fluid pressure
   class IWaveField
   {

--- a/gz-waves/include/gz/waves/WaveSpectrum.hh
+++ b/gz-waves/include/gz/waves/WaveSpectrum.hh
@@ -17,89 +17,87 @@
 #define GZ_WAVES_WAVESPECTRUM_HH_
 
 #include <Eigen/Dense>
- 
+
 using Eigen::ArrayXXd;
 
 namespace gz
 {
 namespace waves
 {
-inline namespace v2
+class OmniDirectionalWaveSpectrum
 {
-  class OmniDirectionalWaveSpectrum
-  {
-  public:
-    virtual ~OmniDirectionalWaveSpectrum();
+ public:
+  virtual ~OmniDirectionalWaveSpectrum();
 
-    virtual double Evaluate(double k) const = 0;
+  virtual double Evaluate(double k) const = 0;
 
-    virtual void Evaluate(
-        Eigen::Ref<Eigen::ArrayXXd> spectrum,
-        const Eigen::Ref<const Eigen::ArrayXXd> &k) const = 0;
-  };
+  virtual void Evaluate(
+      Eigen::Ref<Eigen::ArrayXXd> spectrum,
+      const Eigen::Ref<const Eigen::ArrayXXd>& k) const = 0;
+};
 
-  class PiersonMoskowitzWaveSpectrum : public OmniDirectionalWaveSpectrum
-  {
-  public:
-    virtual ~PiersonMoskowitzWaveSpectrum();
+class PiersonMoskowitzWaveSpectrum : public OmniDirectionalWaveSpectrum
+{
+ public:
+  virtual ~PiersonMoskowitzWaveSpectrum();
 
-    PiersonMoskowitzWaveSpectrum(double u19=5.0, double gravity=9.81);
+  explicit PiersonMoskowitzWaveSpectrum(
+      double u19 = 5.0,
+      double gravity = 9.81);
 
-    virtual double Evaluate(double k) const override;
+  double Evaluate(double k) const override;
 
-    virtual void Evaluate(
-        Eigen::Ref<Eigen::ArrayXXd> spectrum,
-        const Eigen::Ref<const Eigen::ArrayXXd> &k) const override;
+  void Evaluate(
+      Eigen::Ref<Eigen::ArrayXXd> spectrum,
+      const Eigen::Ref<const Eigen::ArrayXXd>& k) const override;
 
-    double Gravity() const;
+  double Gravity() const;
 
-    void SetGravity(double value);
+  void SetGravity(double value);
 
-    double U19() const;
+  double U19() const;
 
-    void SetU19(double value);
+  void SetU19(double value);
 
-  private:
-    double gravity_{9.81};
-    double u19_{5.0};
-  };
+ private:
+  double gravity_{9.81};
+  double u19_{5.0};
+};
 
-  class ECKVWaveSpectrum : public OmniDirectionalWaveSpectrum
-  {
-  public:
-    virtual ~ECKVWaveSpectrum();
+class ECKVWaveSpectrum : public OmniDirectionalWaveSpectrum
+{
+ public:
+  virtual ~ECKVWaveSpectrum();
 
-    ECKVWaveSpectrum(
-        double u10=5.0,
-        double cap_omega_c=0.84,
-        double gravity=9.81);
+  explicit ECKVWaveSpectrum(
+      double u10 = 5.0,
+      double cap_omega_c = 0.84,
+      double gravity = 9.81);
 
-    virtual double Evaluate(double k) const override;
+  double Evaluate(double k) const override;
 
-    virtual void Evaluate(
-        Eigen::Ref<Eigen::ArrayXXd> spectrum,
-        const Eigen::Ref<const Eigen::ArrayXXd> &k) const override;
+  void Evaluate(
+      Eigen::Ref<Eigen::ArrayXXd> spectrum,
+      const Eigen::Ref<const Eigen::ArrayXXd>& k) const override;
 
-    double Gravity() const;
+  double Gravity() const;
 
-    void SetGravity(double value);
+  void SetGravity(double value);
 
-    double U10() const;
+  double U10() const;
 
-    void SetU10(double value);
+  void SetU10(double value);
 
-    double CapOmegaC() const;
+  double CapOmegaC() const;
 
-    void SetCapOmegaC(double value);
+  void SetCapOmegaC(double value);
 
-  private:
-    double gravity_{9.81};
-    double u10_{5.0};
-    double cap_omega_c_{0.84};
-  };
+ private:
+  double gravity_{9.81};
+  double u10_{5.0};
+  double cap_omega_c_{0.84};
+};
+}  // namespace waves
+}  // namespace gz
 
-}
-}
-}
-
-#endif
+#endif  // GZ_WAVES_WAVESPECTRUM_HH_

--- a/gz-waves/include/gz/waves/WaveSpreadingFunction.hh
+++ b/gz-waves/include/gz/waves/WaveSpreadingFunction.hh
@@ -13,102 +13,99 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef GZ_WAVE_SPREADING_FUNCTION_HH_
-#define GZ_WAVE_SPREADING_FUNCTION_HH_
+#ifndef GZ_WAVES_WAVESPREADINGFUNCTION_HH_
+#define GZ_WAVES_WAVESPREADINGFUNCTION_HH_
 
 #include <Eigen/Dense>
- 
+
 using Eigen::ArrayXXd;
- 
+
 namespace gz
 {
 namespace waves
 {
-inline namespace v2
+class DirectionalSpreadingFunction
 {
-  class DirectionalSpreadingFunction
-  {
-  public:
-    virtual ~DirectionalSpreadingFunction();
+ public:
+  virtual ~DirectionalSpreadingFunction();
 
-    virtual double Evaluate(
-        double theta, double theta_mean, double k=1.0) const = 0;
+  virtual double Evaluate(
+      double theta, double theta_mean, double k = 1.0) const = 0;
 
-    virtual void Evaluate(
-        Eigen::Ref<Eigen::ArrayXXd> phi,
-        const Eigen::Ref<const Eigen::ArrayXXd> &theta,
-        double theta_mean,
-        const Eigen::Ref<const Eigen::ArrayXXd> &k=Eigen::ArrayXXd())
-        const = 0;
-  };
+  virtual void Evaluate(
+      Eigen::Ref<Eigen::ArrayXXd> phi,
+      const Eigen::Ref<const Eigen::ArrayXXd>& theta,
+      double theta_mean,
+      const Eigen::Ref<const Eigen::ArrayXXd>& k = Eigen::ArrayXXd())
+      const = 0;
+};
 
-  class Cos2sSpreadingFunction : public DirectionalSpreadingFunction
-  {
-  public:
-    virtual ~Cos2sSpreadingFunction();
+class Cos2sSpreadingFunction : public DirectionalSpreadingFunction
+{
+ public:
+  virtual ~Cos2sSpreadingFunction();
 
-    Cos2sSpreadingFunction(double spread=10.0);
+  explicit Cos2sSpreadingFunction(double spread = 10.0);
 
-    virtual double Evaluate(
-        double theta, double theta_mean, double k=1.0) const override;
+  double Evaluate(
+      double theta, double theta_mean, double k = 1.0) const override;
 
-    virtual void Evaluate(
-        Eigen::Ref<Eigen::ArrayXXd> phi,
-        const Eigen::Ref<const Eigen::ArrayXXd> &theta,
-        double theta_mean,
-        const Eigen::Ref<const Eigen::ArrayXXd> &k=Eigen::ArrayXXd())
-        const override;
+  void Evaluate(
+      Eigen::Ref<Eigen::ArrayXXd> phi,
+      const Eigen::Ref<const Eigen::ArrayXXd>& theta,
+      double theta_mean,
+      const Eigen::Ref<const Eigen::ArrayXXd>& k = Eigen::ArrayXXd())
+      const override;
 
-    double Spread() const;
+  double Spread() const;
 
-    void SetSpread(double value);
+  void SetSpread(double value);
 
-  private:
-    void RecalcCoeffs();
+ private:
+  void RecalcCoeffs();
 
-    double spread_{10.0};
-    double cap_c_s_{0.0};
-  };
+  double spread_{10.0};
+  double cap_c_s_{0.0};
+};
 
-  class ECKVSpreadingFunction : public DirectionalSpreadingFunction
-  {
-  public:
-    virtual ~ECKVSpreadingFunction();
+class ECKVSpreadingFunction : public DirectionalSpreadingFunction
+{
+ public:
+  virtual ~ECKVSpreadingFunction();
 
-    ECKVSpreadingFunction(
-        double u10=5.0,
-        double cap_omega_c=0.84,
-        double gravity=9.81);
+  explicit ECKVSpreadingFunction(
+      double u10 = 5.0,
+      double cap_omega_c = 0.84,
+      double gravity = 9.81);
 
-    virtual double Evaluate(
-        double theta, double theta_mean, double k=1.0) const override;
+  double Evaluate(
+      double theta, double theta_mean, double k = 1.0) const override;
 
-    virtual void Evaluate(
-        Eigen::Ref<Eigen::ArrayXXd> phi,
-        const Eigen::Ref<const Eigen::ArrayXXd> &theta,
-        double theta_mean,
-        const Eigen::Ref<const Eigen::ArrayXXd> &k=Eigen::ArrayXXd())
-        const override;
+  void Evaluate(
+      Eigen::Ref<Eigen::ArrayXXd> phi,
+      const Eigen::Ref<const Eigen::ArrayXXd>& theta,
+      double theta_mean,
+      const Eigen::Ref<const Eigen::ArrayXXd>& k = Eigen::ArrayXXd())
+      const override;
 
-    double Gravity() const;
+  double Gravity() const;
 
-    void SetGravity(double value);
+  void SetGravity(double value);
 
-    double U10() const;
+  double U10() const;
 
-    void SetU10(double value);
+  void SetU10(double value);
 
-    double CapOmegaC() const;
+  double CapOmegaC() const;
 
-    void SetCapOmegaC(double value);
+  void SetCapOmegaC(double value);
 
-  private:
-    double gravity_{9.81};
-    double u10_{5.0};
-    double cap_omega_c_{0.84};
-  };
-}
-}
-}
+ private:
+  double gravity_{9.81};
+  double u10_{5.0};
+  double cap_omega_c_{0.84};
+};
+}  // namespace waves
+}  // namespace gz
 
-#endif
+#endif  // GZ_WAVES_WAVESPREADINGFUNCTION_HH_

--- a/gz-waves/include/gz/waves/Wavefield.hh
+++ b/gz-waves/include/gz/waves/Wavefield.hh
@@ -14,18 +14,18 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /// \file Wavefield.hh
-/// \brief This file contains definitions for the class used to manage
-/// a wave field.
+/// \brief A class to interact with a wave field.
 
 #ifndef GZ_WAVES_WAVEFIELD_HH_
 #define GZ_WAVES_WAVEFIELD_HH_
 
-#include "gz/waves/CGALTypes.hh"
+#include <memory>
+#include <string>
 
 #include <gz/math.hh>
 
-#include <memory>
-#include <string>
+#include "gz/waves/CGALTypes.hh"
+
 
 namespace gz
 {
@@ -37,31 +37,32 @@ namespace waves
   /// \brief A class to manage a wave field.
   class Wavefield
   {
-    /// Destructor.
-    public: virtual ~Wavefield();
+  public:
+    /// \brief Destructor.
+    virtual ~Wavefield();
 
-    /// Constructor.
-    public: Wavefield(const std::string &_worldName);
+    /// \brief Constructor.
+    Wavefield(const std::string &world_name);
 
-    // Compute the height at a point.
-    public: bool Height(const cgal::Point3& point, double& height) const;
+    /// \brief Compute the height at a point (vertical distance to surface).
+    bool Height(const cgal::Point3 &point, double &height) const;
 
     /// \brief Get the wave parameters.
-    public: std::shared_ptr<const WaveParameters> GetParameters() const;
+    std::shared_ptr<const WaveParameters> GetParameters() const;
 
     /// \brief Set the wave parameters.
     ///
-    /// \param[in] _params    The new wave parameters.
-    public: void SetParameters(std::shared_ptr<WaveParameters> _params);
+    /// \param[in] params    The new wave parameters.
+    void SetParameters(std::shared_ptr<WaveParameters> params);
 
     /// \brief Update (recalculate) the wave field for the given time.
     ///
-    /// \param[in] _time    The time parameter for the wave evolution.
-    public: void Update(double _time);
+    /// \param[in] time    The time parameter for the wave evolution.
+    void Update(double time);
 
-    /// \internal
-    /// \brief Pointer to the class private data.
-    private: std::shared_ptr<WavefieldPrivate> dataPtr;
+  private:
+    /// \internal Private implementation.
+    std::shared_ptr<WavefieldPrivate> impl_;
   };
 
   typedef std::shared_ptr<Wavefield> WavefieldPtr;

--- a/gz-waves/include/gz/waves/Wavefield.hh
+++ b/gz-waves/include/gz/waves/Wavefield.hh
@@ -26,48 +26,47 @@
 
 #include "gz/waves/CGALTypes.hh"
 
-
 namespace gz
 {
 namespace waves
 {
-  class WaveParameters;
-  class WavefieldPrivate;
+class WaveParameters;
+class WavefieldPrivate;
 
-  /// \brief A class to manage a wave field.
-  class Wavefield
-  {
-  public:
-    /// \brief Destructor.
-    virtual ~Wavefield();
+/// \brief A class to manage a wave field.
+class Wavefield
+{
+ public:
+  /// \brief Destructor.
+  virtual ~Wavefield();
 
-    /// \brief Constructor.
-    Wavefield(const std::string &world_name);
+  /// \brief Constructor.
+  explicit Wavefield(const std::string& world_name);
 
-    /// \brief Compute the height at a point (vertical distance to surface).
-    bool Height(const cgal::Point3 &point, double &height) const;
+  /// \brief Compute the height at a point (vertical distance to surface).
+  bool Height(const cgal::Point3& point, double& height) const;
 
-    /// \brief Get the wave parameters.
-    std::shared_ptr<const WaveParameters> GetParameters() const;
+  /// \brief Get the wave parameters.
+  std::shared_ptr<const WaveParameters> GetParameters() const;
 
-    /// \brief Set the wave parameters.
-    ///
-    /// \param[in] params    The new wave parameters.
-    void SetParameters(std::shared_ptr<WaveParameters> params);
+  /// \brief Set the wave parameters.
+  ///
+  /// \param[in] params    The new wave parameters.
+  void SetParameters(std::shared_ptr<WaveParameters> params);
 
-    /// \brief Update (recalculate) the wave field for the given time.
-    ///
-    /// \param[in] time    The time parameter for the wave evolution.
-    void Update(double time);
+  /// \brief Update (recalculate) the wave field for the given time.
+  ///
+  /// \param[in] time    The time parameter for the wave evolution.
+  void Update(double time);
 
-  private:
-    /// \internal Private implementation.
-    std::shared_ptr<WavefieldPrivate> impl_;
-  };
+ private:
+  /// \internal Private implementation.
+  std::shared_ptr<WavefieldPrivate> impl_;
+};
 
-  typedef std::shared_ptr<Wavefield> WavefieldPtr;
-  typedef std::weak_ptr<Wavefield> WavefieldWeakPtr;
-}
-}
+typedef std::shared_ptr<Wavefield> WavefieldPtr;
+typedef std::weak_ptr<Wavefield> WavefieldWeakPtr;
+}  // namespace waves
+}  // namespace gz
 
-#endif
+#endif  // GZ_WAVES_WAVEFIELD_HH_

--- a/gz-waves/include/gz/waves/WavefieldSampler.hh
+++ b/gz-waves/include/gz/waves/WavefieldSampler.hh
@@ -18,11 +18,12 @@
 #ifndef GZ_WAVES_WAVEFIELDSAMPLER_HH_
 #define GZ_WAVES_WAVEFIELDSAMPLER_HH_
 
-#include "gz/waves/CGALTypes.hh"
+#include <memory>
 
 #include <gz/math/Pose3.hh>
 
-#include <memory>
+#include "gz/waves/CGALTypes.hh"
+
 
 namespace gz
 {
@@ -39,63 +40,64 @@ namespace waves
   /// \brief A class to manage sampling depths from a wave field.
   class WavefieldSampler
   {
+  public:
     /// \brief Destructor
-    public: ~WavefieldSampler();
+    ~WavefieldSampler();
 
     /// \brief Constructor
     ///
-    /// \param[in] _wavefield     The wave field being sampled.
-    /// \param[in] _waterPatch    The area of the wave field being sampled.
-    public: WavefieldSampler(
-      std::shared_ptr<const Wavefield> _wavefield,
-      std::shared_ptr<const Grid> _waterPatch);
+    /// \param[in] wavefield  The wave field being sampled.
+    /// \param[in] patch      The area of the wave field being sampled.
+    WavefieldSampler(
+      std::shared_ptr<const Wavefield> wavefield,
+      std::shared_ptr<const Grid> patch);
 
     /// \brief Get the water patch (i.e. the area of the wave field sampled).
-    public: std::shared_ptr<const Grid> GetWaterPatch() const;
+    std::shared_ptr<const Grid> GetWaterPatch() const;
 
     /// \brief Translate the initial water patch using the Pose X Y coordinates.
     ///
-    /// \param[in] _pose    The pose of the rigid body the water patch supports.
-    public: void ApplyPose(const math::Pose3d& _pose);
+    /// \param[in] pose     The pose of the rigid body the water patch supports.
+    void ApplyPose(const math::Pose3d &pose);
 
     /// \brief Update the water patch 
-    public: void UpdatePatch();
+    void UpdatePatch();
 
     /// \brief Compute the depth at a point.
     ///
-    /// \param[in] _point       The point at which we want the depth
-    /// \return                 The depth 'h' at the point.
-    public: double ComputeDepth(const cgal::Point3& _point) const;
+    /// \param[in] point       The point at which we want the depth
+    /// \return                The depth 'h' at the point.
+    double ComputeDepth(const cgal::Point3 &point) const;
 
     /// \brief Compute the depth at a point.
     ///
-    /// \param[in] _patch       A water patch. 
-    /// \param[in] _point       The point at which we want the depth
-    /// \return                 The depth 'h' at the point.
-    public: static double ComputeDepth(const Grid& _patch, const cgal::Point3& _point);
+    /// \param[in] patch       A water patch. 
+    /// \param[in] point       The point at which we want the depth
+    /// \return                The depth 'h' at the point.
+    static double ComputeDepth(const Grid &patch, const cgal::Point3 &point);
 
-    /// \brief Compute the depth at a point directly (no sampling or interpolation).
+    /// \brief Compute the depth at a point directly (no sampling).
     ///
-    /// This method solves for (x, y) that when input into the Gerstner wave function
-    /// gives the coordinates of the supplied parameter _point (_point.x(), _point.y()),
-    /// and also computes the wave height pz at this point.
-    /// The depth h = pz - point.z().  
-    /// This is a numerical method that uses a multi-variate Newton solver to solve
-    /// the two dimensional non-linear system. In general it is not as fast as
-    /// sampling from a discretised wave field with an efficient line intersection
-    /// algorithm.
+    /// This method solves for (x, y) that when input into the Gerstner
+    /// wave function gives the coordinates of the supplied parameter point
+    /// (point.x(), point.y()), and also computes the wave height pz at this
+    /// point. The depth h = pz - point.z().  
+    /// This is a numerical method that uses a multi-variate Newton solver
+    /// to solve the two dimensional non-linear system. In general it is not
+    /// as fast as sampling from a discretised wave field with an efficient
+    /// line intersection algorithm.
     ///
-    /// \param[in] _waveParams  Gerstner wave parameters. 
-    /// \param[in] _point       The point at which we want the depth.
+    /// \param[in] wave_params  Gerstner wave parameters. 
+    /// \param[in] point       The point at which we want the depth.
     /// \return                 The depth 'h' at the point.
-    public: static double ComputeDepthDirectly(
-      const WaveParameters& _waveParams,
-      const cgal::Point3& _point,
+    static double ComputeDepthDirectly(
+      const WaveParameters &wave_params,
+      const cgal::Point3 &point,
       double time);
-
-    /// \internal
-    /// \brief Pointer to the class private data.
-    private: std::shared_ptr<WavefieldSamplerPrivate> data;
+  
+  private:
+    /// \internal Private implementation.
+    std::shared_ptr<WavefieldSamplerPrivate> impl_;
   };
 
   typedef std::shared_ptr<WavefieldSampler> WavefieldSamplerPtr;

--- a/gz-waves/include/gz/waves/WavefieldSampler.hh
+++ b/gz-waves/include/gz/waves/WavefieldSampler.hh
@@ -29,79 +29,80 @@ namespace gz
 {
 namespace waves
 {
-  class Grid;
-  class Wavefield;
-  class WaveParameters;
+class Grid;
+class Wavefield;
+class WaveParameters;
 
-  /// \internal
-  /// \brief Class to hold private data for WavefieldSampler.
-  class WavefieldSamplerPrivate;
-  
-  /// \brief A class to manage sampling depths from a wave field.
-  class WavefieldSampler
-  {
-  public:
-    /// \brief Destructor
-    ~WavefieldSampler();
+/// \internal
+/// \brief Class to hold private data for WavefieldSampler.
+class WavefieldSamplerPrivate;
 
-    /// \brief Constructor
-    ///
-    /// \param[in] wavefield  The wave field being sampled.
-    /// \param[in] patch      The area of the wave field being sampled.
-    WavefieldSampler(
-      std::shared_ptr<const Wavefield> wavefield,
-      std::shared_ptr<const Grid> patch);
+/// \brief A class to manage sampling depths from a wave field.
+class WavefieldSampler
+{
+ public:
+  /// \brief Destructor
+  ~WavefieldSampler();
 
-    /// \brief Get the water patch (i.e. the area of the wave field sampled).
-    std::shared_ptr<const Grid> GetWaterPatch() const;
+  /// \brief Constructor
+  ///
+  /// \param[in] wavefield  The wave field being sampled.
+  /// \param[in] patch      The area of the wave field being sampled.
+  WavefieldSampler(
+    std::shared_ptr<const Wavefield> wavefield,
+    std::shared_ptr<const Grid> patch);
 
-    /// \brief Translate the initial water patch using the Pose X Y coordinates.
-    ///
-    /// \param[in] pose     The pose of the rigid body the water patch supports.
-    void ApplyPose(const math::Pose3d &pose);
+  /// \brief Get the water patch (i.e. the area of the wave field sampled).
+  std::shared_ptr<const Grid> GetWaterPatch() const;
 
-    /// \brief Update the water patch 
-    void UpdatePatch();
+  /// \brief Translate the initial water patch using the Pose X Y coordinates.
+  ///
+  /// \param[in] pose     The pose of the rigid body the water patch supports.
+  void ApplyPose(const math::Pose3d& pose);
 
-    /// \brief Compute the depth at a point.
-    ///
-    /// \param[in] point       The point at which we want the depth
-    /// \return                The depth 'h' at the point.
-    double ComputeDepth(const cgal::Point3 &point) const;
+  /// \brief Update the water patch
+  void UpdatePatch();
 
-    /// \brief Compute the depth at a point.
-    ///
-    /// \param[in] patch       A water patch. 
-    /// \param[in] point       The point at which we want the depth
-    /// \return                The depth 'h' at the point.
-    static double ComputeDepth(const Grid &patch, const cgal::Point3 &point);
+  /// \brief Compute the depth at a point.
+  ///
+  /// \param[in] point       The point at which we want the depth
+  /// \return                The depth 'h' at the point.
+  double ComputeDepth(const cgal::Point3& point) const;
 
-    /// \brief Compute the depth at a point directly (no sampling).
-    ///
-    /// This method solves for (x, y) that when input into the Gerstner
-    /// wave function gives the coordinates of the supplied parameter point
-    /// (point.x(), point.y()), and also computes the wave height pz at this
-    /// point. The depth h = pz - point.z().  
-    /// This is a numerical method that uses a multi-variate Newton solver
-    /// to solve the two dimensional non-linear system. In general it is not
-    /// as fast as sampling from a discretised wave field with an efficient
-    /// line intersection algorithm.
-    ///
-    /// \param[in] wave_params  Gerstner wave parameters. 
-    /// \param[in] point       The point at which we want the depth.
-    /// \return                 The depth 'h' at the point.
-    static double ComputeDepthDirectly(
-      const WaveParameters &wave_params,
-      const cgal::Point3 &point,
-      double time);
-  
-  private:
-    /// \internal Private implementation.
-    std::shared_ptr<WavefieldSamplerPrivate> impl_;
-  };
+  /// \brief Compute the depth at a point.
+  ///
+  /// \param[in] patch       A water patch.
+  /// \param[in] point       The point at which we want the depth
+  /// \return                The depth 'h' at the point.
+  static double ComputeDepth(const Grid& patch, const cgal::Point3& point);
 
-  typedef std::shared_ptr<WavefieldSampler> WavefieldSamplerPtr;
-}
-}
+  /// \brief Compute the depth at a point directly (no sampling).
+  ///
+  /// This method solves for (x, y) that when input into the Gerstner
+  /// wave function gives the coordinates of the supplied parameter point
+  /// (point.x(), point.y()), and also computes the wave height pz at this
+  /// point. The depth h = pz - point.z().
+  /// This is a numerical method that uses a multi-variate Newton solver
+  /// to solve the two dimensional non-linear system. In general it is not
+  /// as fast as sampling from a discretised wave field with an efficient
+  /// line intersection algorithm.
+  ///
+  /// \param[in] wave_params  Gerstner wave parameters.
+  /// \param[in] point       The point at which we want the depth.
+  /// \return                 The depth 'h' at the point.
+  static double ComputeDepthDirectly(
+    const WaveParameters& wave_params,
+    const cgal::Point3& point,
+    double time);
 
-#endif
+ private:
+  /// \internal Private implementation.
+  std::shared_ptr<WavefieldSamplerPrivate> impl_;
+};
+
+typedef std::shared_ptr<WavefieldSampler> WavefieldSamplerPtr;
+
+}  // namespace waves
+}  // namespace gz
+
+#endif  // GZ_WAVES_WAVEFIELDSAMPLER_HH_

--- a/gz-waves/src/Algorithm_TEST.cc
+++ b/gz-waves/src/Algorithm_TEST.cc
@@ -15,11 +15,13 @@
 
 #include "gz/waves/Algorithm.hh"
 
-#include <gtest/gtest.h>
-
 #include <array>
 #include <iostream>
 #include <string>
+
+#include <gtest/gtest.h>
+
+#include "gz/waves/Types.hh"
 
 using namespace gz;
 using namespace waves;
@@ -32,14 +34,14 @@ TEST(Algorithm, SortIndexArray2)
 {
   { // Case 1
     std::array<double, 2> v {0, 1};
-    std::array<size_t, 2> idx = sort_indexes(v);
+    std::array<Index, 2> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 1.0);
     EXPECT_EQ(v[idx[1]], 0.0);
   }
 
   { // Case 2
     std::array<double, 2> v {1, 0};
-    std::array<size_t, 2> idx = sort_indexes(v);
+    std::array<Index, 2> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 1.0);
     EXPECT_EQ(v[idx[1]], 0.0);
   } 
@@ -49,14 +51,14 @@ TEST(Algorithm, SortIndexVector2)
 {
   { // Case 1
     std::vector<double> v {0, 1};
-    std::vector<size_t> idx = sort_indexes(v);
+    std::vector<Index> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 1.0);
     EXPECT_EQ(v[idx[1]], 0.0);
   }
 
   { // Case 2
     std::vector<double> v {1, 0};
-    std::vector<size_t> idx = sort_indexes(v);
+    std::vector<Index> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 1.0);
     EXPECT_EQ(v[idx[1]], 0.0);
   }  
@@ -66,7 +68,7 @@ TEST(Algorithm, SortIndex3)
 {
   { // Case 1
     std::vector<double> v {0, 1, 2};
-    std::vector<size_t> idx = sort_indexes(v);
+    std::vector<Index> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
@@ -74,7 +76,7 @@ TEST(Algorithm, SortIndex3)
 
   { // Case 2
     std::vector<double> v {0, 2, 1};
-    std::vector<size_t> idx = sort_indexes(v);
+    std::vector<Index> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
@@ -82,7 +84,7 @@ TEST(Algorithm, SortIndex3)
 
   { // Case 3
     std::vector<double> v {1, 0, 2};
-    std::vector<size_t> idx = sort_indexes(v);
+    std::vector<Index> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
@@ -90,7 +92,7 @@ TEST(Algorithm, SortIndex3)
 
   { // Case 4
     std::vector<double> v {1, 2, 0};
-    std::vector<size_t> idx = sort_indexes(v);
+    std::vector<Index> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
@@ -98,7 +100,7 @@ TEST(Algorithm, SortIndex3)
 
   { // Case 5
     std::vector<double> v {2, 0, 1};
-    std::vector<size_t> idx = sort_indexes(v);
+    std::vector<Index> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
@@ -106,7 +108,7 @@ TEST(Algorithm, SortIndex3)
 
   { // Case 6
     std::vector<double> v {2, 1, 0};
-    std::vector<size_t> idx = sort_indexes(v);
+    std::vector<Index> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);

--- a/gz-waves/src/Algorithm_TEST.cc
+++ b/gz-waves/src/Algorithm_TEST.cc
@@ -13,23 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "gz/waves/Algorithm.hh"
+#include <gtest/gtest.h>
 
 #include <array>
 #include <iostream>
 #include <string>
 
-#include <gtest/gtest.h>
-
+#include "gz/waves/Algorithm.hh"
 #include "gz/waves/Types.hh"
 
-using namespace gz;
-using namespace waves;
-using namespace algorithm;
+using gz::waves::Index;
+using gz::waves::algorithm::sort_indexes;
 
-///////////////////////////////////////////////////////////////////////////////
-// Define tests
-
+//////////////////////////////////////////////////
 TEST(Algorithm, SortIndexArray2)
 {
   { // Case 1
@@ -44,9 +40,10 @@ TEST(Algorithm, SortIndexArray2)
     std::array<Index, 2> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 1.0);
     EXPECT_EQ(v[idx[1]], 0.0);
-  } 
+  }
 }
 
+//////////////////////////////////////////////////
 TEST(Algorithm, SortIndexVector2)
 {
   { // Case 1
@@ -61,9 +58,10 @@ TEST(Algorithm, SortIndexVector2)
     std::vector<Index> idx = sort_indexes(v);
     EXPECT_EQ(v[idx[0]], 1.0);
     EXPECT_EQ(v[idx[1]], 0.0);
-  }  
+  }
 }
 
+//////////////////////////////////////////////////
 TEST(Algorithm, SortIndex3)
 {
   { // Case 1
@@ -72,7 +70,7 @@ TEST(Algorithm, SortIndex3)
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
-  }  
+  }
 
   { // Case 2
     std::vector<double> v {0, 2, 1};
@@ -80,7 +78,7 @@ TEST(Algorithm, SortIndex3)
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
-  }  
+  }
 
   { // Case 3
     std::vector<double> v {1, 0, 2};
@@ -88,7 +86,7 @@ TEST(Algorithm, SortIndex3)
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
-  }  
+  }
 
   { // Case 4
     std::vector<double> v {1, 2, 0};
@@ -96,7 +94,7 @@ TEST(Algorithm, SortIndex3)
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
-  }  
+  }
 
   { // Case 5
     std::vector<double> v {2, 0, 1};
@@ -104,7 +102,7 @@ TEST(Algorithm, SortIndex3)
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
-  }  
+  }
 
   { // Case 6
     std::vector<double> v {2, 1, 0};
@@ -112,13 +110,10 @@ TEST(Algorithm, SortIndex3)
     EXPECT_EQ(v[idx[0]], 2.0);
     EXPECT_EQ(v[idx[1]], 1.0);
     EXPECT_EQ(v[idx[2]], 0.0);
-  }  
-
+  }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Run tests
-
+//////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/gz-waves/src/CGAL_TEST.cc
+++ b/gz-waves/src/CGAL_TEST.cc
@@ -13,6 +13,25 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <gtest/gtest.h>
+
+#include <CGAL/AABB_face_graph_triangle_primitive.h>
+#include <CGAL/AABB_tree.h>
+#include <CGAL/AABB_traits.h>
+#include <CGAL/number_utils.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Timer.h>
+#include <CGAL/boost/graph/Euler_operations.h>
+
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <list>
+#include <memory>
+#include <string>
+
 #include "gz/waves/Geometry.hh"
 #include "gz/waves/Grid.hh"
 #include "gz/waves/MeshTools.hh"
@@ -26,89 +45,77 @@
 #include <gz/math/Vector3.hh>
 #include <gz/math/Triangle.hh>
 
-#include <CGAL/AABB_face_graph_triangle_primitive.h>
-#include <CGAL/AABB_tree.h>
-#include <CGAL/AABB_traits.h>
-#include <CGAL/number_utils.h>
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Simple_cartesian.h>
-#include <CGAL/Surface_mesh.h>
-#include <CGAL/Timer.h>
+namespace waves
+{
+using gz::waves::Grid;
+using gz::waves::MeshTools;
+using gz::waves::TriangulatedGrid;
+using gz::waves::Wavefield;
+using gz::waves::WaveParameters;
+}
 
-#include <CGAL/boost/graph/Euler_operations.h>
-
-// #include <tbb/tbb.h>
-
-#include <gtest/gtest.h>
-
-#include <algorithm>
-#include <iostream>
-#include <iterator>
-#include <list>
-#include <memory>
-#include <string>
-
-using namespace gz;
-
-///////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////
 // Utilities
 
 // Extract a triangle from a face
-namespace {
-  typedef CGAL::Simple_cartesian<double> K;
-  typedef K::Triangle_3 Triangle;
-  typedef K::Point_3 Point3;
-  typedef K::Vector_3 Vector3;
-  typedef CGAL::Surface_mesh<K::Point_3> Mesh;
-  typedef Mesh::Face_index Face_descriptor;
-  typedef Mesh::Halfedge_index Halfedge_descriptor;  
+namespace
+{
+typedef CGAL::Simple_cartesian<double> K;
+typedef K::Triangle_3 Triangle;
+typedef K::Point_3 Point3;
+typedef K::Vector_3 Vector3;
+typedef CGAL::Surface_mesh<K::Point_3> Mesh;
+typedef Mesh::Face_index Face_descriptor;
+typedef Mesh::Halfedge_index Halfedge_descriptor;
 
-  std::shared_ptr<cgal::Mesh> CreateSphere(
-    const std::string& meshName,
-    double radius
-  )
-  {
-    gz::common::MeshManager::Instance()->CreateSphere(
-      meshName,
-      radius,                   // radius
-      32,                       // rings
-      32);                      // segments
-    GZ_ASSERT(gz::common::MeshManager::Instance()->HasMesh(meshName),
-      "Failed to create Mesh for Cylinder");
+std::shared_ptr<gz::cgal::Mesh> CreateSphere(
+  const std::string& meshName,
+  double radius
+)
+{
+  gz::common::MeshManager::Instance()->CreateSphere(
+    meshName,
+    radius,                   // radius
+    32,                       // rings
+    32);                      // segments
+  GZ_ASSERT(gz::common::MeshManager::Instance()->HasMesh(meshName),
+    "Failed to create Mesh for Cylinder");
 
-    const gz::common::Mesh* source =
-        gz::common::MeshManager::Instance()->MeshByName(meshName);
-    GZ_ASSERT(source != nullptr, "Invalid Sphere Mesh");
-    // std::cout << "Mesh:       " << source->GetName() << std::endl;
-    // std::cout << "Vertex:     " << source->GetVertexCount() << std::endl;
+  const gz::common::Mesh* source =
+      gz::common::MeshManager::Instance()->MeshByName(meshName);
+  GZ_ASSERT(source != nullptr, "Invalid Sphere Mesh");
+  // std::cout << "Mesh:       " << source->GetName() << "\n";
+  // std::cout << "Vertex:     " << source->GetVertexCount() << "\n";
 
-    std::shared_ptr<cgal::Mesh> target = std::make_shared<cgal::Mesh>();
-    waves::MeshTools::MakeSurfaceMesh(*source, *target);
-    return target;
-  }
+  std::shared_ptr<gz::cgal::Mesh> target = std::make_shared<gz::cgal::Mesh>();
+  waves::MeshTools::MakeSurfaceMesh(*source, *target);
+  return target;
+}
+}  // namespace
 
-} // namespace (anon)
-
-///////////////////////////////////////////////////////////////////////////////
-// Define tests
+//////////////////////////////////////////////////
 TEST(CGAL, Surprising) {
   typedef CGAL::Simple_cartesian<double> Kernel;
   typedef Kernel::Point_2 Point_2;
 
   {
     Point_2 p(0, 0.3), q(1, 0.6), r(2, 0.9);
-    // std::cout << (CGAL::collinear(p,q,r) ? "collinear\n" : "not collinear\n");   
+    // std::cout << (CGAL::collinear(p,q,r) ?
+    //  "collinear\n" : "not collinear\n");
   }
   {
     Point_2 p(0, 1.0/3.0), q(1, 2.0/3.0), r(2, 1);
-    // std::cout << (CGAL::collinear(p,q,r) ? "collinear\n" : "not collinear\n");   
-  }  
+    // std::cout << (CGAL::collinear(p,q,r) ?
+    //  "collinear\n" : "not collinear\n");
+  }
   {
-    Point_2 p(0,0), q(1, 1), r(2, 2);
-    // std::cout << (CGAL::collinear(p,q,r) ? "collinear\n" : "not collinear\n");   
-  }  
+    Point_2 p(0, 0), q(1, 1), r(2, 2);
+    // std::cout << (CGAL::collinear(p,q,r) ?
+    //  "collinear\n" : "not collinear\n");
+  }
 }
 
+//////////////////////////////////////////////////
 TEST(CGAL, SurfaceMesh) {
   typedef CGAL::Simple_cartesian<double> K;
   typedef K::Point_3 Point3;
@@ -119,8 +126,10 @@ TEST(CGAL, SurfaceMesh) {
   typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
   typedef CGAL::AABB_traits<K, Primitive> Traits;
   typedef CGAL::AABB_tree<Traits> Tree;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
-  typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
+  typedef boost::optional<Tree::Intersection_and_primitive_id<Segment>::Type>
+  Segment_intersection;
+  typedef boost::optional<Tree::Intersection_and_primitive_id<Plane>::Type>
+  Plane_intersection;
   typedef Tree::Primitive_id Primitive_id;
 
   Point3 p(1.0, 0.0, 0.0);
@@ -136,58 +145,60 @@ TEST(CGAL, SurfaceMesh) {
   // constructs segment query
   Point3 a(-0.2, 0.2, -0.2);
   Point3 b(1.3, 0.2, 1.3);
-  Segment segment_query(a,b);
+  Segment segment_query(a, b);
 
   // tests intersections with segment query
-  if(tree.do_intersect(segment_query)) {
-      // std::cout << "intersection(s)" << std::endl;
-  }
-  else {
-    // std::cout << "no intersection" << std::endl;
+  if (tree.do_intersect(segment_query)) {
+      // std::cout << "intersection(s)" << "\n";
+  } else {
+    // std::cout << "no intersection" << "\n";
   }
 
   // computes #intersections with segment query
   // std::cout << tree.number_of_intersected_primitives(segment_query)
-  //     << " intersection(s)" << std::endl;
+  //     << " intersection(s)" << "\n";
 
   // computes first encountered intersection with segment query
   // (generally a point)
   Segment_intersection intersection =
       tree.any_intersection(segment_query);
-  if(intersection) {
+  if (intersection) {
     // gets intersection object
-    if(boost::get<Point3>(&(intersection->first))) {
+    if (boost::get<Point3>(&(intersection->first))) {
       // Point3* p = boost::get<Point3>(&(intersection->first));
-      // std::cout << "intersection object is a point " << *p <<  std::endl;
-      // std::cout << "with face "<< intersection->second  <<  std::endl;
+      // std::cout << "intersection object is a point " << *p <<  "\n";
+      // std::cout << "with face "<< intersection->second  <<  "\n";
     }
   }
 
-  // computes all intersections with segment query (as pairs object - primitive_id)
+  // computes all intersections with segment query
+  // (as pairs object - primitive_id)
   std::list<Segment_intersection> intersections;
   tree.all_intersections(segment_query, std::back_inserter(intersections));
 
   // computes all intersected primitives with segment query as primitive ids
   std::list<Primitive_id> primitives;
-  tree.all_intersected_primitives(segment_query, std::back_inserter(primitives));
+  tree.all_intersected_primitives(segment_query,
+      std::back_inserter(primitives));
 
   // constructs plane query
-  Point3 base(0.0,0.0,0.5);
-  Vector3 vec(0.0,0.0,1.0);
-  Plane plane_query(base,vec);
+  Point3 base(0.0, 0.0, 0.5);
+  Vector3 vec(0.0, 0.0, 1.0);
+  Plane plane_query(base, vec);
 
   // computes first encountered intersection with plane query
   // (generally a segment)
   Plane_intersection plane_intersection = tree.any_intersection(plane_query);
-  if(plane_intersection) {
-    if(boost::get<Segment>(&(plane_intersection->first))) {
+  if (plane_intersection) {
+    if (boost::get<Segment>(&(plane_intersection->first))) {
       // Segment* s = boost::get<Segment>(&(plane_intersection->first));
-      // std::cout << "one intersection object is the segment " << s << std::endl;
-      // std::cout << "with face "<< intersection->second  <<  std::endl;
+      // std::cout << "one intersection object is the segment " << s << "\n";
+      // std::cout << "with face "<< intersection->second  <<  "\n";
     }
   }
 }
 
+//////////////////////////////////////////////////
 /// This example based upon the examples distributed with CGAL in:
 /// CGAL-4.13/examples/AABB_tree/AABB_polyhedron_facet_intersection_example.cpp
 /// Author(s) : Camille Wormser, Pierre Alliez
@@ -210,7 +221,7 @@ TEST(CGAL, AABBPolyhedronFacetIntersection) {
   Polyhedron polyhedron;
   polyhedron.make_tetrahedron(p, q, r, s);
 
-  // constructs AABB tree and computes internal KD-tree 
+  // constructs AABB tree and computes internal KD-tree
   // data structure to accelerate distance queries
   Tree tree(faces(polyhedron).first, faces(polyhedron).second, polyhedron);
   tree.accelerate_distance_queries();
@@ -220,24 +231,25 @@ TEST(CGAL, AABBPolyhedronFacetIntersection) {
 
   // computes squared distance from query
   // FT sqd = tree.squared_distance(query);
-  // std::cout << "squared distance: " << sqd << std::endl;
+  // std::cout << "squared distance: " << sqd << "\n";
 
   // computes closest point
   // Point3 closest = tree.closest_point(query);
-  // std::cout << "closest point: " << closest << std::endl;
+  // std::cout << "closest point: " << closest << "\n";
 
   // computes closest point and primitive id
   // Point_and_primitive_id pp = tree.closest_point_and_primitive(query);
   // Point3 closest_point = pp.first;
   // Polyhedron::Face_handle f = pp.second; // closest primitive id
-  // std::cout << "closest point: " << closest_point << std::endl;
+  // std::cout << "closest point: " << closest_point << "\n";
   // std::cout << "closest triangle: ( "
-  //   << f->halfedge()->vertex()->point() << " , " 
+  //   << f->halfedge()->vertex()->point() << " , "
   //   << f->halfedge()->next()->vertex()->point() << " , "
   //   << f->halfedge()->next()->next()->vertex()->point()
-  //   << " )" << std::endl;
+  //   << " )" << "\n";
 }
 
+//////////////////////////////////////////////////
 TEST(CGAL, SurfaceMeshGridCell) {
   typedef CGAL::Simple_cartesian<double> K;
   typedef K::Point_3 Point3;
@@ -253,19 +265,22 @@ TEST(CGAL, SurfaceMeshGridCell) {
   typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
   typedef CGAL::AABB_traits<K, Primitive> Traits;
   typedef CGAL::AABB_tree<Traits> Tree;
-  // typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
-  // typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Segment>::Type>
+  // Segment_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Plane>::Type>
+  // Plane_intersection;
   // typedef Tree::Primitive_id Primitive_id;
 
-  typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
+  typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type>
+  Ray_intersection;
 
   typedef CGAL::Timer Timer;
 
   Point3 p0(-1.0, -1.0, 1.0);
-  Point3 p1( 1.0, -1.0, 1.5);
-  Point3 p2( 1.0,  1.0, 1.3);
-  Point3 p3(-1.0,  1.0, 1.6);
-  
+  Point3 p1(1.0, -1.0, 1.5);
+  Point3 p2(1.0, 1.0, 1.3);
+  Point3 p3(-1.0, 1.0, 1.6);
+
   Mesh mesh;
   Mesh::Vertex_index v0 = mesh.add_vertex(p0);
   Mesh::Vertex_index v1 = mesh.add_vertex(p1);
@@ -275,32 +290,32 @@ TEST(CGAL, SurfaceMeshGridCell) {
   mesh.add_face(v0, v1, v2);
   mesh.add_face(v0, v2, v3);
 
- { 
-    // std::cout << "Vertices " << std::endl;    
+  {
+    // std::cout << "Vertices " << "\n";
     // for(auto&& vertex : mesh.vertices()) {
-    //   std::cout << vertex << std::endl;
-    // }
-  }
-
-  { 
-    // std::cout << "Faces " << std::endl;
-    // for(auto&& face : mesh.faces()) {
-    //   std::cout << face << std::endl;
-
-    //   Triangle tri = waves::Geometry::MakeTriangle(mesh, face);
-    //   std::cout << tri << std::endl;
+    //   std::cout << vertex << "\n";
     // }
   }
 
   {
-    // std::cout << "AABB Tree " << std::endl;
+    // std::cout << "Faces " << "\n";
+    // for(auto&& face : mesh.faces()) {
+    //   std::cout << face << "\n";
+
+    //   Triangle tri = MakeTriangle(mesh, face);
+    //   std::cout << tri << "\n";
+    // }
+  }
+
+  {
+    // std::cout << "AABB Tree " << "\n";
 
     Timer t;
     t.start();
     Tree tree(faces(mesh).first, faces(mesh).second, mesh);
     tree.build();
     t.stop();
-    // std::cout << "Build: " << t.time() << " sec" << std::endl;
+    // std::cout << "Build: " << t.time() << " sec" << "\n";
 
     Point3 r0(0.5, 0.5, 101.0);
     Point3 r1(0.5, 0.5, 100.0);
@@ -309,21 +324,22 @@ TEST(CGAL, SurfaceMeshGridCell) {
     t.reset();
     t.start();
     Ray_intersection intersection;
-    for (int i=0; i<1000; ++i) {
+    for (int i=0; i < 1000; ++i) {
       intersection = tree.first_intersection(ray_query);
     }
     t.stop();
-    // std::cout << "Intersect (x1000): " << t.time() << " sec" << std::endl;
+    // std::cout << "Intersect (x1000): " << t.time() << " sec" << "\n";
 
     // if(intersection) {
     //   if(boost::get<Point3>(&(intersection->first))) {
     //     const Point3* p =  boost::get<Point3>(&(intersection->first));
-    //     std::cout <<  *p << std::endl;
+    //     std::cout <<  *p << "\n";
     //   }
     // }
   }
 }
 
+//////////////////////////////////////////////////
 TEST(CGAL, SurfaceMeshGrid) {
   typedef CGAL::Simple_cartesian<double> K;
   typedef K::Point_3 Point3;
@@ -339,11 +355,14 @@ TEST(CGAL, SurfaceMeshGrid) {
   typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
   typedef CGAL::AABB_traits<K, Primitive> Traits;
   typedef CGAL::AABB_tree<Traits> Tree;
-  // typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
-  // typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Segment>::Type>
+  // Segment_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Plane>::Type>
+  // Plane_intersection;
   // typedef Tree::Primitive_id Primitive_id;
 
-  typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
+  typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type>
+  Ray_intersection;
 
   typedef CGAL::Timer Timer;
 
@@ -351,32 +370,32 @@ TEST(CGAL, SurfaceMeshGrid) {
   waves::Grid grid({ 100, 100 }, { 4, 4 });
 
   // Convert to SurfaceMesh
-  const cgal::Mesh& mesh = *grid.GetMesh();
+  const gz::cgal::Mesh& mesh = *grid.GetMesh();
 
   // Properties
-  // { 
-  //   std::cout << "Vertices " << std::endl;    
+  // {
+  //   std::cout << "Vertices " << "\n";
   //   for(auto&& vertex : mesh.vertices()) {
-  //     std::cout << vertex << std::endl;
+  //     std::cout << vertex << "\n";
   //   }
   // }
 
-  // { 
-  //   std::cout << "Faces " << std::endl;
+  // {
+  //   std::cout << "Faces " << "\n";
   //   for(auto&& face : mesh.faces()) {
-  //     std::cout << face << std::endl;
+  //     std::cout << face << "\n";
 
-  //     Triangle tri = waves::Geometry::MakeTriangle(mesh, face);
-  //     std::cout << tri << std::endl;
+  //     Triangle tri = MakeTriangle(mesh, face);
+  //     std::cout << tri << "\n";
   //   }
   // }
 
   // Intersections
   {
-    // std::cout << "AABB Tree " << std::endl;
+    // std::cout << "AABB Tree " << "\n";
 
     // Create a sphere
-    std::shared_ptr<cgal::Mesh> sphere = CreateSphere(
+    std::shared_ptr<gz::cgal::Mesh> sphere = CreateSphere(
       "TestSurfaceMeshGridCellSphere", 5.25);
 
     Timer t;
@@ -384,7 +403,7 @@ TEST(CGAL, SurfaceMeshGrid) {
     Tree tree(faces(mesh).first, faces(mesh).second, mesh);
     tree.build();
     t.stop();
-    // std::cout << "Build: " << t.time() << " sec" << std::endl;
+    // std::cout << "Build: " << t.time() << " sec" << "\n";
 
     t.reset();
     t.start();
@@ -396,17 +415,19 @@ TEST(CGAL, SurfaceMeshGrid) {
       intersection = tree.first_intersection(ray_query);
     }
     t.stop();
-    // std::cout << "Intersect (x" << sphere->number_of_vertices() << "): " << t.time() << " sec" << std::endl;
+    // std::cout << "Intersect (x" << sphere->number_of_vertices()
+    //    << "): " << t.time() << " sec" << "\n";
 
     // if(intersection) {
     //   if(boost::get<Point3>(&(intersection->first))) {
     //     const Point3* p =  boost::get<Point3>(&(intersection->first));
-    //     std::cout <<  *p << std::endl;
+    //     std::cout <<  *p << "\n";
     //   }
     // }
   }
 }
 
+//////////////////////////////////////////////////
 TEST(CGAL, SurfaceMeshModifyGrid) {
   typedef CGAL::Simple_cartesian<double> K;
   typedef K::Point_3 Point3;
@@ -422,11 +443,14 @@ TEST(CGAL, SurfaceMeshModifyGrid) {
   // typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
   // typedef CGAL::AABB_traits<K, Primitive> Traits;
   // typedef CGAL::AABB_tree<Traits> Tree;
-  // typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
-  // typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Segment>::Type>
+  // Segment_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Plane>::Type>
+  // Plane_intersection;
   // typedef Tree::Primitive_id Primitive_id;
 
-  // typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type>
+  // Ray_intersection;
 
   // typedef CGAL::Timer Timer;
 
@@ -434,28 +458,29 @@ TEST(CGAL, SurfaceMeshModifyGrid) {
   waves::Grid grid({ 100, 100 }, { 4, 4 });
 
   // Convert to SurfaceMesh
-  cgal::Mesh& mesh = const_cast<cgal::Mesh&>(*grid.GetMesh());
+  gz::cgal::Mesh& mesh = const_cast<gz::cgal::Mesh&>(*grid.GetMesh());
 
   // Properties
-  { 
-    // std::cout << "Update Points" << std::endl;    
-    for(auto&& vertex : mesh.vertices()) {
+  {
+    // std::cout << "Update Points" << "\n";
+    for (auto&& vertex : mesh.vertices()) {
       Point3& point = mesh.point(vertex);
-      point += Vector3(0, 0, 10);  
+      point += Vector3(0, 0, 10);
     }
   }
 
-  { 
-    // std::cout << "Faces" << std::endl;
+  {
+    // std::cout << "Faces" << "\n";
     // for(auto&& face : mesh.faces()) {
-    //   std::cout << face << std::endl;
+    //   std::cout << face << "\n";
 
-    //   Triangle tri = waves::Geometry::MakeTriangle(mesh, face);
-    //   std::cout << tri << std::endl;
+    //   Triangle tri = MakeTriangle(mesh, face);
+    //   std::cout << tri << "\n";
     // }
   }
 }
 
+//////////////////////////////////////////////////
 TEST(CGAL, SurfaceMeshWavefield) {
   // typedef CGAL::Simple_cartesian<double> K;
   // typedef K::Point_3 Point3;
@@ -471,47 +496,52 @@ TEST(CGAL, SurfaceMeshWavefield) {
   // typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
   // typedef CGAL::AABB_traits<K, Primitive> Traits;
   // typedef CGAL::AABB_tree<Traits> Tree;
-  // typedef boost::optional< Tree::Intersection_and_primitive_id<Segment>::Type > Segment_intersection;
-  // typedef boost::optional< Tree::Intersection_and_primitive_id<Plane>::Type > Plane_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Segment>::Type>
+  // Segment_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Plane>::Type>
+  // Plane_intersection;
   // typedef Tree::Primitive_id Primitive_id;
 
-  // typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type> Ray_intersection;
+  // typedef boost::optional<Tree::Intersection_and_primitive_id<Ray>::Type>
+  // Ray_intersection;
 
   typedef CGAL::Timer Timer;
 
   // Wavefield Parameters
-  std::shared_ptr<waves::WaveParameters> params(new waves::WaveParameters());
+  std::shared_ptr<waves::WaveParameters> params(
+      new waves::WaveParameters());
   params->SetNumber(1);
   params->SetAmplitude(3.0);
   params->SetPeriod(10.0);
   params->SetPhase(0.0);
 
   // Wavefield
-  waves::Wavefield wavefield("waves"); 
+  waves::Wavefield wavefield("waves");
   wavefield.SetParameters(params);
 
   // Evolve to t=10 with 1000 updates
   Timer t;
   t.start();
-  for (size_t i=0; i<1000; ++i) {
+  for (size_t i=0; i < 1000; ++i) {
     wavefield.Update(i/100.0);
   }
   t.stop();
-  // std::cout << "Update (x1000): " << t.time() << " sec" << std::endl;
+  // std::cout << "Update (x1000): " << t.time() << " sec" << "\n";
 
   // Debug info
   // auto mesh = wavefield.GetMesh();
-  // { 
-  //   std::cout << "Faces" << std::endl;
+  // {
+  //   std::cout << "Faces" << "\n";
   //   for(auto&& face : mesh->faces()) {
-  //     Triangle tri = waves::Geometry::MakeTriangle(*mesh, face);
-  //     std::cout << face << ": " << tri << std::endl;
+  //     Triangle tri = MakeTriangle(*mesh, face);
+  //     std::cout << face << ": " << tri << "\n";
   //   }
   // }
 }
 
+//////////////////////////////////////////////////
 /// \todo: resolve TBB issues
-#if 0 
+#if 0
 TEST(CGAL, TBBParallelFor) {
   typedef std::vector<double>::iterator Iterator;
 
@@ -525,18 +555,20 @@ TEST(CGAL, TBBParallelFor) {
 
   // loop lambda
   auto applyKernel = [=](const tbb::blocked_range<Iterator>& _r) {
-    for (Iterator it=_r.begin(); it!=_r.end(); ++it) { 
+    for (Iterator it=_r.begin(); it != _r.end(); ++it) {
       kernel(*it);
     }
   };
 
-  tbb::parallel_for(tbb::blocked_range<Iterator>(a.begin(), a.end()), applyKernel);
+  tbb::parallel_for(tbb::blocked_range<Iterator>(
+      a.begin(), a.end()), applyKernel);
   for (auto v : a) {
-    // std::cout << v << std::endl;
+    // std::cout << v << "\n";
   }
 }
 #endif
 
+//////////////////////////////////////////////////
 TEST(CGAL, VertexRangeIterator) {
   // Mesh
   Point3 p0(0, 0, 0);
@@ -559,7 +591,7 @@ TEST(CGAL, VertexRangeIterator) {
   //   ++vb) {
   //   auto&& v  = *vb;
   //   const Point3& p = mesh.point(v);
-  //   std::cout << p << std::endl;
+  //   std::cout << p << "\n";
   // }
 
   // Iterate over two variables using std::pair
@@ -569,11 +601,11 @@ TEST(CGAL, VertexRangeIterator) {
   //   ++it.first, ++it.second) {
   //   auto&& v = *it.first;
   //   const Point3& p = mesh.point(v);
-  //   std::cout << it.second << ": " << p << std::endl;
+  //   std::cout << it.second << ": " << p << "\n";
   // }
-
 }
 
+//////////////////////////////////////////////////
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/Constrained_triangulation_2.h>
@@ -617,20 +649,20 @@ TEST(CGAL, CreateTriangulationN) {
   double dl = L / N;
   double lm = - L / 2.0;
 
-  // Points - (N+1) points in each row / column 
-  for (size_t iy=0; iy<=N; ++iy) {
+  // Points - (N+1) points in each row / column
+  for (size_t iy=0; iy <= N; ++iy) {
     double py = iy * dl + lm;
-    for (size_t ix=0; ix<=N; ++ix) {
+    for (size_t ix=0; ix <= N; ++ix) {
       // Vertex position
       double px = ix * dl + lm;
-      Point point(px, py);        
+      Point point(px, py);
       points.push_back(point);
     }
   }
 
   // Face indices
-  for (size_t iy=0; iy<N; ++iy) {
-    for (size_t ix=0; ix<N; ++ix) {
+  for (size_t iy=0; iy < N; ++iy) {
+    for (size_t ix=0; ix < N; ++ix) {
       // Get the points in the cell coordinates
       size_t idx0 = iy * NPlus1 + ix;
       size_t idx1 = iy * NPlus1 + ix + 1;
@@ -645,7 +677,7 @@ TEST(CGAL, CreateTriangulationN) {
 
   // Infinite indices (follow edges counter clockwise around grid)
   infiniteIndices.resize(4*N);
-  for (size_t i=0; i<N; ++i) {
+  for (size_t i=0; i < N; ++i) {
     // bottom
     size_t idx = i;
     infiniteIndices[i] = { idx, idx+1 };
@@ -663,17 +695,17 @@ TEST(CGAL, CreateTriangulationN) {
     infiniteIndices[4*N-1-i] = { idx+NPlus1, idx };
   }
 
-  // std::cout << "points:" << std::endl;
+  // std::cout << "points:" << "\n";
   // for (auto&& p : points)  {
-  //   std::cout << p << std::endl;
+  //   std::cout << p << "\n";
   // }
-  // std::cout << "indices:" << std::endl;
+  // std::cout << "indices:" << "\n";
   // for (auto&& i : indices) {
-  //   std::cout << i[0] << " " << i[1] << " " << i[2]  << std::endl;
+  //   std::cout << i[0] << " " << i[1] << " " << i[2]  << "\n";
   // }
-  // std::cout << "infinite indices:" << std::endl;
+  // std::cout << "infinite indices:" << "\n";
   // for (auto&& i : infiniteIndices) {
-  //   std::cout << i[0] << " " << i[1] << std::endl;
+  //   std::cout << i[0] << " " << i[1] << "\n";
   // }
 
   // Manually create a triangulation
@@ -690,7 +722,7 @@ TEST(CGAL, CreateTriangulationN) {
     Vertex_handle vi = tds.create_vertex();
     t.set_infinite_vertex(vi);
     vi = t.infinite_vertex();
-  
+
     // Finite vertices
     std::vector<Vertex_handle> vertices;
     for (auto&& p : points) {
@@ -710,7 +742,7 @@ TEST(CGAL, CreateTriangulationN) {
       Face_handle f = tds.create_face(v0, v1, v2);
       faces.push_back(f);
     }
-  
+
     // Infinite faces
     std::vector<Face_handle> infiniteFaces;
     for (auto&& i : infiniteIndices) {
@@ -726,8 +758,8 @@ TEST(CGAL, CreateTriangulationN) {
     // Set vertex faces excluding top and right
     // @DEBUG_INFO
     std::vector<size_t> debugVertexFaces(NPlus1*NPlus1, -1);
-    for (size_t iy=0; iy<N; ++iy) {
-      for (size_t ix=0; ix<N; ++ix) {
+    for (size_t iy=0; iy < N; ++iy) {
+      for (size_t ix=0; ix < N; ++ix) {
         size_t vidx = iy * NPlus1 + ix;
         size_t fidx = 2 * (iy * N + ix);
         vertices[vidx]->set_face(faces[fidx]);
@@ -736,7 +768,7 @@ TEST(CGAL, CreateTriangulationN) {
       }
     }
     // Set vertex faces : top and right
-    for (size_t i=0; i<N; ++i) {
+    for (size_t i=0; i < N; ++i) {
       // right
       size_t vidx = i * NPlus1 + N;
       size_t fidx = 2 * (i * N + N - 1);
@@ -747,7 +779,7 @@ TEST(CGAL, CreateTriangulationN) {
       // top
       vidx = N * NPlus1 + i;
       fidx = 2 * ((N - 1) * N + i) + 1;
-      vertices[vidx]->set_face(faces[fidx]);    
+      vertices[vidx]->set_face(faces[fidx]);
       // @DEBUG_INFO
       debugVertexFaces[vidx] = fidx;
     }
@@ -755,21 +787,21 @@ TEST(CGAL, CreateTriangulationN) {
       // top-right
       size_t vidx = NPlus1*NPlus1-1;
       size_t fidx = 2 * (N * N - 1);
-      vertices[vidx]->set_face(faces[fidx]);    
+      vertices[vidx]->set_face(faces[fidx]);
       // @DEBUG_INFO
       debugVertexFaces[vidx] = fidx;
     }
 
-    // std::cout << "vertex : faces" << std::endl;
+    // std::cout << "vertex : faces" << "\n";
     // for (size_t i=0; i<debugVertexFaces.size(); ++i)
     // {
-    //   std::cout << i << " " << debugVertexFaces[i] << std::endl;
+    //   std::cout << i << " " << debugVertexFaces[i] << "\n";
     // }
 
     // Set Finite Face neighbours
-    for (size_t iy=0; iy<N; ++iy) {
-      for (size_t ix=0; ix<N; ++ix) {
-        for (size_t k=0; k<2; ++k) {
+    for (size_t iy=0; iy < N; ++iy) {
+      for (size_t ix=0; ix < N; ++ix) {
+        for (size_t k=0; k < 2; ++k) {
           size_t idx = 2 * (iy * N + ix);
 
           if (k == 0) {
@@ -780,27 +812,27 @@ TEST(CGAL, CreateTriangulationN) {
                 size_t f0 = N;
                 size_t f1 = idx + 1;
                 size_t f2 = N - 1;
-                faces[fk]->set_neighbors(infiniteFaces[f0], faces[f1], infiniteFaces[f2]);
-              }
-              else { // ix != N-1
+                faces[fk]->set_neighbors(infiniteFaces[f0],
+                    faces[f1], infiniteFaces[f2]);
+              } else {  // ix != N-1
                 // case 2
                 size_t fk = idx;
                 size_t f0 = idx + 3;
                 size_t f1 = idx + 1;
                 size_t f2 = ix;
-                faces[fk]->set_neighbors(faces[f0], faces[f1], infiniteFaces[f2]);
+                faces[fk]->set_neighbors(faces[f0], faces[f1],
+                    infiniteFaces[f2]);
               }
-            }
-            else { // iy != 0
-              if (ix == N-1) { 
+            } else {  // iy != 0
+              if (ix == N-1) {
                 // case 3
                 size_t fk = idx;
                 size_t f0 = N + iy;
                 size_t f1 = idx + 1;
                 size_t f2 = idx + 1 - 2 * N;
-                faces[fk]->set_neighbors(infiniteFaces[f0], faces[f1], faces[f2]);
-              }
-              else {
+                faces[fk]->set_neighbors(infiniteFaces[f0],
+                    faces[f1], faces[f2]);
+              } else {
                 // case 4 (general)
                 size_t fk = idx;
                 size_t f0 = idx + 3;
@@ -808,7 +840,7 @@ TEST(CGAL, CreateTriangulationN) {
                 size_t f2 = idx + 1 - 2 * N;
                 faces[fk]->set_neighbors(faces[f0], faces[f1], faces[f2]);
               }
-            } 
+            }
           }
           if (k == 1) {
             if (ix == 0){
@@ -818,27 +850,27 @@ TEST(CGAL, CreateTriangulationN) {
                 size_t f0 = 3 * N - 1;
                 size_t f1 = 3 * N;
                 size_t f2 = idx;
-                faces[fk]->set_neighbors(infiniteFaces[f0], infiniteFaces[f1], faces[f2]);
-              }
-              else {
+                faces[fk]->set_neighbors(infiniteFaces[f0],
+                    infiniteFaces[f1], faces[f2]);
+              } else {
                 // case 6
                 size_t fk = idx + 1;
                 size_t f0 = idx + 2 * N;
                 size_t f1 = 4 * N - 1 - iy;
                 size_t f2 = idx;
-                faces[fk]->set_neighbors(faces[f0], infiniteFaces[f1], faces[f2]);
+                faces[fk]->set_neighbors(faces[f0],
+                    infiniteFaces[f1], faces[f2]);
               }
-            }
-            else { // ix != 0
+            } else {  // ix != 0
               if (iy == N-1) {
                 // case 7
                 size_t fk = idx + 1;
                 size_t f0 = 3 * N - 1 - ix;
                 size_t f1 = idx - 2;
                 size_t f2 = idx;
-                faces[fk]->set_neighbors(infiniteFaces[f0], faces[f1], faces[f2]);
-              }
-              else {
+                faces[fk]->set_neighbors(infiniteFaces[f0],
+                    faces[f1], faces[f2]);
+              } else {
                 // case 8 (general)
                 size_t fk = idx + 1;
                 size_t f0 = idx + 2 * N;
@@ -853,7 +885,7 @@ TEST(CGAL, CreateTriangulationN) {
     }
 
     // Set Infinite Face neighbours
-    for (size_t i=0; i<N; ++i) {
+    for (size_t i=0; i < N; ++i) {
       // bottom
       {
         size_t fk = i;
@@ -862,7 +894,8 @@ TEST(CGAL, CreateTriangulationN) {
         size_t f2 = fk - 1;
         if (i == 0)
           f2 = 4 * N - 1;
-        infiniteFaces[fk]->set_neighbors(infiniteFaces[f0], faces[f1], infiniteFaces[f2]);
+        infiniteFaces[fk]->set_neighbors(infiniteFaces[f0],
+            faces[f1], infiniteFaces[f2]);
       }
 
       // right
@@ -871,7 +904,8 @@ TEST(CGAL, CreateTriangulationN) {
         size_t f0 = fk + 1;
         size_t f1 = 2 * (i * N + N - 1);
         size_t f2 = fk - 1;
-        infiniteFaces[fk]->set_neighbors(infiniteFaces[f0], faces[f1], infiniteFaces[f2]);        
+        infiniteFaces[fk]->set_neighbors(infiniteFaces[f0],
+            faces[f1], infiniteFaces[f2]);
       }
 
       // top
@@ -880,7 +914,8 @@ TEST(CGAL, CreateTriangulationN) {
         size_t f0 = fk + 1;
         size_t f1 = 2 * ((N - 1) * N + i) + 1;
         size_t f2 = fk - 1;
-        infiniteFaces[fk]->set_neighbors(infiniteFaces[f0], faces[f1], infiniteFaces[f2]);
+        infiniteFaces[fk]->set_neighbors(infiniteFaces[f0],
+            faces[f1], infiniteFaces[f2]);
       }
 
       // left
@@ -891,7 +926,8 @@ TEST(CGAL, CreateTriangulationN) {
         size_t f2 = fk - 1;
         if (i == N - 1)
           f0 = 0;
-        infiniteFaces[fk]->set_neighbors(infiniteFaces[f0], faces[f1], infiniteFaces[f2]);
+        infiniteFaces[fk]->set_neighbors(infiniteFaces[f0],
+            faces[f1], infiniteFaces[f2]);
       }
     }
 
@@ -916,25 +952,25 @@ TEST(CGAL, CreateTriangulationN) {
     }
 
     // Verify triangulation
-    // std::cout << "triangulation data structure" << std::endl;
-    // std::cout << tds << std::endl; 
-    // std::cout << "is valid: " << tds.is_valid() << std::endl;
-    // std::cout << "dimension: " << tds.dimension() << std::endl;
-    // std::cout << "number of vertices : " << tds.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << tds.number_of_faces() << std::endl;
-    // std::cout << "number of edges : " << tds.number_of_edges() << std::endl;
+    // std::cout << "triangulation data structure" << "\n";
+    // std::cout << tds << "\n";
+    // std::cout << "is valid: " << tds.is_valid() << "\n";
+    // std::cout << "dimension: " << tds.dimension() << "\n";
+    // std::cout << "number of vertices : " << tds.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << tds.number_of_faces() << "\n";
+    // std::cout << "number of edges : " << tds.number_of_edges() << "\n";
     EXPECT_TRUE(tds.is_valid());
     EXPECT_EQ(tds.dimension(), 2);
     // EXPECT_EQ(tds.number_of_vertices(), 5);
     // EXPECT_EQ(tds.number_of_faces(), 6);
     // EXPECT_EQ(tds.number_of_edges(), 9);
 
-    // std::cout << "triangulation" << std::endl;
-    // std::cout << t << std::endl; 
-    // std::cout << "is valid: " << t.is_valid() << std::endl;
-    // std::cout << "dimension: " << t.dimension() << std::endl;
-    // std::cout << "number of vertices : " << t.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << t.number_of_faces() << std::endl;
+    // std::cout << "triangulation" << "\n";
+    // std::cout << t << "\n";
+    // std::cout << "is valid: " << t.is_valid() << "\n";
+    // std::cout << "dimension: " << t.dimension() << "\n";
+    // std::cout << "number of vertices : " << t.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << t.number_of_faces() << "\n";
     EXPECT_TRUE(t.is_valid());
     EXPECT_EQ(t.dimension(), 2);
     // EXPECT_EQ(t.number_of_vertices(), 4);
@@ -946,38 +982,40 @@ TEST(CGAL, CreateTriangulationN) {
   Triangulation::Triangulation_data_structure& ctds = ct.tds();
   {
     // Add all finite edges as constraints.
-    for (auto e = t.finite_edges_begin(); e != t.finite_edges_end(); ++e) {      
+    for (auto e = t.finite_edges_begin(); e != t.finite_edges_end(); ++e) {
       const auto& f = e->first;
       int i = e->second;
       const auto& v0 = f->vertex(f->cw(i));
       const auto& v1 = f->vertex(f->ccw(i));
       ct.insert_constraint(v0->point(), v1->point());
     }
-    // std::cout << "constrained triangulation" << std::endl;
-    // std::cout << t << std::endl; 
+    // std::cout << "constrained triangulation" << "\n";
+    // std::cout << t << "\n";
 
-    // Now insert all finite points (to force building the triangulation hierarchy)
-    for (auto v = ct.finite_vertices_begin(); v != ct.finite_vertices_end(); ++v) {      
+    // Now insert all finite points (to force building the
+    // triangulation hierarchy)
+    for (auto v = ct.finite_vertices_begin();
+        v != ct.finite_vertices_end(); ++v) {
       ct.insert(v->point());
     }
 
-    // std::cout << "constrained triangulation" << std::endl;
-    // std::cout << t << std::endl; 
-    // std::cout << "is valid: " << ct.is_valid() << std::endl;
-    // std::cout << "dimension: " << ct.dimension() << std::endl;
-    // std::cout << "number of vertices : " << ct.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << ct.number_of_faces() << std::endl;
+    // std::cout << "constrained triangulation" << "\n";
+    // std::cout << t << "\n";
+    // std::cout << "is valid: " << ct.is_valid() << "\n";
+    // std::cout << "dimension: " << ct.dimension() << "\n";
+    // std::cout << "number of vertices : " << ct.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << ct.number_of_faces() << "\n";
     EXPECT_TRUE(ct.is_valid());
 
-    // Face list mapping  
+    // Face list mapping
 
     // Initialise face info
     for (auto f = t.all_faces_begin(); f != t.all_faces_end(); ++f) {
-      f->info() = -1; 
+      f->info() = -1;
     }
 
     for (auto f = ct.all_faces_begin(); f != ct.all_faces_end(); ++f) {
-      f->info() = -2; 
+      f->info() = -2;
     }
 
     // Face matching
@@ -989,15 +1027,14 @@ TEST(CGAL, CreateTriangulationN) {
       Point p2 = f->vertex(2)->point();
       Point p(
         (p0.x() + p1.x() + p2.x())/3.0,
-        (p0.y() + p1.y() + p2.y())/3.0
-      );
+        (p0.y() + p1.y() + p2.y())/3.0);
       fh = ct.locate(p, fh);
       bool found = fh != nullptr;
 
       // @ISSUE - the problem with using is_face is that fh is a handle
       //          to a Face in triangulation t not ct. It appears that
       //          is_face obtains the face from the vertices rather than
-      //          the list of faces stored in the triangular data structure. 
+      //          the list of faces stored in the triangular data structure.
       // bool found = ct.is_face(f->vertex(0), f->vertex(1), f->vertex(2), fh);
 
       // Set the info value on the found face.
@@ -1007,35 +1044,38 @@ TEST(CGAL, CreateTriangulationN) {
         // std::cout << "found: " << found
         //   << ", is_infinite: " << ct.is_infinite(fh)
         //   << ", info: " << fh->info()
-        //   << std::endl;
+        //   << "\n";
       }
     }
- 
+
     // Display.
     // size_t idx = 0;
-    // std::cout << "t info:" << std::endl;
-    // for (auto f = t.all_faces_begin(); f != t.all_faces_end(); ++f, ++idx) {
+    // std::cout << "t info:" << "\n";
+    // for (auto f = t.all_faces_begin();
+    //    f != t.all_faces_end(); ++f, ++idx) {
     //   std::cout << "idx: " << idx
     //     << ", is_infinite: " << t.is_infinite(f)
     //     << ", info: " << f->info()
-    //     << std::endl; 
+    //     << "\n";
     // }
 
     // idx = 0;
-    // std::cout << "ct info:" << std::endl;
-    // for (auto f = ct.all_faces_begin(); f != ct.all_faces_end(); ++f, ++idx) {
+    // std::cout << "ct info:" << "\n";
+    // for (auto f = ct.all_faces_begin();
+    //    f != ct.all_faces_end(); ++f, ++idx) {
     //   std::cout << "idx: " << idx
     //     << ", is_infinite: " << ct.is_infinite(f)
     //     << ", info: " << f->info()
-    //     << std::endl; 
+    //     << "\n";
     // }
 
     // idx = 0;
-    // std::cout << "ct face info:" << std::endl;
-    // for (auto f = ct.finite_faces_begin(); f != ct.finite_faces_end(); ++f, ++idx) {
+    // std::cout << "ct face info:" << "\n";
+    // for (auto f = ct.finite_faces_begin();
+    //    f != ct.finite_faces_end(); ++f, ++idx) {
     //   std::cout << "ct: " << idx
     //     << ", t: " << f->info()
-    //     << std::endl; 
+    //     << "\n";
     // }
   }
 }
@@ -1055,17 +1095,17 @@ TEST(CGAL, CreateTriangulationHierarchyN) {
   // Location tests..
   std::vector<Point3> points;
   std::vector<std::array<int64_t, 3>> indices;
-  
+
   // Create mesh
   {
     int NPlus1 = N + 1;
     double dl = L / N;
     double lm = - L / 2.0;
 
-    // Points - (N+1) points in each row / column 
-    for (int64_t iy=0; iy<=N; ++iy) {
+    // Points - (N+1) points in each row / column
+    for (int64_t iy=0; iy <= N; ++iy) {
       double py = iy * dl + lm;
-      for (int64_t ix=0; ix<=N; ++ix) {
+      for (int64_t ix=0; ix <= N; ++ix) {
         // Vertex position
         double px = ix * dl + lm;
         Point3 point(px, py, 0.0);
@@ -1074,8 +1114,8 @@ TEST(CGAL, CreateTriangulationHierarchyN) {
     }
 
     // Face indices
-    for (int64_t iy=0; iy<N; ++iy) {
-      for (int64_t ix=0; ix<N; ++ix) {
+    for (int64_t iy=0; iy < N; ++iy) {
+      for (int64_t ix=0; ix < N; ++ix) {
         // Get the points in the cell coordinates
         int64_t idx0 = iy * NPlus1 + ix;
         int64_t idx1 = iy * NPlus1 + ix + 1;
@@ -1086,16 +1126,16 @@ TEST(CGAL, CreateTriangulationHierarchyN) {
         indices.push_back({ idx0, idx1, idx2 });
         indices.push_back({ idx0, idx2, idx3 });
       }
-    } 
-  } 
+    }
+  }
 
   // Locate faces
   {
     // CGAL::Timer timer;
     // timer.start();
-    for (int64_t i=0; i<indices.size(); ++i) {
+    for (int64_t i=0; i < indices.size(); ++i) {
       // Get face index.
-      auto& f  = indices[i]; 
+      auto& f  = indices[i];
 
       // Compute centroid.
       auto& p0 = points[f[0]];
@@ -1104,8 +1144,7 @@ TEST(CGAL, CreateTriangulationHierarchyN) {
       Point3 p(
         (p0.x() + p1.x() + p2.x())/3.0,
         (p0.y() + p1.y() + p2.y())/3.0,
-        (p0.z() + p1.z() + p2.z())/3.0
-      );
+        (p0.z() + p1.z() + p2.z())/3.0);
 
       // Locate point.
       int64_t fidx = 0;
@@ -1114,7 +1153,8 @@ TEST(CGAL, CreateTriangulationHierarchyN) {
       EXPECT_EQ(fidx, i);
     }
     // timer.stop();
-    // std::cout << "Locate " << indices.size() << " points: (" << timer.time() << " s)" << std::endl;
+    // std::cout << "Locate " << indices.size() << " points: ("
+    //    << timer.time() << " s)" << "\n";
   }
 
   // Update mesh
@@ -1128,29 +1168,28 @@ TEST(CGAL, CreateTriangulationHierarchyN) {
     double k = omega * omega / g;
     double kx = k;
     double ky = 0.0;
-    EXPECT_LT(amplitude * k, 1.0); 
+    EXPECT_LT(amplitude * k, 1.0);
 
     // Trochoid wave
-    for (int64_t i=0; i<points.size(); ++i) {
-      const auto& p0 = points[i]; 
-      auto& p = points2[i]; 
+    for (int64_t i=0; i < points.size(); ++i) {
+      const auto& p0 = points[i];
+      auto& p = points2[i];
       double theta = kx * p0.x() + ky * p0.y() - omega * time;
       double c = std::cos(theta);
       double s = std::sin(theta);
       // double sx = amplitude * s;
       // double sy = amplitude * s;
       p = Point3(
-        p0.x() - kx / k * amplitude * s, 
-        p0.y() - ky / k * amplitude * s, 
-        p0.z() + amplitude * c 
-        );
-    } 
+        p0.x() - kx / k * amplitude * s,
+        p0.y() - ky / k * amplitude * s,
+        p0.z() + amplitude * c);
+    }
   }
 
-  // std::cout << "points2: " << std::endl;
+  // std::cout << "points2: " << "\n";
   // std::copy(points2.begin(), points2.end(),
   //   std::ostream_iterator<Point3>(std::cout, "\n"));
-  // std::cout << std::endl; 
+  // std::cout << "\n";
 
   tri_grid.UpdatePoints(points2);
   // tri_grid.DebugPrintTriangulation();
@@ -1159,9 +1198,9 @@ TEST(CGAL, CreateTriangulationHierarchyN) {
   {
     CGAL::Timer timer;
     timer.start();
-    for (int64_t i=0; i<indices.size(); ++i) {
+    for (int64_t i=0; i < indices.size(); ++i) {
       // Get face index.
-      auto& f  = indices[i]; 
+      auto& f  = indices[i];
 
       // Compute centroid of updated point.
       auto& p0 = points2[f[0]];
@@ -1170,8 +1209,7 @@ TEST(CGAL, CreateTriangulationHierarchyN) {
       Point3 p(
         (p0.x() + p1.x() + p2.x())/3.0,
         (p0.y() + p1.y() + p2.y())/3.0,
-        (p0.z() + p1.z() + p2.z())/3.0
-      );
+        (p0.z() + p1.z() + p2.z())/3.0);
 
       // Locate point.
       int64_t fidx = 0;
@@ -1180,14 +1218,18 @@ TEST(CGAL, CreateTriangulationHierarchyN) {
       EXPECT_EQ(fidx, i);
     }
     timer.stop();
-    // std::cout << "Locate " << indices.size() << " points: (" << timer.time() << " s)" << std::endl;
+    // std::cout << "Locate " << indices.size()
+    //    << " points: (" << timer.time() << " s)" << "\n";
   }
 }
 #endif
+
+//////////////////////////////////////////////////
 TEST(CGAL, CreateTriangulation3) {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
-  // When not using the triangulation hierarchy use the default triangulation data structure
+  // When not using the triangulation hierarchy use the default
+  // triangulation data structure
   typedef CGAL::Triangulation_2<K>                         TSlow;
 
   // Otherwise must use the extended vertex base class
@@ -1207,7 +1249,6 @@ TEST(CGAL, CreateTriangulation3) {
   // typedef Triangulation::Edge                     Edge;
   // typedef Triangulation::Segment                  Segment;
 
-  
   // Points
   Point p1(0, 0);
   Point p2(0, 1);
@@ -1225,32 +1266,32 @@ TEST(CGAL, CreateTriangulation3) {
     // t.insert(p4);
 
     // Check valid
-    // std::cout << "triangulation data structure" << std::endl;
-    // std::cout << "is valid: " << tds.is_valid() << std::endl;
-    // std::cout << "dimension: " << tds.dimension() << std::endl;
-    // std::cout << "number of vertices : " << tds.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << tds.number_of_faces() << std::endl;
-    // std::cout << "number of edges : " << tds.number_of_edges() << std::endl;
-    // std::cout << tds << std::endl; 
+    // std::cout << "triangulation data structure" << "\n";
+    // std::cout << "is valid: " << tds.is_valid() << "\n";
+    // std::cout << "dimension: " << tds.dimension() << "\n";
+    // std::cout << "number of vertices : " << tds.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << tds.number_of_faces() << "\n";
+    // std::cout << "number of edges : " << tds.number_of_edges() << "\n";
+    // std::cout << tds << "\n";
 
-    // std::cout << "triangulation" << std::endl;
-    // std::cout << "is valid: " << t.is_valid() << std::endl;
-    // std::cout << "dimension: " << t.dimension() << std::endl;
-    // std::cout << "number of vertices : " << t.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << t.number_of_faces() << std::endl;
-    // std::cout << t << std::endl; 
+    // std::cout << "triangulation" << "\n";
+    // std::cout << "is valid: " << t.is_valid() << "\n";
+    // std::cout << "dimension: " << t.dimension() << "\n";
+    // std::cout << "number of vertices : " << t.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << t.number_of_faces() << "\n";
+    // std::cout << t << "\n";
 
-    // std::cout << "finite vertices" << std::endl;
-    // for (auto v=t.finite_vertices_begin(); v != t.finite_vertices_end(); ++v) {
-    //   std::cout << *v << std::endl;
+    // std::cout << "finite vertices" << "\n";
+    // for (auto v=t.finite_vertices_begin();
+    //    v != t.finite_vertices_end(); ++v) {
+    //   std::cout << *v << "\n";
     // }
 
-    // std::cout << "finite faces" << std::endl;
+    // std::cout << "finite faces" << "\n";
     // for (auto f=t.finite_faces_begin(); f != t.finite_faces_end(); ++f) {
-    //   std::cout << *f->vertex(0) << ", " << *f->vertex(1) << ", " << *f->vertex(2) << std::endl;
+    //   std::cout << *f->vertex(0) << ", " << *f->vertex(1)
+    //      << ", " << *f->vertex(2) << "\n";
     // }
-
-
   }
 
   if (0) {
@@ -1264,12 +1305,12 @@ TEST(CGAL, CreateTriangulation3) {
     // Set dimension
     tds.set_dimension(2);
 
-    // std::cout << "before vertex insertion..." << std::endl;
-    // std::cout << "is valid: " << tds.is_valid() << std::endl;
-    // std::cout << "dimension: " << tds.dimension() << std::endl;
-    // std::cout << "number of vertices : " << tds.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << tds.number_of_faces() << std::endl;
-    // std::cout << "number of edges : " << tds.number_of_edges() << std::endl;
+    // std::cout << "before vertex insertion..." << "\n";
+    // std::cout << "is valid: " << tds.is_valid() << "\n";
+    // std::cout << "dimension: " << tds.dimension() << "\n";
+    // std::cout << "number of vertices : " << tds.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << tds.number_of_faces() << "\n";
+    // std::cout << "number of edges : " << tds.number_of_edges() << "\n";
     EXPECT_FALSE(tds.is_valid());
     EXPECT_EQ(tds.dimension(), 2);
     EXPECT_EQ(tds.number_of_vertices(), 0);
@@ -1310,156 +1351,163 @@ TEST(CGAL, CreateTriangulation3) {
     f3->set_neighbors(f0, f2, f1);
 
     // Check vertices valid
-    // std::cout << "v0->is_valid: " << v0->is_valid(true) << std::endl;
-    // std::cout << "v1->is_valid: " << v1->is_valid(true) << std::endl;
-    // std::cout << "v2->is_valid: " << v2->is_valid(true) << std::endl;
-    // std::cout << "v3->is_valid: " << v3->is_valid(true) << std::endl;
+    // std::cout << "v0->is_valid: " << v0->is_valid(true) << "\n";
+    // std::cout << "v1->is_valid: " << v1->is_valid(true) << "\n";
+    // std::cout << "v2->is_valid: " << v2->is_valid(true) << "\n";
+    // std::cout << "v3->is_valid: " << v3->is_valid(true) << "\n";
     EXPECT_TRUE(v0->is_valid());
     EXPECT_TRUE(v1->is_valid());
     EXPECT_TRUE(v2->is_valid());
     EXPECT_TRUE(v3->is_valid());
 
     // Check faces valid
-    // std::cout << "f0->is_valid: " << f0->is_valid(true) << std::endl;
-    // std::cout << "f1->is_valid: " << f1->is_valid(true) << std::endl;
-    // std::cout << "f2->is_valid: " << f2->is_valid(true) << std::endl;
-    // std::cout << "f3->is_valid: " << f3->is_valid(true) << std::endl;
+    // std::cout << "f0->is_valid: " << f0->is_valid(true) << "\n";
+    // std::cout << "f1->is_valid: " << f1->is_valid(true) << "\n";
+    // std::cout << "f2->is_valid: " << f2->is_valid(true) << "\n";
+    // std::cout << "f3->is_valid: " << f3->is_valid(true) << "\n";
     EXPECT_TRUE(f0->is_valid());
     EXPECT_TRUE(f1->is_valid());
     EXPECT_TRUE(f2->is_valid());
     EXPECT_TRUE(f3->is_valid());
 
     // Check valid
-    // std::cout << "is valid: " << tds.is_valid() << std::endl;
-    // std::cout << "dimension: " << tds.dimension() << std::endl;
-    // std::cout << "number of vertices : " << tds.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << tds.number_of_faces() << std::endl;
-    // std::cout << "number of edges : " << tds.number_of_edges() << std::endl;
+    // std::cout << "is valid: " << tds.is_valid() << "\n";
+    // std::cout << "dimension: " << tds.dimension() << "\n";
+    // std::cout << "number of vertices : " << tds.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << tds.number_of_faces() << "\n";
+    // std::cout << "number of edges : " << tds.number_of_edges() << "\n";
     EXPECT_TRUE(tds.is_valid());
     EXPECT_EQ(tds.dimension(), 2);
     EXPECT_EQ(tds.number_of_vertices(), 4);
     EXPECT_EQ(tds.number_of_faces(), 4);
     EXPECT_EQ(tds.number_of_edges(), 6);
 
-    // std::cout << "triangulation data structure" << std::endl;
-    // std::cout << tds << std::endl; 
+    // std::cout << "triangulation data structure" << "\n";
+    // std::cout << tds << "\n";
 
-    // std::cout << "is infinite (T): " << t.is_infinite(v0) << std::endl;
-    // std::cout << "is infinite (T): " << t.is_infinite(f0) << std::endl;
-    // std::cout << "is infinite (T): " << t.is_infinite(f2) << std::endl;
-    // std::cout << "is infinite (T): " << t.is_infinite(f3) << std::endl;
+    // std::cout << "is infinite (T): " << t.is_infinite(v0) << "\n";
+    // std::cout << "is infinite (T): " << t.is_infinite(f0) << "\n";
+    // std::cout << "is infinite (T): " << t.is_infinite(f2) << "\n";
+    // std::cout << "is infinite (T): " << t.is_infinite(f3) << "\n";
     EXPECT_TRUE(t.is_infinite(v0));
     EXPECT_TRUE(t.is_infinite(f0));
     EXPECT_TRUE(t.is_infinite(f2));
     EXPECT_TRUE(t.is_infinite(f3));
 
-    // std::cout << "is infinite (F): " << t.is_infinite(v1) << std::endl;
-    // std::cout << "is infinite (F): " << t.is_infinite(v2) << std::endl;
-    // std::cout << "is infinite (F): " << t.is_infinite(v3) << std::endl;
-    // std::cout << "is infinite (F): " << t.is_infinite(f1) << std::endl;
+    // std::cout << "is infinite (F): " << t.is_infinite(v1) << "\n";
+    // std::cout << "is infinite (F): " << t.is_infinite(v2) << "\n";
+    // std::cout << "is infinite (F): " << t.is_infinite(v3) << "\n";
+    // std::cout << "is infinite (F): " << t.is_infinite(f1) << "\n";
     EXPECT_FALSE(t.is_infinite(v1));
     EXPECT_FALSE(t.is_infinite(v2));
     EXPECT_FALSE(t.is_infinite(v3));
     EXPECT_FALSE(t.is_infinite(f1));
 
-    // std::cout << "is valid: " << t.is_valid() << std::endl;
-    // std::cout << "dimension: " << t.dimension() << std::endl;
-    // std::cout << "number of vertices : " << t.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << t.number_of_faces() << std::endl;
+    // std::cout << "is valid: " << t.is_valid() << "\n";
+    // std::cout << "dimension: " << t.dimension() << "\n";
+    // std::cout << "number of vertices : " << t.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << t.number_of_faces() << "\n";
     EXPECT_TRUE(t.is_valid());
     EXPECT_EQ(t.dimension(), 2);
     EXPECT_EQ(t.number_of_vertices(), 3);
     EXPECT_EQ(t.number_of_faces(), 1);
 
-    // std::cout << "triangulation" << std::endl;
-    // std::cout << t << std::endl; 
+    // std::cout << "triangulation" << "\n";
+    // std::cout << t << "\n";
 
 
     // Point location.
-    std::cout << "point location..." << std::endl;
+    std::cout << "point location..." << "\n";
     Face_handle f = t.locate(Point(0.1, 0.1));
-    std::cout << "point found: " << !t.is_infinite(f) << std::endl;
-    std::cout << *f->vertex(0) << ", " << *f->vertex(1) << ", " << *f->vertex(2) << std::endl;
+    std::cout << "point found: " << !t.is_infinite(f) << "\n";
+    std::cout << *f->vertex(0) << ", " << *f->vertex(1)
+        << ", " << *f->vertex(2) << "\n";
 
     f = t.locate(Point(-1.0, -1.0));
-    std::cout << "point found: " << !t.is_infinite(f) << std::endl;
-    std::cout << *f->vertex(0) << ", " << *f->vertex(1) << ", " << *f->vertex(2) << std::endl;
+    std::cout << "point found: " << !t.is_infinite(f) << "\n";
+    std::cout << *f->vertex(0) << ", " << *f->vertex(1)
+        << ", " << *f->vertex(2) << "\n";
 
     // Now shift the points on the vertices.
     v1->set_point(Point(-10, -10));
     f = t.locate(Point(-1.0, -1.0));
-    std::cout << "point found: " << !t.is_infinite(f) << std::endl;
-    std::cout << *f->vertex(0) << ", " << *f->vertex(1) << ", " << *f->vertex(2) << std::endl;
+    std::cout << "point found: " << !t.is_infinite(f) << "\n";
+    std::cout << *f->vertex(0) << ", " << *f->vertex(1)
+        << ", " << *f->vertex(2) << "\n";
 
     // Point location using triangulation hierarchy
     // Verbose mode of is_valid shows the number of vertices at each level.
-    std::cout << "number of vertices at successive levels:" << std::endl;
+    std::cout << "number of vertices at successive levels:" << "\n";
     EXPECT_TRUE(t.is_valid(true));
 
     {
       typedef CGAL::Creator_uniform_2<double, Point> Creator;
-      std::cout << "insertion of random points" << std::endl;
+      std::cout << "insertion of random points" << "\n";
       int N = 256;
       Triangulation tt;
       CGAL::Random_points_in_square_2<Point, Creator> g(1.);
       CGAL::cpp11::copy_n(g, (N+1)*(N+1), std::back_inserter(tt));
 
       // Verbose mode of is_valid shows the number of vertices at each level.
-      std::cout << "The number of vertices at successive levels" << std::endl;
+      std::cout << "The number of vertices at successive levels" << "\n";
       EXPECT_TRUE(tt.is_valid(true));
 
       // Full search
       CGAL::Timer timer;
       timer.start();
-      for (int64_t i=0; i<1000; ++i) {
+      for (int64_t i=0; i < 1000; ++i) {
         f = tt.locate(Point(0.1, 0.7));
       }
       timer.stop();
 
-      std::cout << "point found: " << !tt.is_infinite(f) << ", time (1000x): " << timer.time() << std::endl;
-      std::cout << *f->vertex(0) << ", " << *f->vertex(1) << ", " << *f->vertex(2) << std::endl;
+      std::cout << "point found: " << !tt.is_infinite(f)
+          << ", time (1000x): " << timer.time() << "\n";
+      std::cout << *f->vertex(0) << ", " << *f->vertex(1)
+          << ", " << *f->vertex(2) << "\n";
 
       // With hint
       timer.reset();
       timer.start();
-      for (int64_t i=0; i<1000; ++i) {
+      for (int64_t i=0; i < 1000; ++i) {
         f = tt.locate(Point(0.1, 0.7), f);
       }
       timer.stop();
 
-      std::cout << "point found: " << !tt.is_infinite(f) << ", time (1000x): " << timer.time() << std::endl;
-      std::cout << *f->vertex(0) << ", " << *f->vertex(1) << ", " << *f->vertex(2) << std::endl;
-
+      std::cout << "point found: " << !tt.is_infinite(f)
+          << ", time (1000x): " << timer.time() << "\n";
+      std::cout << *f->vertex(0) << ", " << *f->vertex(1)
+          << ", " << *f->vertex(2) << "\n";
     }
     {
       // Point location without triangulation hierarchy.
       typedef CGAL::Creator_uniform_2<double, TSlow::Point> Creator;
-      std::cout << "insertion of random points" << std::endl;
+      std::cout << "insertion of random points" << "\n";
       int N = 256;
       TSlow tt;
       CGAL::Random_points_in_square_2<TSlow::Point, Creator> g(1.);
       CGAL::cpp11::copy_n(g, (N+1)*(N+1), std::back_inserter(tt));
 
       // Verbose mode of is_valid shows the number of vertices at each level.
-      std::cout << "The number of vertices at successive levels" << std::endl;
+      std::cout << "The number of vertices at successive levels" << "\n";
       EXPECT_TRUE(tt.is_valid(true));
 
       CGAL::Timer timer;
       timer.start();
       TSlow::Face_handle ff;
-      for (int64_t i=0; i<1000; ++i) {
+      for (int64_t i=0; i < 1000; ++i) {
         ff = tt.locate(TSlow::Point(0.1, 0.7));
       }
       timer.stop();
 
-      std::cout << "point found: " << !tt.is_infinite(ff) << ", time (1000x): " << timer.time() << std::endl;
-      std::cout << *ff->vertex(0) << ", " << *ff->vertex(1) << ", " << *ff->vertex(2) << std::endl;
-    }    
-
+      std::cout << "point found: " << !tt.is_infinite(ff)
+          << ", time (1000x): " << timer.time() << "\n";
+      std::cout << *ff->vertex(0) << ", " << *ff->vertex(1)
+          << ", " << *ff->vertex(2) << "\n";
+    }
   }
-
 }
 
+//////////////////////////////////////////////////
 TEST(CGAL, CreateTriangulation4) {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
   typedef CGAL::Triangulation_2<K>                Triangulation;
@@ -1471,7 +1519,7 @@ TEST(CGAL, CreateTriangulation4) {
   // typedef Triangulation::Triangle                 Triangle;
   // typedef Triangulation::Edge                     Edge;
   // typedef Triangulation::Segment                  Segment;
-  
+
   // Points
   Point p0(0, 0);
   Point p1(1, 0);
@@ -1531,11 +1579,11 @@ TEST(CGAL, CreateTriangulation4) {
     if3->set_neighbors(if0, ff1, if2);
 
     // Check vertices valid
-    // std::cout << "vi->is_valid: " << vi->is_valid(true) << std::endl;
-    // std::cout << "v0->is_valid: " << v0->is_valid(true) << std::endl;
-    // std::cout << "v1->is_valid: " << v1->is_valid(true) << std::endl;
-    // std::cout << "v2->is_valid: " << v2->is_valid(true) << std::endl;
-    // std::cout << "v3->is_valid: " << v3->is_valid(true) << std::endl;
+    // std::cout << "vi->is_valid: " << vi->is_valid(true) << "\n";
+    // std::cout << "v0->is_valid: " << v0->is_valid(true) << "\n";
+    // std::cout << "v1->is_valid: " << v1->is_valid(true) << "\n";
+    // std::cout << "v2->is_valid: " << v2->is_valid(true) << "\n";
+    // std::cout << "v3->is_valid: " << v3->is_valid(true) << "\n";
     EXPECT_TRUE(vi->is_valid());
     EXPECT_TRUE(v0->is_valid());
     EXPECT_TRUE(v1->is_valid());
@@ -1543,34 +1591,34 @@ TEST(CGAL, CreateTriangulation4) {
     EXPECT_TRUE(v3->is_valid());
 
     // Check faces valid
-    // std::cout << "ff0->is_valid: " << ff0->is_valid(true) << std::endl;
-    // std::cout << "ff1->is_valid: " << ff1->is_valid(true) << std::endl;
+    // std::cout << "ff0->is_valid: " << ff0->is_valid(true) << "\n";
+    // std::cout << "ff1->is_valid: " << ff1->is_valid(true) << "\n";
     EXPECT_TRUE(ff0->is_valid());
     EXPECT_TRUE(ff1->is_valid());
 
-    // std::cout << "if0->is_valid: " << if0->is_valid(true) << std::endl;
-    // std::cout << "if1->is_valid: " << if1->is_valid(true) << std::endl;
-    // std::cout << "if2->is_valid: " << if2->is_valid(true) << std::endl;
-    // std::cout << "if3->is_valid: " << if3->is_valid(true) << std::endl;
+    // std::cout << "if0->is_valid: " << if0->is_valid(true) << "\n";
+    // std::cout << "if1->is_valid: " << if1->is_valid(true) << "\n";
+    // std::cout << "if2->is_valid: " << if2->is_valid(true) << "\n";
+    // std::cout << "if3->is_valid: " << if3->is_valid(true) << "\n";
     EXPECT_TRUE(if0->is_valid());
     EXPECT_TRUE(if1->is_valid());
     EXPECT_TRUE(if2->is_valid());
     EXPECT_TRUE(if3->is_valid());
 
     // Check valid
-    // std::cout << "is valid: " << tds.is_valid() << std::endl;
-    // std::cout << "dimension: " << tds.dimension() << std::endl;
-    // std::cout << "number of vertices : " << tds.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << tds.number_of_faces() << std::endl;
-    // std::cout << "number of edges : " << tds.number_of_edges() << std::endl;
+    // std::cout << "is valid: " << tds.is_valid() << "\n";
+    // std::cout << "dimension: " << tds.dimension() << "\n";
+    // std::cout << "number of vertices : " << tds.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << tds.number_of_faces() << "\n";
+    // std::cout << "number of edges : " << tds.number_of_edges() << "\n";
     EXPECT_TRUE(tds.is_valid(true));
     EXPECT_EQ(tds.dimension(), 2);
     EXPECT_EQ(tds.number_of_vertices(), 5);
     EXPECT_EQ(tds.number_of_faces(), 6);
     EXPECT_EQ(tds.number_of_edges(), 9);
 
-    // std::cout << "triangulation data structure" << std::endl;
-    // std::cout << tds << std::endl; 
+    // std::cout << "triangulation data structure" << "\n";
+    // std::cout << tds << "\n";
 
     EXPECT_TRUE(t.is_infinite(vi));
     EXPECT_TRUE(t.is_infinite(if0));
@@ -1585,22 +1633,21 @@ TEST(CGAL, CreateTriangulation4) {
     EXPECT_FALSE(t.is_infinite(ff0));
     EXPECT_FALSE(t.is_infinite(ff1));
 
-    // std::cout << "is valid: " << t.is_valid() << std::endl;
-    // std::cout << "dimension: " << t.dimension() << std::endl;
-    // std::cout << "number of vertices : " << t.number_of_vertices() << std::endl;
-    // std::cout << "number of faces : " << t.number_of_faces() << std::endl;
+    // std::cout << "is valid: " << t.is_valid() << "\n";
+    // std::cout << "dimension: " << t.dimension() << "\n";
+    // std::cout << "number of vertices : " << t.number_of_vertices() << "\n";
+    // std::cout << "number of faces : " << t.number_of_faces() << "\n";
     EXPECT_TRUE(t.is_valid(true));
     EXPECT_EQ(t.dimension(), 2);
     EXPECT_EQ(t.number_of_vertices(), 4);
     EXPECT_EQ(t.number_of_faces(), 2);
 
-    // std::cout << "triangulation" << std::endl;
-    // std::cout << t << std::endl; 
-
+    // std::cout << "triangulation" << "\n";
+    // std::cout << t << "\n";
   }
-
 }
 
+//////////////////////////////////////////////////
 TEST(CGAL, CreateConstrainedTrianguation4) {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
   typedef CGAL::Triangulation_vertex_base_2<K>                Vbb;
@@ -1616,7 +1663,7 @@ TEST(CGAL, CreateConstrainedTrianguation4) {
   // typedef Triangulation::Face_handle              Face_handle;
   typedef Triangulation::Point                    Point;
   // typedef Triangulation::Face                     Face;
-  
+
   // Points
   Point p0(0, 0);
   Point p1(1, 0);
@@ -1635,16 +1682,16 @@ TEST(CGAL, CreateConstrainedTrianguation4) {
   t.insert_constraint(p0, p3);
 
 
-  // std::cout << "triangulation data structure:" << std::endl;
-  // std::cout << tds << std::endl;
+  // std::cout << "triangulation data structure:" << "\n";
+  // std::cout << tds << "\n";
 
-  // std::cout << "triangulation:" << std::endl;
-  // std::cout << t << std::endl;
+  // std::cout << "triangulation:" << "\n";
+  // std::cout << t << "\n";
 
-  // std::cout << "is valid: " << t.is_valid(true) << std::endl;
-
+  // std::cout << "is valid: " << t.is_valid(true) << "\n";
 }
 
+//////////////////////////////////////////////////
 TEST(CGAL, CreateCTAlt) {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
   typedef CGAL::Triangulation_vertex_base_2<K>                Vbb;
@@ -1660,7 +1707,7 @@ TEST(CGAL, CreateCTAlt) {
   // typedef Triangulation::Face_handle              Face_handle;
   typedef Triangulation::Point                    Point;
   // typedef Triangulation::Face                     Face;
-  
+
   // Points
   Point p0(0, 0);
   Point p1(1, 0);
@@ -1679,17 +1726,17 @@ TEST(CGAL, CreateCTAlt) {
   t.insert(p2);
   t.insert_constraint(p0, p3);
 
-  // std::cout << "triangulation data structure:" << std::endl;
-  // std::cout << tds << std::endl;
+  // std::cout << "triangulation data structure:" << "\n";
+  // std::cout << tds << "\n";
 
-  // std::cout << "triangulation:" << std::endl;
-  // std::cout << t << std::endl;
+  // std::cout << "triangulation:" << "\n";
+  // std::cout << t << "\n";
 
-  // std::cout << "is valid: " << t.is_valid() << std::endl;
+  // std::cout << "is valid: " << t.is_valid() << "\n";
   EXPECT_TRUE(t.is_valid());
-
 }
 
+//////////////////////////////////////////////////
 TEST(CGAL, CreateCTAltN) {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
   typedef CGAL::Projection_traits_xy_3<K>                     Kp;
@@ -1706,7 +1753,7 @@ TEST(CGAL, CreateCTAltN) {
   // typedef Triangulation::Face_handle              Face_handle;
   typedef K::Point_3                              Point;
   // typedef Triangulation::Face                     Face;
-  
+
   // Create the mesh
   std::vector<Point> points;
   std::vector<std::array<size_t, 3>> indices;
@@ -1722,13 +1769,13 @@ TEST(CGAL, CreateCTAltN) {
   Triangulation t;
   // Triangulation::Triangulation_data_structure& tds = t.tds();
 
-  // Points - (N+1) points in each row / column 
-  for (size_t iy=0; iy<=N; ++iy) {
+  // Points - (N+1) points in each row / column
+  for (size_t iy=0; iy <= N; ++iy) {
     double py = iy * dl + lm;
-    for (size_t ix=0; ix<=N; ++ix) {
+    for (size_t ix=0; ix <= N; ++ix) {
       // Vertex position
       double px = ix * dl + lm;
-      Point p(px, py, 0.0); 
+      Point p(px, py, 0.0);
       points.push_back(p);
 
       // Insert point
@@ -1737,22 +1784,23 @@ TEST(CGAL, CreateCTAltN) {
       // Add diagonal constraint
       // if (ix > 0 && iy > 0) {
       //   size_t idx = (iy - 1) * NPlus1 + (ix - 1);
-      //   t.insert_constraint(points[idx], p);        
+      //   t.insert_constraint(points[idx], p);
       // }
     }
   }
 
-  // Insert points - NOTE: must insert the points to build the triangulation hierarchy.
+  // Insert points - NOTE: must insert the points to build the
+  // triangulation hierarchy.
   CGAL::Timer timer;
   timer.start();
   t.insert(points.begin(), points.end());
   timer.stop();
-  // std::cout << "point insertion: " << timer.time() << " s" << std::endl;
+  // std::cout << "point insertion: " << timer.time() << " s" << "\n";
 
-  // Constraint indices 
+  // Constraint indices
   std::vector<std::pair<size_t, size_t>> cindices;
-  for (size_t iy=0; iy<N; ++iy) {
-    for (size_t ix=0; ix<N; ++ix) {
+  for (size_t iy=0; iy < N; ++iy) {
+    for (size_t ix=0; ix < N; ++ix) {
       size_t idx1 = iy * NPlus1 + ix;
       size_t idx2 = (iy + 1) * NPlus1 + (ix + 1);
       cindices.push_back(std::make_pair(idx1, idx2));
@@ -1762,26 +1810,24 @@ TEST(CGAL, CreateCTAltN) {
   // Insert constraints
   timer.reset();
   timer.start();
-  t.insert_constraints(points.begin(), points.end(), cindices.begin(), cindices.end());   
+  t.insert_constraints(points.begin(), points.end(),
+    cindices.begin(), cindices.end());
   timer.stop();
-  // std::cout << "constraint insertion: " << timer.time() << " s" << std::endl;
+  // std::cout << "constraint insertion: " << timer.time() << " s" << "\n";
 
-  // std::cout << "triangulation data structure:" << std::endl;
-  // std::cout << tds << std::endl;
+  // std::cout << "triangulation data structure:" << "\n";
+  // std::cout << tds << "\n";
 
-  // std::cout << "triangulation:" << std::endl;
-  // std::cout << t << std::endl;
+  // std::cout << "triangulation:" << "\n";
+  // std::cout << t << "\n";
 
-  // std::cout << "is valid: " << t.is_valid() << std::endl;
+  // std::cout << "is valid: " << t.is_valid() << "\n";
   EXPECT_TRUE(t.is_valid());
 }
 
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Run tests
-
-int main(int argc, char **argv) {
+//////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/gz-waves/src/CMakeLists.txt
+++ b/gz-waves/src/CMakeLists.txt
@@ -39,12 +39,12 @@ set(gtest_sources
   EigenFFTW_TEST.cc
   Geometry_TEST.cc
   Grid_TEST.cc
+  LinearRegularWaveSimulation_TEST.cc
+  LinearRandomFFTWaveSimulation_TEST.cc
   MeshTools_TEST.cc
   Physics_TEST.cc
   TriangulatedGrid_TEST.cc
   Wavefield_TEST.cc
-  LinearRegularWaveSimulation_TEST.cc
-  LinearRandomFFTWaveSimulation_TEST
   WaveSpectrum_TEST.cc
   WaveSpreadingFunction_TEST.cc
 )

--- a/gz-waves/src/Convert.cc
+++ b/gz-waves/src/Convert.cc
@@ -24,40 +24,40 @@ namespace gz
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////
 // Conversions
-  
-  gz::math::Vector3d ToGz(const cgal::Point3& _point)
-  {
-    return gz::math::Vector3d(_point.x(), _point.y(), _point.z());
-  }
 
-  gz::math::Vector2d ToGz(const cgal::Vector2& _vector)
-  {
-    return gz::math::Vector2d(_vector.x(), _vector.y());
-  }
+gz::math::Vector3d ToGz(const cgal::Point3& _point)
+{
+  return gz::math::Vector3d(_point.x(), _point.y(), _point.z());
+}
 
-  gz::math::Vector3d ToGz(const cgal::Vector3& _vector)
-  {
-    return gz::math::Vector3d(_vector.x(), _vector.y(), _vector.z());
-  }
+gz::math::Vector2d ToGz(const cgal::Vector2& _vector)
+{
+  return gz::math::Vector2d(_vector.x(), _vector.y());
+}
 
-  cgal::Point3 ToPoint3(const gz::math::Vector3d& _vector)
-  {
-    return cgal::Point3(_vector.X(), _vector.Y(), _vector.Z());
-  }
+gz::math::Vector3d ToGz(const cgal::Vector3& _vector)
+{
+  return gz::math::Vector3d(_vector.x(), _vector.y(), _vector.z());
+}
 
-  cgal::Vector2 ToVector2(const gz::math::Vector2d& _vector)
-  {
-    return cgal::Vector2(_vector.X(), _vector.Y());
-  }
+cgal::Point3 ToPoint3(const gz::math::Vector3d& _vector)
+{
+  return cgal::Point3(_vector.X(), _vector.Y(), _vector.Z());
+}
 
-  cgal::Vector3 ToVector3(const gz::math::Vector3d& _vector)
-  {
-    return cgal::Vector3(_vector.X(), _vector.Y(), _vector.Z());
-  }
+cgal::Vector2 ToVector2(const gz::math::Vector2d& _vector)
+{
+  return cgal::Vector2(_vector.X(), _vector.Y());
+}
+
+cgal::Vector3 ToVector3(const gz::math::Vector3d& _vector)
+{
+  return cgal::Vector3(_vector.X(), _vector.Y(), _vector.Z());
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 
-}
-}
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/EigenFFTW_TEST.cc
+++ b/gz-waves/src/EigenFFTW_TEST.cc
@@ -15,27 +15,27 @@
 
 #include <gtest/gtest.h>
 
+#include <Eigen/Dense>
+
+#include <fftw3.h>
+
 #include <complex>
 #include <iostream>
 #include <memory>
 #include <string>
 
-#include <Eigen/Dense>
-
-#include <fftw3.h>
-
 using Eigen::ArrayXXcd;
 using Eigen::ArrayXcd;
 
 namespace Eigen
-{ 
+{
   typedef Eigen::Array<
     double,
     Eigen::Dynamic,
     Eigen::Dynamic,
     Eigen::RowMajor
   > ArrayXXdRowMajor;
-}
+}  // namespace Eigen
 
 //////////////////////////////////////////////////
 TEST(EigenFFWT, DFT_C2C_1D)
@@ -62,16 +62,18 @@ TEST(EigenFFWT, DFT_C2C_1D)
                   0.,     -0.0366116523516816,  0.125,  -0.2133883476483184;
   xhat.imag() <<  0.,     -0.0883883476483184,  0.125,  -0.0883883476483184,
                   0.,      0.0883883476483184, -0.125,   0.0883883476483184;
-  
+
   { // using fftw_complex
-    fftw_complex* in  = (fftw_complex*)fftw_malloc(n * sizeof(fftw_complex));
-    fftw_complex* out = (fftw_complex*)fftw_malloc(n * sizeof(fftw_complex));
+    fftw_complex* in  =
+        reinterpret_cast<fftw_complex*>(fftw_malloc(n * sizeof(fftw_complex)));
+    fftw_complex* out =
+        reinterpret_cast<fftw_complex*>(fftw_malloc(n * sizeof(fftw_complex)));
 
     // create plan
     fftw_plan plan = fftw_plan_dft_1d(n, in, out, FFTW_BACKWARD, FFTW_ESTIMATE);
 
     // populate input
-    for (int i=0; i<n; ++i)
+    for (int i=0; i < n; ++i)
     {
       in[i][0] = xhat(i).real();
       in[i][1] = xhat(i).imag();
@@ -81,7 +83,7 @@ TEST(EigenFFWT, DFT_C2C_1D)
     fftw_execute(plan);
 
     // check output
-    for (int i=0; i<n; ++i)
+    for (int i=0; i < n; ++i)
     {
       // std::cerr << "[" << i << "] "
       //   << out[i][0] << " + " << out[i][1]
@@ -109,7 +111,7 @@ TEST(EigenFFWT, DFT_C2C_1D)
       FFTW_BACKWARD, FFTW_ESTIMATE);
 
     // populate input
-    for (int i=0; i<n; ++i)
+    for (int i=0; i < n; ++i)
     {
       in[i] = xhat(i);
     }
@@ -118,7 +120,7 @@ TEST(EigenFFWT, DFT_C2C_1D)
     fftw_execute(plan);
 
     // check output
-    for (int i=0; i<n; ++i)
+    for (int i=0; i < n; ++i)
     {
       EXPECT_NEAR(out[i].real(), x(i).real(), 1.0E-15);
       EXPECT_NEAR(out[i].imag(), 0.0, 1.0E-15);
@@ -137,7 +139,7 @@ TEST(EigenFFWT, DFT_C2C_1D)
       FFTW_BACKWARD, FFTW_ESTIMATE);
 
     // populate input
-    for (int i=0; i<n; ++i)
+    for (int i=0; i < n; ++i)
     {
       in(i) = xhat(i);
     }
@@ -146,7 +148,7 @@ TEST(EigenFFWT, DFT_C2C_1D)
     fftw_execute(plan);
 
     // check output
-    for (int i=0; i<n; ++i)
+    for (int i=0; i < n; ++i)
     {
       EXPECT_NEAR(out(i).real(), x(i).real(), 1.0E-15);
       EXPECT_NEAR(out(i).imag(), 0.0, 1.0E-15);
@@ -169,7 +171,7 @@ TEST(EigenFFWT, DFT_C2R_1D)
                   0.;
   xhat.imag() <<  0.,     -0.0883883476483184,  0.125,  -0.0883883476483184,
                   0.;
-  
+
   {
     std::vector<std::complex<double>> in(n/2+1, 0.0);
     std::vector<double> out(n, 0.0);
@@ -182,7 +184,7 @@ TEST(EigenFFWT, DFT_C2R_1D)
         FFTW_ESTIMATE);
 
     // populate input
-    for (int i=0; i<n/2+1; ++i)
+    for (int i=0; i < n/2+1; ++i)
     {
       in[i] = xhat(i);
     }
@@ -191,7 +193,7 @@ TEST(EigenFFWT, DFT_C2R_1D)
     fftw_execute(plan);
 
     // check output
-    for (int i=0; i<n; ++i)
+    for (int i=0; i < n; ++i)
     {
       EXPECT_NEAR(out[i], x(i).real(), 1.0E-15);
     }
@@ -248,7 +250,7 @@ TEST(EigenFFWT, EigenStorageOrdering)
       std::cerr << *(col_maj.data() + i) << " ";
     std::cerr << "\n";
     std::cerr << col_maj.reshaped().transpose() << "\n";
-    
+
     Eigen::Array<double, 2, 3, Eigen::RowMajor> row_maj = col_maj;
 
     std::cerr << "in memory (row-major):" << "\n";
@@ -261,8 +263,6 @@ TEST(EigenFFWT, EigenStorageOrdering)
 #endif
 
 //////////////////////////////////////////////////
-// Run tests
-
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/gz-waves/src/Geometry.cc
+++ b/gz-waves/src/Geometry.cc
@@ -33,313 +33,314 @@ namespace gz
 {
 namespace waves
 {
-  // Typedefs
-  typedef boost::optional<cgal::AABBTree::Intersection_and_primitive_id<cgal::Ray>::Type> RayIntersection;
+// Typedefs
+typedef boost::optional<cgal::AABBTree::Intersection_and_primitive_id<
+    cgal::Ray>::Type> RayIntersection;
 
-  double Geometry::TriangleArea(
-    const cgal::Point3& _p0,
-    const cgal::Point3& _p1,
-    const cgal::Point3& _p2
-  )
+double Geometry::TriangleArea(
+  const cgal::Point3& _p0,
+  const cgal::Point3& _p1,
+  const cgal::Point3& _p2
+)
+{
+  cgal::Vector3 e1 = _p1 - _p0;
+  cgal::Vector3 e2 = _p2 - _p0;
+  return 0.5 * std::sqrt(CGAL::cross_product(e1, e2).squared_length());
+}
+
+double Geometry::TriangleArea(
+  const cgal::Triangle& _tri
+)
+{
+  return TriangleArea(_tri[0], _tri[1], _tri[2]);
+}
+
+cgal::Point3 Geometry::TriangleCentroid(
+  const cgal::Point3& _p0,
+  const cgal::Point3& _p1,
+  const cgal::Point3& _p2
+)
+{
+  return CGAL::centroid(_p0, _p1, _p2);
+}
+
+cgal::Point3 Geometry::TriangleCentroid(
+  const cgal::Triangle& _tri
+)
+{
+  return CGAL::centroid(_tri[0], _tri[1], _tri[2]);
+}
+
+cgal::Point3 Geometry::MidPoint(
+  const cgal::Point3& _p0,
+  const cgal::Point3& _p1
+)
+{
+  return CGAL::midpoint(_p0, _p1);
+}
+
+cgal::Point3 Geometry::Normalize(const cgal::Point3& _p)
+{
+  if (_p == CGAL::ORIGIN)
+    return _p;
+  else
   {
-    cgal::Vector3 e1 = _p1 - _p0;
-    cgal::Vector3 e2 = _p2 - _p0;
-    return 0.5 * std::sqrt(CGAL::cross_product(e1, e2).squared_length());
+    cgal::Vector3 v = _p - CGAL::ORIGIN;
+    double norm = std::sqrt(v.squared_length());
+    return cgal::Point3(_p.x()/norm, _p.y()/norm, _p.z()/norm);
   }
+}
 
-  double Geometry::TriangleArea(
-    const cgal::Triangle& _tri
-  )
+cgal::Vector2 Geometry::Normalize(const cgal::Vector2& _v)
+{
+  if (_v == CGAL::NULL_VECTOR)
+    return _v;
+  else
+    return _v/std::sqrt(_v.squared_length());
+}
+
+cgal::Vector3 Geometry::Normalize(const cgal::Vector3& _v)
+{
+  if (_v == CGAL::NULL_VECTOR)
+    return _v;
+  else
+    return _v/std::sqrt(_v.squared_length());
+}
+
+cgal::Vector3 Geometry::Normal(
+  const cgal::Point3& _p0,
+  const cgal::Point3& _p1,
+  const cgal::Point3& _p2
+)
+{
+  auto n = CGAL::normal(_p0, _p1, _p2);
+  if (n == CGAL::NULL_VECTOR)
+    return n;
+  else
+    return n/std::sqrt(n.squared_length());
+}
+
+cgal::Vector3 Geometry::Normal(
+  const cgal::Triangle& _tri
+)
+{
+  /// \todo improve handling of triangles containing collinear points
+  /// https://github.com/srmainwaring/asv_wave_sim/issues/50
+  if (CGAL::collinear(_tri[0], _tri[1], _tri[2]))
   {
-    return TriangleArea(_tri[0], _tri[1], _tri[2]);
+    return CGAL::NULL_VECTOR;
   }
+  auto n = CGAL::normal(_tri[0], _tri[1], _tri[2]);
+  if (n == CGAL::NULL_VECTOR)
+    return n;
+  else
+    return n/std::sqrt(n.squared_length());
+}
 
-  cgal::Point3 Geometry::TriangleCentroid(
-    const cgal::Point3& _p0,
-    const cgal::Point3& _p1,
-    const cgal::Point3& _p2
-  )
+cgal::Vector3 Geometry::Normal(const cgal::Mesh& _mesh, cgal::FaceIndex _face)
+{
+  cgal::HalfedgeIndex hf = _mesh.halfedge(_face);
+  const cgal::Point3& p0 = _mesh.point(_mesh.target(hf));
+  hf = _mesh.next(hf);
+  const cgal::Point3& p1 = _mesh.point(_mesh.target(hf));
+  hf = _mesh.next(hf);
+  const cgal::Point3& p2 = _mesh.point(_mesh.target(hf));
+  hf = _mesh.next(hf);
+
+  auto n = CGAL::normal(p0, p1, p2);
+
+  if (n == CGAL::NULL_VECTOR)
+    return n;
+  else
+    return n/std::sqrt(n.squared_length());
+}
+
+cgal::Point3 Geometry::HorizontalIntercept(
+  const cgal::Point3& _high,
+  const cgal::Point3& _mid,
+  const cgal::Point3& _low
+)
+{
+  // If _high.Z() = _low().Z() then _high.Z() = _low.Z() = _mid.Z()
+  // so any point on the line LH will satisfy the intercept condition,
+  // including t=0, which we set as default (and so return _low).
+  double t = 0.0;
+  double div = _high.z() - _low.z();
+  if (std::abs(div) > std::numeric_limits<double>::epsilon())
   {
-    return CGAL::centroid(_p0, _p1, _p2);
+    t = (_mid.z() - _low.z()) / div;
   }
+  return cgal::Point3(
+    _low.x() + t * (_high.x() - _low.x()),
+    _low.y() + t * (_high.y() - _low.y()),
+    _mid.z());
+}
 
-  cgal::Point3 Geometry::TriangleCentroid(
-    const cgal::Triangle& _tri
-  )
-  {
-    return CGAL::centroid(_tri[0], _tri[1], _tri[2]);
-  }
-
-  cgal::Point3 Geometry::MidPoint(
-    const cgal::Point3& _p0,
-    const cgal::Point3& _p1
-  )
-  {
-    return CGAL::midpoint(_p0, _p1);
-  }
-
-  cgal::Point3 Geometry::Normalize(const cgal::Point3& _p)
-  {
-    if (_p == CGAL::ORIGIN)
-      return _p;
-    else
-    {
-      cgal::Vector3 v = _p - CGAL::ORIGIN;
-      double norm = std::sqrt(v.squared_length());
-      return cgal::Point3(_p.x()/norm, _p.y()/norm, _p.z()/norm);
-    }
-  }
-
-  cgal::Vector2 Geometry::Normalize(const cgal::Vector2& _v)
-  {
-    if (_v == CGAL::NULL_VECTOR)
-      return _v;
-    else
-      return _v/std::sqrt(_v.squared_length()); 
-  }
-
-  cgal::Vector3 Geometry::Normalize(const cgal::Vector3& _v)
-  {
-    if (_v == CGAL::NULL_VECTOR)
-      return _v;
-    else
-      return _v/std::sqrt(_v.squared_length()); 
-  }
-
-  cgal::Vector3 Geometry::Normal(
-    const cgal::Point3& _p0,
-    const cgal::Point3& _p1,
-    const cgal::Point3& _p2
-  )
-  {
-    auto n = CGAL::normal(_p0, _p1, _p2);
-    if (n == CGAL::NULL_VECTOR)
-      return n;
-    else
-      return n/std::sqrt(n.squared_length()); 
-  }
-
-  cgal::Vector3 Geometry::Normal(
-    const cgal::Triangle& _tri
-  )
-  {
-    /// \todo improve handling of triangles containing collinear points
-    /// https://github.com/srmainwaring/asv_wave_sim/issues/50
-    if (CGAL::collinear(_tri[0], _tri[1], _tri[2]))
-    {
-      return CGAL::NULL_VECTOR;
-    }
-    auto n = CGAL::normal(_tri[0], _tri[1], _tri[2]);
-    if (n == CGAL::NULL_VECTOR)
-      return n;
-    else
-      return n/std::sqrt(n.squared_length()); 
-  }
-
-  cgal::Vector3 Geometry::Normal(const cgal::Mesh& _mesh, cgal::FaceIndex _face)
-  {
-    cgal::HalfedgeIndex hf = _mesh.halfedge(_face);
-    const cgal::Point3& p0 = _mesh.point(_mesh.target(hf));
-    hf = _mesh.next(hf);
-    const cgal::Point3& p1= _mesh.point(_mesh.target(hf));
-    hf = _mesh.next(hf);
-    const cgal::Point3& p2 = _mesh.point(_mesh.target(hf));
-    hf = _mesh.next(hf);
-
-    auto n = CGAL::normal(p0, p1, p2);
-
-    if (n == CGAL::NULL_VECTOR)
-      return n;
-    else
-      return n/std::sqrt(n.squared_length()); 
-  }
-
-  cgal::Point3 Geometry::HorizontalIntercept(
-    const cgal::Point3& _high,
-    const cgal::Point3& _mid,
-    const cgal::Point3& _low
-  )
-  {
-    // If _high.Z() = _low().Z() then _high.Z() = _low.Z() = _mid.Z()
-    // so any point on the line LH will satisfy the intercept condition,
-    // including t=0, which we set as default (and so return _low).
-    double t = 0.0;
-    double div = _high.z() - _low.z();
-    if (std::abs(div) > std::numeric_limits<double>::epsilon())
-    {
-      t = (_mid.z() - _low.z()) / div;
-    }
-    return cgal::Point3(
-      _low.x() + t * (_high.x() - _low.x()),
-      _low.y() + t * (_high.y() - _low.y()),
-      _mid.z()
-    );
-  }
-
-  bool Geometry::RayIntersectsTriangle(
-    const cgal::Point3& _origin,
-    const cgal::Direction3& _direction,
-    const cgal::Triangle& _tri,
-    cgal::Point3& _intersection
-  )
-  {    
-    const cgal::Point3& p0 = _tri[0];
-    const cgal::Point3& p1 = _tri[1];  
-    const cgal::Point3& p2 = _tri[2];
-    cgal::Vector3 _ray(_direction.vector());
-    cgal::Vector3 e1 = p1 - p0;
-    cgal::Vector3 e2 = p2 - p0;
-    cgal::Vector3 h = CGAL::cross_product(_ray, e2);
-    double a = CGAL::scalar_product(e1, h);
-    if (a > -std::numeric_limits<double>::epsilon()
-      && a < std::numeric_limits<double>::epsilon())
-        return false;    // This ray is parallel to this triangle.
-    double f = 1.0 / a;
-    cgal::Vector3 s = _origin - p0;
-    double u = f * CGAL::scalar_product(s, h);
-    if (u < 0.0 || u > 1.0)
-        return false;
-    cgal::Vector3 q = CGAL::cross_product(s, e1);
-    double v = f * CGAL::scalar_product(_ray, q);
-    if (v < 0.0 || u + v > 1.0)
-        return false;
-    // At this stage we can compute t to find out where the intersection point is on the line.
-    double t = f * CGAL::scalar_product(e2, q);
-    if (t > std::numeric_limits<double>::epsilon()) 
-    {
-      // ray intersection
-      _intersection = _origin + _ray * t;
-      return true;
-    }
-    else 
-    {
-      // This means that there is a line intersection but not a ray intersection.
+bool Geometry::RayIntersectsTriangle(
+  const cgal::Point3& _origin,
+  const cgal::Direction3& _direction,
+  const cgal::Triangle& _tri,
+  cgal::Point3& _intersection
+)
+{
+  const cgal::Point3& p0 = _tri[0];
+  const cgal::Point3& p1 = _tri[1];
+  const cgal::Point3& p2 = _tri[2];
+  cgal::Vector3 _ray(_direction.vector());
+  cgal::Vector3 e1 = p1 - p0;
+  cgal::Vector3 e2 = p2 - p0;
+  cgal::Vector3 h = CGAL::cross_product(_ray, e2);
+  double a = CGAL::scalar_product(e1, h);
+  if (a > -std::numeric_limits<double>::epsilon()
+    && a < std::numeric_limits<double>::epsilon())
+      return false;    // This ray is parallel to this triangle.
+  double f = 1.0 / a;
+  cgal::Vector3 s = _origin - p0;
+  double u = f * CGAL::scalar_product(s, h);
+  if (u < 0.0 || u > 1.0)
       return false;
-    }
-  }
-
-  bool Geometry::LineIntersectsTriangle(
-    const cgal::Point3& _origin,
-    const cgal::Direction3& _direction,
-    const cgal::Triangle& _tri,
-    cgal::Point3& _intersection
-  )
+  cgal::Vector3 q = CGAL::cross_product(s, e1);
+  double v = f * CGAL::scalar_product(_ray, q);
+  if (v < 0.0 || u + v > 1.0)
+      return false;
+  // At this stage we can compute t to find out where the intersection point
+  // is on the line.
+  double t = f * CGAL::scalar_product(e2, q);
+  if (t > std::numeric_limits<double>::epsilon())
   {
-    return LineIntersectsTriangle(
-      _origin, _direction, _tri[0], _tri[1], _tri[2], _intersection);
-  }
-
-  bool Geometry::LineIntersectsTriangle(
-    const cgal::Point3& _origin,
-    const cgal::Direction3& _direction,
-    const cgal::Point3& _p0,
-    const cgal::Point3& _p1,  
-    const cgal::Point3& _p2,
-    cgal::Point3& _intersection
-  )
-  {
-    cgal::Vector3 _ray(_direction.vector());
-    cgal::Vector3 e1 = _p1 - _p0;
-    cgal::Vector3 e2 = _p2 - _p0;
-    cgal::Vector3 h = CGAL::cross_product(_ray, e2);
-    double a = CGAL::scalar_product(e1, h);
-    if (a > -std::numeric_limits<double>::epsilon()
-      && a < std::numeric_limits<double>::epsilon())
-        return false;    // This ray is parallel to this triangle.
-    double f = 1.0 / a;
-    cgal::Vector3 s = _origin - _p0;
-    double u = f * CGAL::scalar_product(s, h);
-    if (u < 0.0 || u > 1.0)
-        return false;
-    cgal::Vector3 q = CGAL::cross_product(s, e1);
-    double v = f * CGAL::scalar_product(_ray, q);
-    if (v < 0.0 || u + v > 1.0)
-        return false;
-    // At this stage we can compute t to find out where the intersection point is on the line.
-    double t = f * CGAL::scalar_product(e2, q);
+    // ray intersection
     _intersection = _origin + _ray * t;
     return true;
-  }
-
-  cgal::Triangle Geometry::MakeTriangle(const cgal::Mesh& _mesh, cgal::FaceIndex _face)
-  {
-    cgal::HalfedgeIndex hf = _mesh.halfedge(_face);
-    const cgal::Point3& p0 = _mesh.point(_mesh.target(hf));
-    hf = _mesh.next(hf);
-    const cgal::Point3& p1 = _mesh.point(_mesh.target(hf));
-    hf = _mesh.next(hf);
-    const cgal::Point3& p2 = _mesh.point(_mesh.target(hf));
-    hf = _mesh.next(hf);
-    return cgal::Triangle(p0, p1, p2);
-  }
-
-  std::shared_ptr<cgal::AABBTree> Geometry::MakeAABBTree(const cgal::Mesh& _mesh)
-  {
-    std::shared_ptr<cgal::AABBTree> tree(
-      new cgal::AABBTree(faces(_mesh).first, faces(_mesh).second, _mesh));
-    tree->build();
-    return tree;
-  }
-
-  bool Geometry::SearchMesh(
-    const cgal::Mesh& _mesh,
-    const cgal::Point3& _origin,
-    const cgal::Direction3& _direction,
-    cgal::Point3& _intersection
-  )
-  {
-    // AABB Tree
-    cgal::AABBTree tree(faces(_mesh).first, faces(_mesh).second, _mesh);
-    tree.build();
-    
-    // Query
-    cgal::Ray query(_origin, _direction);
-    RayIntersection intersection = tree.first_intersection(query);
-
-    // Search both directions
-    if (!intersection)
-      intersection = tree.first_intersection(query.opposite());
-
-    // Retrieve intersection point
-    if (intersection)
-    {
-      if (boost::get<cgal::Point3>(&(intersection->first)))
-      {
-        const cgal::Point3* p =  boost::get<cgal::Point3>(&(intersection->first));
-        _intersection = *p;
-        return true;
-      }
-    }
+  } else {
+    // This means that there is a line intersection but not a ray intersection.
     return false;
   }
+}
 
-  bool Geometry::SearchMesh(
-    const cgal::AABBTree& _tree,
-    const cgal::Point3& _origin,
-    const cgal::Direction3& _direction,
-    cgal::Point3& _intersection
-  )
+bool Geometry::LineIntersectsTriangle(
+  const cgal::Point3& _origin,
+  const cgal::Direction3& _direction,
+  const cgal::Triangle& _tri,
+  cgal::Point3& _intersection
+)
+{
+  return LineIntersectsTriangle(
+    _origin, _direction, _tri[0], _tri[1], _tri[2], _intersection);
+}
+
+bool Geometry::LineIntersectsTriangle(
+  const cgal::Point3& _origin,
+  const cgal::Direction3& _direction,
+  const cgal::Point3& _p0,
+  const cgal::Point3& _p1,
+  const cgal::Point3& _p2,
+  cgal::Point3& _intersection
+)
+{
+  cgal::Vector3 _ray(_direction.vector());
+  cgal::Vector3 e1 = _p1 - _p0;
+  cgal::Vector3 e2 = _p2 - _p0;
+  cgal::Vector3 h = CGAL::cross_product(_ray, e2);
+  double a = CGAL::scalar_product(e1, h);
+  if (a > -std::numeric_limits<double>::epsilon()
+    && a < std::numeric_limits<double>::epsilon())
+      return false;    // This ray is parallel to this triangle.
+  double f = 1.0 / a;
+  cgal::Vector3 s = _origin - _p0;
+  double u = f * CGAL::scalar_product(s, h);
+  if (u < 0.0 || u > 1.0)
+      return false;
+  cgal::Vector3 q = CGAL::cross_product(s, e1);
+  double v = f * CGAL::scalar_product(_ray, q);
+  if (v < 0.0 || u + v > 1.0)
+      return false;
+  // At this stage we can compute t to find out where the intersection point
+  // is on the line.
+  double t = f * CGAL::scalar_product(e2, q);
+  _intersection = _origin + _ray * t;
+  return true;
+}
+
+cgal::Triangle Geometry::MakeTriangle(
+    const cgal::Mesh& _mesh, cgal::FaceIndex _face)
+{
+  cgal::HalfedgeIndex hf = _mesh.halfedge(_face);
+  const cgal::Point3& p0 = _mesh.point(_mesh.target(hf));
+  hf = _mesh.next(hf);
+  const cgal::Point3& p1 = _mesh.point(_mesh.target(hf));
+  hf = _mesh.next(hf);
+  const cgal::Point3& p2 = _mesh.point(_mesh.target(hf));
+  hf = _mesh.next(hf);
+  return cgal::Triangle(p0, p1, p2);
+}
+
+std::shared_ptr<cgal::AABBTree> Geometry::MakeAABBTree(const cgal::Mesh& _mesh)
+{
+  std::shared_ptr<cgal::AABBTree> tree(
+    new cgal::AABBTree(faces(_mesh).first, faces(_mesh).second, _mesh));
+  tree->build();
+  return tree;
+}
+
+bool Geometry::SearchMesh(
+  const cgal::Mesh& _mesh,
+  const cgal::Point3& _origin,
+  const cgal::Direction3& _direction,
+  cgal::Point3& _intersection
+)
+{
+  // AABB Tree
+  cgal::AABBTree tree(faces(_mesh).first, faces(_mesh).second, _mesh);
+  tree.build();
+
+  // Query
+  cgal::Ray query(_origin, _direction);
+  RayIntersection intersection = tree.first_intersection(query);
+
+  // Search both directions
+  if (!intersection)
+    intersection = tree.first_intersection(query.opposite());
+
+  // Retrieve intersection point
+  if (intersection)
   {
-    // Query
-    cgal::Ray query(_origin, _direction);
-    RayIntersection intersection = _tree.first_intersection(query);
-
-    // Search both directions
-    if (!intersection)
-      intersection = _tree.first_intersection(query.opposite());
-
-    // Retrieve intersection point
-    if (intersection)
+    if (boost::get<cgal::Point3>(&(intersection->first)))
     {
-      if (boost::get<cgal::Point3>(&(intersection->first)))
-      {
-        const cgal::Point3* p =  boost::get<cgal::Point3>(&(intersection->first));
-        _intersection = *p;
-        return true;
-      }
+      const cgal::Point3* p =  boost::get<cgal::Point3>(&(intersection->first));
+      _intersection = *p;
+      return true;
     }
-    return false;
   }
+  return false;
+}
 
+bool Geometry::SearchMesh(
+  const cgal::AABBTree& _tree,
+  const cgal::Point3& _origin,
+  const cgal::Direction3& _direction,
+  cgal::Point3& _intersection
+)
+{
+  // Query
+  cgal::Ray query(_origin, _direction);
+  RayIntersection intersection = _tree.first_intersection(query);
+
+  // Search both directions
+  if (!intersection)
+    intersection = _tree.first_intersection(query.opposite());
+
+  // Retrieve intersection point
+  if (intersection)
+  {
+    if (boost::get<cgal::Point3>(&(intersection->first)))
+    {
+      const cgal::Point3* p =  boost::get<cgal::Point3>(&(intersection->first));
+      _intersection = *p;
+      return true;
+    }
+  }
+  return false;
 }
-}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/Geometry_TEST.cc
+++ b/gz-waves/src/Geometry_TEST.cc
@@ -13,10 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "gz/waves/Geometry.hh"
-#include "gz/waves/Grid.hh"
-#include "gz/waves/MeshTools.hh"
-
 #include <gtest/gtest.h>
 
 #include <array>
@@ -24,66 +20,79 @@
 #include <iterator>
 #include <string>
 
-using namespace gz;
-using namespace waves;
+#include "gz/waves/Geometry.hh"
+#include "gz/waves/Grid.hh"
+#include "gz/waves/MeshTools.hh"
 
-///////////////////////////////////////////////////////////////////////////////
-// Define tests
+namespace cgal
+{
+using gz::cgal::AABBTree;
+using gz::cgal::Direction3;
+using gz::cgal::Mesh;
+using gz::cgal::Point3;
+using gz::cgal::Triangle;
+using gz::cgal::Vector3;
+}  // namespace cgal
 
+namespace waves
+{
+using gz::waves::Grid;
+}  // namespace waves
+
+using gz::waves::Geometry;
+
+//////////////////////////////////////////////////
 TEST(Geometry, TriangleArea)
 {
   { // Case 1 - b = 1, h = 1
     cgal::Triangle t(
       cgal::Point3(0, 0, 0),
       cgal::Point3(1, 0, 0),
-      cgal::Point3(0, 1, 0)    
-    );    
+      cgal::Point3(0, 1, 0));
     double area = Geometry::TriangleArea(t);
     EXPECT_EQ(area, 0.5);
   }
 
-  { // Case 1 - b = sqrt(2), h = srqt(1^2 + (1/2)^2 + (1/2)^2) = sqrt(1.5) 
+  { // Case 1 - b = sqrt(2), h = srqt(1^2 + (1/2)^2 + (1/2)^2) = sqrt(1.5)
     cgal::Triangle t(
       cgal::Point3(1, 0, 0),
       cgal::Point3(0, 1, 0),
-      cgal::Point3(0, 0, 1)
-    );    
+      cgal::Point3(0, 0, 1));
     double area = Geometry::TriangleArea(t);
     EXPECT_EQ(area, 0.5*std::sqrt(3));
   }
 }
 
+//////////////////////////////////////////////////
 TEST(Geometry, TriangleCentroid)
 {
   { // Case 1: triangle in xy-plane
     cgal::Triangle t(
       cgal::Point3(0, 0, 0),
       cgal::Point3(1, 0, 0),
-      cgal::Point3(0, 1, 0)    
-    );    
-    cgal::Point3 c = Geometry::TriangleCentroid(t);  
+      cgal::Point3(0, 1, 0));
+    cgal::Point3 c = Geometry::TriangleCentroid(t);
     EXPECT_EQ(c, cgal::Point3(1.0/3.0, 1.0/3.0, 0));
   }
 
-  { // Case 2: triangle intersecting each axis at 1 
+  { // Case 2: triangle intersecting each axis at 1
     cgal::Triangle t(
       cgal::Point3(1, 0, 0),
       cgal::Point3(0, 1, 0),
-      cgal::Point3(0, 0, 1)    
-    );    
-    cgal::Point3 c = Geometry::TriangleCentroid(t);  
+      cgal::Point3(0, 0, 1));
+    cgal::Point3 c = Geometry::TriangleCentroid(t);
     EXPECT_EQ(c, cgal::Point3(1.0/3.0, 1.0/3.0, 1.0/3.0));
   }
 }
 
+//////////////////////////////////////////////////
 TEST(Geometry, TriangleNormal)
 {
   { // xy - plane
     cgal::Triangle t(
       cgal::Point3(0, 0, 0),
       cgal::Point3(1, 0, 0),
-      cgal::Point3(0, 1, 0)    
-    );    
+      cgal::Point3(0, 1, 0));
     cgal::Vector3 n = Geometry::Normal(t);
     EXPECT_EQ(n, cgal::Vector3(0, 0, 1));
   }
@@ -92,8 +101,7 @@ TEST(Geometry, TriangleNormal)
     cgal::Triangle t(
       cgal::Point3(0, 0, 0),
       cgal::Point3(0, 1, 0),
-      cgal::Point3(1, 0, 0)    
-    );    
+      cgal::Point3(1, 0, 0));
     cgal::Vector3 n = Geometry::Normal(t);
     EXPECT_EQ(n, cgal::Vector3(0, 0, -1));
   }
@@ -102,8 +110,7 @@ TEST(Geometry, TriangleNormal)
     cgal::Triangle t(
       cgal::Point3(0, 0, 0),
       cgal::Point3(1, 0, 0),
-      cgal::Point3(0, 0, 1)    
-    );    
+      cgal::Point3(0, 0, 1));
     cgal::Vector3 n = Geometry::Normal(t);
     EXPECT_EQ(n, cgal::Vector3(0, -1, 0));
   }
@@ -112,8 +119,7 @@ TEST(Geometry, TriangleNormal)
     cgal::Triangle t(
       cgal::Point3(0, 0, 0),
       cgal::Point3(0, 0, 1),
-      cgal::Point3(1, 0, 0)
-    );    
+      cgal::Point3(1, 0, 0));
     cgal::Vector3 n = Geometry::Normal(t);
     EXPECT_EQ(n, cgal::Vector3(0, 1, 0));
   }
@@ -122,8 +128,7 @@ TEST(Geometry, TriangleNormal)
     cgal::Triangle t(
       cgal::Point3(1, 0, 0),
       cgal::Point3(0, 1, 0),
-      cgal::Point3(0, 0, 1)    
-    );    
+      cgal::Point3(0, 0, 1));
     cgal::Vector3 n = Geometry::Normal(t);
     EXPECT_EQ(n, cgal::Vector3(1/sqrt(3), 1/sqrt(3), 1/sqrt(3)));
   }
@@ -132,8 +137,7 @@ TEST(Geometry, TriangleNormal)
     cgal::Triangle t(
       cgal::Point3(1, 0, 0),
       cgal::Point3(0, 0, 1),
-      cgal::Point3(0, 1, 0)    
-    );    
+      cgal::Point3(0, 1, 0));
     cgal::Vector3 n = Geometry::Normal(t);
     EXPECT_EQ(n, cgal::Vector3(-1/sqrt(3), -1/sqrt(3), -1/sqrt(3)));
   }
@@ -142,35 +146,35 @@ TEST(Geometry, TriangleNormal)
     cgal::Triangle t(
       cgal::Point3(0, 0, 0),
       cgal::Point3(1, 0, 0),
-      cgal::Point3(2, 0, 0)    
-    );    
+      cgal::Point3(2, 0, 0));
     cgal::Vector3 n = Geometry::Normal(t);
     EXPECT_EQ(n, cgal::Vector3(0, 0, 0));
   }
 }
 
+//////////////////////////////////////////////////
 TEST(Geometry, HorizontalIntercept)
 {
-  // Case - parallel to xz-plane 
-  { 
-    cgal::Point3 H( 0, 0, -10);
+  // Case - parallel to xz-plane
+  {
+    cgal::Point3 H(0, 0, -10);
     cgal::Point3 M(10, 0, -20);
-    cgal::Point3 L( 0, 0, -20);
+    cgal::Point3 L(0, 0, -20);
     cgal::Point3 D = Geometry::HorizontalIntercept(H, M, L);
     EXPECT_EQ(D, cgal::Point3(0, 0, -20));
   }
 
   // Case - parallel to xy-plane
-  { 
-    cgal::Point3 H( 0, 0, -10);
+  {
+    cgal::Point3 H(0, 0, -10);
     cgal::Point3 M(10, 0, -10);
-    cgal::Point3 L( 0, 10, -10);
+    cgal::Point3 L(0, 10, -10);
     cgal::Point3 D = Geometry::HorizontalIntercept(H, M, L);
     EXPECT_EQ(D, L);
   }
-
 }
 
+//////////////////////////////////////////////////
 TEST(Geometry, MidPoint)
 {
   { // General vector
@@ -202,6 +206,7 @@ TEST(Geometry, MidPoint)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(Geometry, LineIntersectsTriangle)
 {
   { // Triangle in xy-plane. Line intersects
@@ -217,7 +222,7 @@ TEST(Geometry, LineIntersectsTriangle)
     cgal::Point3 origin(0.5, 0.5, 1);
     cgal::Direction3 direction(0, 0, 1);
     cgal::Point3 point = CGAL::ORIGIN;
-    std::shared_ptr<cgal::AABBTree> tree = Geometry::MakeAABBTree(mesh);  
+    std::shared_ptr<cgal::AABBTree> tree = Geometry::MakeAABBTree(mesh);
     bool isFound = Geometry::SearchMesh(*tree, origin, direction, point);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(point, cgal::Point3(0.5, 0.5, 0));
@@ -236,7 +241,7 @@ TEST(Geometry, LineIntersectsTriangle)
     cgal::Point3 origin(0.5, 0.5, 1);
     cgal::Direction3 direction(0, 0, -1);
     cgal::Point3 point = CGAL::ORIGIN;
-    std::shared_ptr<cgal::AABBTree> tree = Geometry::MakeAABBTree(mesh);  
+    std::shared_ptr<cgal::AABBTree> tree = Geometry::MakeAABBTree(mesh);
     bool isFound = Geometry::SearchMesh(*tree, origin, direction, point);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(point, cgal::Point3(0.5, 0.5, 0));
@@ -281,14 +286,15 @@ TEST(Geometry, LineIntersectsTriangle)
   }
 }
 
+//////////////////////////////////////////////////
 // @TODO_UPDATE - these tests are over a Mesh not a cell - update
 TEST(Geometry, SearchCell)
 {
   // 2x2 Grid in xy-plane.
-  Grid grid({ 2, 2 }, { 2, 2 });
+  waves::Grid grid({ 2, 2 }, { 2, 2 });
 
   const cgal::Mesh& mesh = *grid.GetMesh();
-  std::shared_ptr<cgal::AABBTree> tree = Geometry::MakeAABBTree(mesh);  
+  std::shared_ptr<cgal::AABBTree> tree = Geometry::MakeAABBTree(mesh);
 
   { // Line intersects Cell(1, 1).
     cgal::Point3 origin(0.5, 0.5, 1);
@@ -309,14 +315,15 @@ TEST(Geometry, SearchCell)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(Geometry, SearchGrid)
 {
   // 2x2 Grid in xy-plane.
   std::string gridName("grid_2x2");
-  Grid grid({ 2, 2 }, { 2, 2 });
+  waves::Grid grid({ 2, 2 }, { 2, 2 });
 
   const cgal::Mesh& mesh = *grid.GetMesh();
-  std::shared_ptr<cgal::AABBTree> tree = Geometry::MakeAABBTree(mesh);  
+  std::shared_ptr<cgal::AABBTree> tree = Geometry::MakeAABBTree(mesh);
 
   { // Line intersects Cell(0, 0).
     cgal::Point3 origin(-0.5, -0.5, 1);
@@ -359,9 +366,7 @@ TEST(Geometry, SearchGrid)
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Run tests
-
+//////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/gz-waves/src/Grid.cc
+++ b/gz-waves/src/Grid.cc
@@ -14,15 +14,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/Grid.hh"
-#include "gz/waves/CGALTypes.hh"
-#include "gz/waves/Geometry.hh"
-#include "gz/waves/Types.hh"
 
 #include <CGAL/number_utils.h>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
-
-#include <gz/common.hh>
 
 #include <array>
 #include <iostream>
@@ -30,505 +25,530 @@
 #include <string>
 #include <vector>
 
+#include <gz/common.hh>
+
+#include "gz/waves/CGALTypes.hh"
+#include "gz/waves/Geometry.hh"
+#include "gz/waves/Types.hh"
+
 namespace gz
 {
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////
-// GridPrivate
+//////////////////////////////////////////////////
+class GridPrivate
+{
+ public:
+  /// \brief The size of the grid in each direction
+  std::array<double, 2> size;
 
-  class GridPrivate
+  /// \brief The number of cells in each direction
+  std::array<Index, 2> cellCount;
+
+  /// \brief The position of the grid center
+  cgal::Point3 center;
+
+  /// \brief The grid mesh
+  std::shared_ptr<cgal::Mesh> mesh;
+
+  /// \brief The grid normals (for each face)
+  std::vector<cgal::Vector3> normals;
+};
+
+//////////////////////////////////////////////////
+Grid::Grid(
+  const std::array<double, 2>& _size,
+  const std::array<Index, 2>& _cellCount) :
+    data(new GridPrivate())
+{
+  this->data->size = _size;
+  this->data->cellCount = _cellCount;
+  this->data->center = CGAL::ORIGIN;
+  this->data->mesh = std::make_shared<cgal::Mesh>();
+
+  // Grid dimensions
+  const Index nx = this->data->cellCount[0];
+  const Index ny = this->data->cellCount[1];
+  const double Lx = this->data->size[0];
+  const double Ly = this->data->size[1];
+  const double lx = Lx/nx;
+  const double ly = Ly/ny;
+
+  auto& mesh = *this->data->mesh;
+  auto& normals = this->data->normals;
+
+  // Add vertices
+  for (Index iy=0; iy <= ny; ++iy)
   {
-    /// \brief The size of the grid in each direction
-    public: std::array<double, 2> size;
-
-    /// \brief The number of cells in each direction
-    public: std::array<Index, 2> cellCount;
-    
-    /// \brief The position of the grid center
-    public: cgal::Point3 center;
-
-    /// \brief The grid mesh
-    public: std::shared_ptr<cgal::Mesh> mesh;
-
-    /// \brief The grid normals (for each face)
-    public: std::vector<cgal::Vector3> normals;
-  };
-
-///////////////////////////////////////////////////////////////////////////////
-// Grid
-
-  Grid::Grid(
-    const std::array<double, 2>& _size,
-    const std::array<Index, 2>& _cellCount
-  ) : data(new GridPrivate()) 
-  {
-    this->data->size = _size;
-    this->data->cellCount = _cellCount;
-    this->data->center = CGAL::ORIGIN;
-    this->data->mesh = std::make_shared<cgal::Mesh>();
-
-    // Grid dimensions
-    const Index nx = this->data->cellCount[0];
-    const Index ny = this->data->cellCount[1];
-    const double Lx = this->data->size[0];
-    const double Ly = this->data->size[1];
-    const double lx = Lx/nx;
-    const double ly = Ly/ny;
-
-    auto& mesh = *this->data->mesh;
-    auto& normals = this->data->normals;
-
-    // Add vertices
-    for (Index iy=0; iy<=ny; ++iy)
+    double py = iy * ly - Ly/2.0;
+    for (Index ix=0; ix <= nx; ++ix)
     {
-      double py = iy * ly - Ly/2.0;
-      for (Index ix=0; ix<=nx; ++ix)
-      {
-        double px = ix * lx - Lx/2.0;
-        mesh.add_vertex(cgal::Point3(px, py, 0));
-      }
-    }
-
-    // Add faces
-    for (Index iy=0; iy<ny; ++iy)
-    {
-      for (Index ix=0; ix<nx; ++ix)
-      {
-        // Get the vertices in the cell coordinates
-        const Index idx0 = iy * (nx+1) + ix;
-        const Index idx1 = iy * (nx+1) + ix + 1;
-        const Index idx2 = (iy+1) * (nx+1) + ix + 1;
-        const Index idx3 = (iy+1) * (nx+1) + ix;
-
-        // Vertex iterators
-        auto v0 = std::begin(mesh.vertices());
-        auto v1 = std::begin(mesh.vertices());
-        auto v2 = std::begin(mesh.vertices());
-        auto v3 = std::begin(mesh.vertices());
-        std::advance(v0, idx0);
-        std::advance(v1, idx1);
-        std::advance(v2, idx2);
-        std::advance(v3, idx3);
-
-        // Faces
-        mesh.add_face(*v0, *v1, *v2);
-        mesh.add_face(*v0, *v2, *v3);
-
-        // Face Normals
-        cgal::Point3 p0(mesh.point(*v0));
-        cgal::Point3 p1(mesh.point(*v1));
-        cgal::Point3 p2(mesh.point(*v2));
-        cgal::Point3 p3(mesh.point(*v3));
-        normals.push_back(Geometry::Normal(p0, p1, p2));
-        normals.push_back(Geometry::Normal(p0, p2, p3));
-      }
+      double px = ix * lx - Lx/2.0;
+      mesh.add_vertex(cgal::Point3(px, py, 0));
     }
   }
 
-  Grid::Grid(const Grid& _other) :
-    data(new GridPrivate()) 
+  // Add faces
+  for (Index iy=0; iy < ny; ++iy)
   {
-    this->data->size = _other.data->size;
-    this->data->cellCount = _other.data->cellCount;
-    this->data->mesh.reset(new cgal::Mesh(*_other.data->mesh));
+    for (Index ix=0; ix < nx; ++ix)
+    {
+      // Get the vertices in the cell coordinates
+      const Index idx0 = iy * (nx+1) + ix;
+      const Index idx1 = iy * (nx+1) + ix + 1;
+      const Index idx2 = (iy+1) * (nx+1) + ix + 1;
+      const Index idx3 = (iy+1) * (nx+1) + ix;
+
+      // Vertex iterators
+      auto v0 = std::begin(mesh.vertices());
+      auto v1 = std::begin(mesh.vertices());
+      auto v2 = std::begin(mesh.vertices());
+      auto v3 = std::begin(mesh.vertices());
+      std::advance(v0, idx0);
+      std::advance(v1, idx1);
+      std::advance(v2, idx2);
+      std::advance(v3, idx3);
+
+      // Faces
+      mesh.add_face(*v0, *v1, *v2);
+      mesh.add_face(*v0, *v2, *v3);
+
+      // Face Normals
+      cgal::Point3 p0(mesh.point(*v0));
+      cgal::Point3 p1(mesh.point(*v1));
+      cgal::Point3 p2(mesh.point(*v2));
+      cgal::Point3 p3(mesh.point(*v3));
+      normals.push_back(Geometry::Normal(p0, p1, p2));
+      normals.push_back(Geometry::Normal(p0, p2, p3));
+    }
   }
+}
 
-  Grid& Grid::operator=(const Grid& _other)
-  {
-    // Check for self assignment
-    if (&_other == this)
-      return *this;
+//////////////////////////////////////////////////
+Grid::Grid(const Grid& _other) :
+  data(new GridPrivate())
+{
+  this->data->size = _other.data->size;
+  this->data->cellCount = _other.data->cellCount;
+  this->data->mesh.reset(new cgal::Mesh(*_other.data->mesh));
+}
 
-    // Copy
-    this->data->size = _other.data->size;
-    this->data->cellCount = _other.data->cellCount;
-    this->data->mesh.reset(new cgal::Mesh(*_other.data->mesh));
+//////////////////////////////////////////////////
+Grid& Grid::operator=(const Grid& _other)
+{
+  // Check for self assignment
+  if (&_other == this)
     return *this;
+
+  // Copy
+  this->data->size = _other.data->size;
+  this->data->cellCount = _other.data->cellCount;
+  this->data->mesh.reset(new cgal::Mesh(*_other.data->mesh));
+  return *this;
+}
+
+//////////////////////////////////////////////////
+std::shared_ptr<const cgal::Mesh> Grid::GetMesh() const
+{
+  return this->data->mesh;
+}
+
+//////////////////////////////////////////////////
+std::shared_ptr<cgal::Mesh> Grid::GetMesh()
+{
+  return this->data->mesh;
+}
+
+//////////////////////////////////////////////////
+const cgal::Mesh& Grid::GetMeshByRef() const
+{
+  return *this->data->mesh;
+}
+
+//////////////////////////////////////////////////
+const std::array<double, 2>& Grid::GetSize() const
+{
+  return this->data->size;
+}
+
+//////////////////////////////////////////////////
+const std::array<Index, 2>& Grid::GetCellCount() const
+{
+  return this->data->cellCount;
+}
+
+//////////////////////////////////////////////////
+Index Grid::GetVertexCount() const
+{
+  return this->data->mesh->number_of_vertices();
+}
+
+//////////////////////////////////////////////////
+Index Grid::GetFaceCount() const
+{
+  return this->data->mesh->number_of_faces();
+}
+
+//////////////////////////////////////////////////
+const cgal::Point3& Grid::GetPoint(Index _i) const
+{
+  auto vb = std::begin(this->data->mesh->vertices());
+  std::advance(vb, _i);
+  return this->data->mesh->point(*vb);
+}
+
+//////////////////////////////////////////////////
+void Grid::SetPoint(Index _i, const cgal::Point3& _v)
+{
+  auto vb = std::begin(this->data->mesh->vertices());
+  std::advance(vb, _i);
+  this->data->mesh->point(*vb) = _v;
+}
+
+//////////////////////////////////////////////////
+cgal::Triangle Grid::GetTriangle(Index _ix, Index _iy, Index _k) const
+{
+  // Original lookup using cell indexing - keep for index arithmetic
+  // // Grid dimensions
+  // const Index nx = this->data->cellCount[0];
+  // const Index ny = this->data->cellCount[1];
+
+  // // Get the vertices in the cell coordinates
+  // const Index idx0 = _iy * (nx+1) + _ix;
+  // const Index idx1 = _iy * (nx+1) + _ix + 1;
+  // const Index idx2 = (_iy+1) * (nx+1) + _ix + 1;
+  // const Index idx3 = (_iy+1) * (nx+1) + _ix;
+
+  // switch (_k)
+  // {
+  // case 0:
+  //   return cgal::Triangle(
+  //     this->GetPoint(idx0),
+  //     this->GetPoint(idx1),
+  //     this->GetPoint(idx2)
+  //   );
+  // case 1:
+  //   return cgal::Triangle(
+  //     this->GetPoint(idx0),
+  //     this->GetPoint(idx2),
+  //     this->GetPoint(idx3)
+  //   );
+  // default:
+  //   gzthrow("Index too large: " << _k << " > 1");
+  // }
+
+  // Optimised lookup using face indexing
+  // Face index
+  const Index nx = this->data->cellCount[0];
+  const Index idx = 2 * (nx * _iy + _ix) + _k;
+
+  // Make triangle from face descriptor
+  auto& mesh = *this->data->mesh;
+  auto fb = std::begin(mesh.faces());
+  std::advance(fb, idx);
+  return Geometry::MakeTriangle(mesh, *fb);
+}
+
+//////////////////////////////////////////////////
+cgal::FaceIndex Grid::GetFace(Index _ix, Index _iy, Index _k) const
+{
+  // Face index
+  const Index nx = this->data->cellCount[0];
+  const Index idx = 2 * (nx * _iy + _ix) + _k;
+
+  // Make triangle from face descriptor
+  auto& mesh = *this->data->mesh;
+  auto fb = std::begin(mesh.faces());
+  std::advance(fb, idx);
+  return *fb;
+}
+
+//////////////////////////////////////////////////
+const cgal::Vector3& Grid::GetNormal(Index _ix, Index _iy, Index _k) const
+{
+  // Face index
+  const Index nx = this->data->cellCount[0];
+  const Index idx = 2 * (nx * _iy + _ix) + _k;
+
+  return this->data->normals[idx];
+}
+
+//////////////////////////////////////////////////
+const cgal::Vector3& Grid::GetNormal(Index _idx) const
+{
+  return this->data->normals[_idx];
+}
+
+//////////////////////////////////////////////////
+void Grid::RecalculateNormals()
+{
+  auto& mesh = *this->data->mesh;
+  int64_t idx = 0;
+  for (auto&& face : mesh.faces())
+  {
+    cgal::Vector3 normal = Geometry::Normal(mesh, face);
+    this->data->normals[idx++] = normal;
   }
+}
 
-  std::shared_ptr<const cgal::Mesh> Grid::GetMesh() const
+//////////////////////////////////////////////////
+const cgal::Point3& Grid::GetCenter() const
+{
+  return this->data->center;
+}
+
+//////////////////////////////////////////////////
+void Grid::SetCenter(const cgal::Point3& _center)
+{
+  this->data->center = _center;
+}
+
+//////////////////////////////////////////////////
+void Grid::DebugPrint() const
+{
+  auto&& mesh = *this->data->mesh;
+
+  gzmsg << "Center " << std::endl;
+  gzmsg << "c0:  " << this->data->center << std::endl;
+
+  gzmsg << "Vertices " << std::endl;
+  for (auto&& vertex : mesh.vertices())
   {
-    return this->data->mesh;
+    gzmsg << vertex << ": " << mesh.point(vertex) << std::endl;
   }
-
-  std::shared_ptr<cgal::Mesh> Grid::GetMesh()
+  gzmsg << "Faces " << std::endl;
+  for (auto&& face : mesh.faces())
   {
-    return this->data->mesh;
+    cgal::Triangle tri = Geometry::MakeTriangle(mesh, face);
+    gzmsg << face << ": " << tri << std::endl;
   }
+}
 
-  const cgal::Mesh& Grid::GetMeshByRef() const
-  {
-    return *this->data->mesh;
-  }
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+bool GridTools::FindIntersectionIndex(
+  const Grid& _grid,
+  double _x, double _y,
+  std::array<Index, 3>& _index
+)
+{
+  const Index nx = _grid.GetCellCount()[0];
+  const Index ny = _grid.GetCellCount()[1];
+  const double Lx = _grid.GetSize()[0];
+  const double Ly = _grid.GetSize()[1];
+  const double lx = Lx/nx;
+  const double ly = Ly/ny;
+  const double lowerX = -Lx/2.0 + _grid.GetCenter().x();
+  const double upperX =  Lx/2.0 + _grid.GetCenter().x();
+  const double lowerY = -Ly/2.0 + _grid.GetCenter().y();
+  const double upperY =  Ly/2.0 + _grid.GetCenter().y();
 
-  const std::array<double, 2>& Grid::GetSize() const
-  {
-    return this->data->size;
-  } 
-
-  const std::array<Index, 2>& Grid::GetCellCount() const
-  {
-    return this->data->cellCount;
-  } 
-
-  Index Grid::GetVertexCount() const
-  {
-    return this->data->mesh->number_of_vertices();
-  }
-
-  Index Grid::GetFaceCount() const
-  {
-    return this->data->mesh->number_of_faces();
-  }
-
-  const cgal::Point3& Grid::GetPoint(Index _i) const
-  {
-    auto vb = std::begin(this->data->mesh->vertices());
-    std::advance(vb, _i);
-    return this->data->mesh->point(*vb);
-  }
-
-  void Grid::SetPoint(Index _i, const cgal::Point3& _v)
-  {
-    auto vb = std::begin(this->data->mesh->vertices());
-    std::advance(vb, _i);
-    this->data->mesh->point(*vb) = _v;
-  }
-
-  cgal::Triangle Grid::GetTriangle(Index _ix, Index _iy, Index _k) const
-  {
-    // Original lookup using cell indexing - keep for index arithmetic
-    // // Grid dimensions
-    // const Index nx = this->data->cellCount[0];
-    // const Index ny = this->data->cellCount[1];
-
-    // // Get the vertices in the cell coordinates
-    // const Index idx0 = _iy * (nx+1) + _ix;
-    // const Index idx1 = _iy * (nx+1) + _ix + 1;
-    // const Index idx2 = (_iy+1) * (nx+1) + _ix + 1;
-    // const Index idx3 = (_iy+1) * (nx+1) + _ix;
-
-    // switch (_k) 
-    // {
-    // case 0:
-    //   return cgal::Triangle(
-    //     this->GetPoint(idx0),
-    //     this->GetPoint(idx1),
-    //     this->GetPoint(idx2)
-    //   );
-    // case 1:
-    //   return cgal::Triangle(
-    //     this->GetPoint(idx0),
-    //     this->GetPoint(idx2),
-    //     this->GetPoint(idx3)
-    //   );      
-    // default:
-    //   gzthrow("Index too large: " << _k << " > 1");
-    // }
-
-    // Optimised lookup using face indexing
-    // Face index
-    const Index nx = this->data->cellCount[0];
-    const Index idx = 2 * (nx * _iy + _ix) + _k;
-
-    // Make triangle from face descriptor
-    auto& mesh = *this->data->mesh;
-    auto fb = std::begin(mesh.faces());
-    std::advance(fb, idx);
-    return Geometry::MakeTriangle(mesh, *fb);
-  }
-
-  cgal::FaceIndex Grid::GetFace(Index _ix, Index _iy, Index _k) const
-  {
-    // Face index
-    const Index nx = this->data->cellCount[0];
-    const Index idx = 2 * (nx * _iy + _ix) + _k;
-
-    // Make triangle from face descriptor
-    auto& mesh = *this->data->mesh;
-    auto fb = std::begin(mesh.faces());
-    std::advance(fb, idx);
-    return *fb;
-  }
-
-  const cgal::Vector3& Grid::GetNormal(Index _ix, Index _iy, Index _k) const
-  {
-    // Face index
-    const Index nx = this->data->cellCount[0];
-    const Index idx = 2 * (nx * _iy + _ix) + _k;
-
-    return this->data->normals[idx];
-  }
-
-  const cgal::Vector3& Grid::GetNormal(Index _idx) const
-  {
-    return this->data->normals[_idx];
-  }
-
-  void Grid::RecalculateNormals()
-  {
-    auto& mesh = *this->data->mesh;
-    unsigned long idx = 0;
-    for(auto&& face : mesh.faces())
-    {
-      cgal::Vector3 normal = Geometry::Normal(mesh, face);
-      this->data->normals[idx++] = normal;
-    }
-  }
-
-  const cgal::Point3& Grid::GetCenter() const
-  {
-    return this->data->center;
-  }
-
-  void Grid::SetCenter(const cgal::Point3& _center)
-  {
-    this->data->center = _center;
-  }
-
-  void Grid::DebugPrint() const
-  {
-    auto&& mesh = *this->data->mesh;
-
-    gzmsg << "Center " << std::endl;    
-    gzmsg << "c0:  " << this->data->center << std::endl;
-
-    gzmsg << "Vertices " << std::endl;    
-    for(auto&& vertex : mesh.vertices())
-    {
-      gzmsg << vertex << ": " << mesh.point(vertex) << std::endl;
-    }
-    gzmsg << "Faces " << std::endl;
-    for(auto&& face : mesh.faces())
-    {
-      cgal::Triangle tri = Geometry::MakeTriangle(mesh, face);
-      gzmsg << face << ": " << tri << std::endl;
-    }
-  }
-
-
-///////////////////////////////////////////////////////////////////////////////
-// GridTools
-
-  bool GridTools::FindIntersectionIndex(
-    const Grid& _grid,
-    double _x, double _y,
-    std::array<Index, 3>& _index
-  )
-  {
-    const Index nx = _grid.GetCellCount()[0];
-    const Index ny = _grid.GetCellCount()[1];
-    const double Lx = _grid.GetSize()[0];
-    const double Ly = _grid.GetSize()[1];
-    const double lx = Lx/nx;
-    const double ly = Ly/ny;
-    const double lowerX = -Lx/2.0 + _grid.GetCenter().x();
-    const double upperX =  Lx/2.0 + _grid.GetCenter().x();
-    const double lowerY = -Ly/2.0 + _grid.GetCenter().y();
-    const double upperY =  Ly/2.0 + _grid.GetCenter().y();
-
-    // Check x bounds
-    if (_x < lowerX || _x > upperX)
-      return false;
-
-    // Check y bounds
-    if (_y < lowerY || _y > upperY)
-      return false;
-
-    // Cell
-    Index ix = static_cast<Index>(std::floor((_x - lowerX)/lx));
-    Index iy = static_cast<Index>(std::floor((_y - lowerY)/ly));
-
-    // Face / triangle
-    double x0 = ix * lx + lowerX;
-    double y0 = iy * ly + lowerY;
-    double m = ly/lx;
-    double c = y0 - m * x0;
-    Index k = _y > (m * _x + c) ? 1 : 0;
-
-    // @DEBUG_INFO
-    // gzmsg << "ix: " << ix << std::endl;
-    // gzmsg << "iy: " << iy << std::endl;
-    // gzmsg << "x0: " << x0 << std::endl;
-    // gzmsg << "y0: " << y0 << std::endl;
-    // gzmsg << "m:  " << m  << std::endl;
-    // gzmsg << "c:  " << c  << std::endl;
-    // gzmsg << "k:  " << k  << std::endl;
-
-    _index[0] = ix;
-    _index[1] = iy;
-    _index[2] = k;
-
-    return true;    
-  }
-
-  bool GridTools::FindIntersectionTriangle(
-    const Grid& _grid,
-    const cgal::Point3& _origin,
-    const cgal::Direction3& _direction,
-    const std::array<Index, 3>& _index,
-    cgal::Point3& _intersection
-  )
-  {
-    // FaceIndex version: the ByRef vs shared_ptr access makes 
-    // a difference (50% of this functions execution time!)
-    const auto& mesh = _grid.GetMeshByRef();
-    auto face = _grid.GetFace(_index[0], _index[1], _index[2]);
-    cgal::HalfedgeIndex hf = mesh.halfedge(face);
-    const cgal::Point3& p0 = mesh.point(mesh.target(hf));
-    hf = mesh.next(hf);
-    const cgal::Point3& p1 = mesh.point(mesh.target(hf));
-    hf = mesh.next(hf);
-    const cgal::Point3& p2 = mesh.point(mesh.target(hf));
-    hf = mesh.next(hf);
-
-    return Geometry::LineIntersectsTriangle(
-      _origin, _direction, p0, p1, p2, _intersection); 
-  }
-
-  bool GridTools::FindIntersectionCell(
-    const Grid& _grid,
-    const cgal::Point3& _origin,
-    const cgal::Direction3& _direction,
-    std::array<Index, 3>& _index,
-    cgal::Point3& _intersection
-  )
-  {
-    // Search each of the two triangles comprising each cell 
-    bool isFound = FindIntersectionTriangle(
-      _grid, _origin, _direction, _index, _intersection); 
-    if (isFound)
-    {
-      return true;  
-    }
-    _index[2] = (_index[2] == 0) ? 1 : 0;
-    return FindIntersectionTriangle(
-      _grid, _origin, _direction, _index, _intersection); 
-  }
-
-  // NOTE: This routine as written must use 'Index' rather than 'unsigned int'
-  // otherwise the index arithmetic will be incorrect.
-  bool GridTools::FindIntersectionGrid(
-    const Grid& _grid,
-    const cgal::Point3& _origin,
-    const cgal::Direction3& _direction,
-    std::array<Index, 3>& _index,
-    cgal::Point3& _point
-  )
-  {
-    // The flag 'isDone' is true if there are no remaining cells to search.
-    bool isDone = false;
-
-    // index of the first cell searched.
-    isDone = FindIntersectionCell(_grid, _origin, _direction, _index, _point);
-    if (isDone)
-    {
-      return isDone;
-    }
-    
-    // Grid dimensions
-    Index nx = _grid.GetCellCount()[0];
-    Index ny = _grid.GetCellCount()[1];
-
-    // indexes for the grid boundaries
-    Index kxmin = 0;
-    Index kxmax = nx - 1;
-    Index kymin = 0;
-    Index kymax = ny - 1;
-            
-    // grid boundary indexes for the first cell. 
-    Index kx   = _index[0];
-    Index ky   = _index[1];
-    Index kxm0 = kx;
-    Index kxp0 = kxm0;
-    Index kym0 = ky;
-    Index kyp0 = kym0;
-
-    // loop searches the cells in an expanding shell about the area already searched. 
-    while (!isDone)
-    {
-      isDone = true;
-
-      // boundary of the next shell
-      Index kxm = std::max(kxm0 - 1, kxmin);
-      Index kxp = std::min(kxp0 + 1, kxmax);
-      Index kym = std::max(kym0 - 1, kymin);
-      Index kyp = std::min(kyp0 + 1, kymax);
-      
-      // row0 : lower limit offset for the column loop is either 0 or 1 
-      Index row0 = 0;
-      if (kxm != kxm0)
-      {
-        isDone = false;
-        row0 = 1;
-        for (Index j=kym; j<=kyp; ++j)
-        {
-          _index[0] = kxm;
-          _index[1] = j;
-          isDone = FindIntersectionCell(_grid, _origin, _direction, _index, _point);
-          if (isDone)
-            return true;
-        }
-      }
-      
-      // row1 : upper limit offset for the column loop is either 0 or 1.
-      Index row1 = 0;
-      if (kxp != kxp0)
-      {
-        isDone = false;
-        row1 = 1;
-        for (Index j=kym; j<=kyp; ++j)
-        {
-          _index[0] = kxp;
-          _index[1] = j;
-          isDone = FindIntersectionCell(_grid, _origin, _direction, _index, _point);
-          if (isDone)
-            return true;
-        }
-      }
-      
-      // col0
-      if (kym != kym0)
-      {
-        isDone = false;
-        for (Index i=kxm+row0; i<=kxp-row1; ++i)
-        {
-          _index[0] = i;
-          _index[1] = kym;
-          isDone = FindIntersectionCell(_grid, _origin, _direction, _index, _point);
-          if (isDone)
-            return true;
-        }
-      }
-      
-      // col1
-      if (kyp != kyp0)
-      {
-        isDone = false;
-        for (Index i=kxm+row0; i<=kxp-row1; ++i)
-        {
-          _index[0] = i;
-          _index[1] = kyp;
-          isDone = FindIntersectionCell(_grid, _origin, _direction, _index, _point);
-          if (isDone)
-            return true;
-        }
-      }
-      
-      // update
-      kxm0 = kxm;
-      kxp0 = kxp;
-      kym0 = kym;
-      kyp0 = kyp;
-    }
-
-    // Fail to find an intersection after searching all cells 
+  // Check x bounds
+  if (_x < lowerX || _x > upperX)
     return false;
+
+  // Check y bounds
+  if (_y < lowerY || _y > upperY)
+    return false;
+
+  // Cell
+  Index ix = static_cast<Index>(std::floor((_x - lowerX)/lx));
+  Index iy = static_cast<Index>(std::floor((_y - lowerY)/ly));
+
+  // Face / triangle
+  double x0 = ix * lx + lowerX;
+  double y0 = iy * ly + lowerY;
+  double m = ly/lx;
+  double c = y0 - m * x0;
+  Index k = _y > (m * _x + c) ? 1 : 0;
+
+  // @DEBUG_INFO
+  // gzmsg << "ix: " << ix << std::endl;
+  // gzmsg << "iy: " << iy << std::endl;
+  // gzmsg << "x0: " << x0 << std::endl;
+  // gzmsg << "y0: " << y0 << std::endl;
+  // gzmsg << "m:  " << m  << std::endl;
+  // gzmsg << "c:  " << c  << std::endl;
+  // gzmsg << "k:  " << k  << std::endl;
+
+  _index[0] = ix;
+  _index[1] = iy;
+  _index[2] = k;
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool GridTools::FindIntersectionTriangle(
+  const Grid& _grid,
+  const cgal::Point3& _origin,
+  const cgal::Direction3& _direction,
+  const std::array<Index, 3>& _index,
+  cgal::Point3& _intersection)
+{
+  // FaceIndex version: the ByRef vs shared_ptr access makes
+  // a difference (50% of this functions execution time!)
+  const auto& mesh = _grid.GetMeshByRef();
+  auto face = _grid.GetFace(_index[0], _index[1], _index[2]);
+  cgal::HalfedgeIndex hf = mesh.halfedge(face);
+  const cgal::Point3& p0 = mesh.point(mesh.target(hf));
+  hf = mesh.next(hf);
+  const cgal::Point3& p1 = mesh.point(mesh.target(hf));
+  hf = mesh.next(hf);
+  const cgal::Point3& p2 = mesh.point(mesh.target(hf));
+  hf = mesh.next(hf);
+
+  return Geometry::LineIntersectsTriangle(
+    _origin, _direction, p0, p1, p2, _intersection);
+}
+
+//////////////////////////////////////////////////
+bool GridTools::FindIntersectionCell(
+  const Grid& _grid,
+  const cgal::Point3& _origin,
+  const cgal::Direction3& _direction,
+  std::array<Index, 3>& _index,
+  cgal::Point3& _intersection
+)
+{
+  // Search each of the two triangles comprising each cell
+  bool isFound = FindIntersectionTriangle(
+    _grid, _origin, _direction, _index, _intersection);
+  if (isFound)
+  {
+    return true;
+  }
+  _index[2] = (_index[2] == 0) ? 1 : 0;
+  return FindIntersectionTriangle(
+    _grid, _origin, _direction, _index, _intersection);
+}
+
+//////////////////////////////////////////////////
+// NOTE: This routine as written must use 'Index' rather than 'unsigned int'
+// otherwise the index arithmetic will be incorrect.
+bool GridTools::FindIntersectionGrid(
+  const Grid& _grid,
+  const cgal::Point3& _origin,
+  const cgal::Direction3& _direction,
+  std::array<Index, 3>& _index,
+  cgal::Point3& _point
+)
+{
+  // The flag 'isDone' is true if there are no remaining cells to search.
+  bool isDone = false;
+
+  // index of the first cell searched.
+  isDone = FindIntersectionCell(_grid, _origin, _direction, _index, _point);
+  if (isDone)
+  {
+    return isDone;
   }
 
-///////////////////////////////////////////////////////////////////////////////
+  // Grid dimensions
+  Index nx = _grid.GetCellCount()[0];
+  Index ny = _grid.GetCellCount()[1];
 
+  // indexes for the grid boundaries
+  Index kxmin = 0;
+  Index kxmax = nx - 1;
+  Index kymin = 0;
+  Index kymax = ny - 1;
+
+  // grid boundary indexes for the first cell.
+  Index kx   = _index[0];
+  Index ky   = _index[1];
+  Index kxm0 = kx;
+  Index kxp0 = kxm0;
+  Index kym0 = ky;
+  Index kyp0 = kym0;
+
+  // loop searches the cells in an expanding shell about
+  // the area already searched.
+  while (!isDone)
+  {
+    isDone = true;
+
+    // boundary of the next shell
+    Index kxm = std::max(kxm0 - 1, kxmin);
+    Index kxp = std::min(kxp0 + 1, kxmax);
+    Index kym = std::max(kym0 - 1, kymin);
+    Index kyp = std::min(kyp0 + 1, kymax);
+
+    // row0 : lower limit offset for the column loop is either 0 or 1
+    Index row0 = 0;
+    if (kxm != kxm0)
+    {
+      isDone = false;
+      row0 = 1;
+      for (Index j=kym; j <= kyp; ++j)
+      {
+        _index[0] = kxm;
+        _index[1] = j;
+        isDone = FindIntersectionCell(_grid, _origin,
+            _direction, _index, _point);
+        if (isDone)
+          return true;
+      }
+    }
+
+    // row1 : upper limit offset for the column loop is either 0 or 1.
+    Index row1 = 0;
+    if (kxp != kxp0)
+    {
+      isDone = false;
+      row1 = 1;
+      for (Index j=kym; j <= kyp; ++j)
+      {
+        _index[0] = kxp;
+        _index[1] = j;
+        isDone = FindIntersectionCell(_grid, _origin,
+            _direction, _index, _point);
+        if (isDone)
+          return true;
+      }
+    }
+
+    // col0
+    if (kym != kym0)
+    {
+      isDone = false;
+      for (Index i=kxm+row0; i <= kxp-row1; ++i)
+      {
+        _index[0] = i;
+        _index[1] = kym;
+        isDone = FindIntersectionCell(_grid, _origin,
+            _direction, _index, _point);
+        if (isDone)
+          return true;
+      }
+    }
+
+    // col1
+    if (kyp != kyp0)
+    {
+      isDone = false;
+      for (Index i=kxm+row0; i <= kxp-row1; ++i)
+      {
+        _index[0] = i;
+        _index[1] = kyp;
+        isDone = FindIntersectionCell(_grid, _origin,
+            _direction, _index, _point);
+        if (isDone)
+          return true;
+      }
+    }
+
+    // update
+    kxm0 = kxm;
+    kxp0 = kxp;
+    kym0 = kym;
+    kyp0 = kyp;
+  }
+
+  // Fail to find an intersection after searching all cells
+  return false;
 }
-}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/Grid_TEST.cc
+++ b/gz-waves/src/Grid_TEST.cc
@@ -13,23 +13,28 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "gz/waves/Grid.hh"
-#include "gz/waves/Geometry.hh"
-#include "gz/waves/CGALTypes.hh"
-#include "gz/waves/Types.hh"
-
 #include <gtest/gtest.h>
 
 #include <cmath>
 #include <iostream>
 #include <string>
 
-using namespace gz;
-using namespace waves;
+#include "gz/waves/Grid.hh"
+#include "gz/waves/Geometry.hh"
+#include "gz/waves/CGALTypes.hh"
+#include "gz/waves/Types.hh"
 
-///////////////////////////////////////////////////////////////////////////////
-// Define tests
+namespace cgal
+{
+using gz::cgal::Direction3;
+using gz::cgal::Point3;
+}  // namespace cgal
 
+using gz::waves::Index;
+using gz::waves::Grid;
+using gz::waves::GridTools;
+
+//////////////////////////////////////////////////
 TEST(Grid, Constructor)
 {
   std::array<double, 2> size = { 2, 2 };
@@ -50,7 +55,7 @@ TEST(Grid, Constructor)
   EXPECT_EQ(grid.GetCellCount()[1], ny);
 
   // Vertices
-  // auto mesh = grid.GetMesh(); 
+  // auto mesh = grid.GetMesh();
   // std::cout << "Vertices " << std::endl;
   // for(auto&& vertex : mesh->vertices())
   // {
@@ -71,14 +76,14 @@ TEST(Grid, Constructor)
   // GetPoint
   // for (Index i=0; i<grid.GetVertexCount(); ++i)
   // {
-  //   std:: cout << i << ": " << grid.GetPoint(i) << std::endl;    
+  //   std:: cout << i << ": " << grid.GetPoint(i) << std::endl;
   // }
 
   // SetPoint
   // for (Index i=0; i<grid.GetVertexCount(); ++i)
   // {
   //   cgal::Point3 p = grid.GetPoint(i);
-  //   p += cgal::Vector3(0, 0, 10); 
+  //   p += cgal::Vector3(0, 0, 10);
   //   grid.SetPoint(i, p);
   // }
   // for(auto&& vertex : mesh->vertices())
@@ -93,14 +98,15 @@ TEST(Grid, Constructor)
   //   {
   //     for (Index k=0; k<2; ++k)
   //     {
-  //       std::cout 
-  //         << "[" << ix << ", " << iy << ", " << k << "]: " 
+  //       std::cout
+  //         << "[" << ix << ", " << iy << ", " << k << "]: "
   //         << grid.GetTriangle(ix, iy, k) << std::endl;
   //     }
-  //   }    
+  //   }
   // }
 }
 
+//////////////////////////////////////////////////
 TEST(Grid, FindIntersectionIndex)
 {
   std::array<double, 2> size = { 4, 2 };
@@ -276,6 +282,7 @@ TEST(Grid, FindIntersectionIndex)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(Grid, FindIntersectionTriangle)
 {
   std::array<double, 2> size = { 4, 2 };
@@ -356,6 +363,7 @@ TEST(Grid, FindIntersectionTriangle)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(Grid, FindIntersectionCell)
 {
   std::array<double, 2> size = { 4, 2 };
@@ -400,6 +408,7 @@ TEST(Grid, FindIntersectionCell)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(Grid, FindIntersectionGrid)
 {
   std::array<double, 2> size = { 4, 2 };
@@ -427,7 +436,7 @@ TEST(Grid, FindIntersectionGrid)
 
     // Reset index
     index = { 0, 0, 0 };
-    
+
     // Find intersection
     cgal::Point3 origin = cgal::Point3(x, y, 10);
     cgal::Direction3 direction = cgal::Direction3(0, 0, 1);
@@ -436,7 +445,7 @@ TEST(Grid, FindIntersectionGrid)
       grid, origin, direction, index, point);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(point, cgal::Point3(x, y, 0));
- 
+
     // Found index
     EXPECT_EQ(index[0], 3);
     EXPECT_EQ(index[1], 1);
@@ -446,13 +455,9 @@ TEST(Grid, FindIntersectionGrid)
   }
 }
 
-
-///////////////////////////////////////////////////////////////////////////////
-// Run tests
-
+//////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/gz-waves/src/Grid_TEST.cc
+++ b/gz-waves/src/Grid_TEST.cc
@@ -16,6 +16,7 @@
 #include "gz/waves/Grid.hh"
 #include "gz/waves/Geometry.hh"
 #include "gz/waves/CGALTypes.hh"
+#include "gz/waves/Types.hh"
 
 #include <gtest/gtest.h>
 
@@ -32,13 +33,13 @@ using namespace waves;
 TEST(Grid, Constructor)
 {
   std::array<double, 2> size = { 2, 2 };
-  std::array<size_t, 2> cellCount = { 2, 2 };
+  std::array<Index, 2> cellCount = { 2, 2 };
   Grid grid(size, cellCount);
 
   double Lx = size[0];
   double Ly = size[1];
-  size_t nx = cellCount[0];
-  size_t ny = cellCount[1];
+  Index nx = cellCount[0];
+  Index ny = cellCount[1];
 
   // GetSize
   EXPECT_EQ(grid.GetSize()[0], Lx);
@@ -68,13 +69,13 @@ TEST(Grid, Constructor)
   EXPECT_EQ(grid.GetVertexCount(), (cellCount[0]+1) * (cellCount[1]+1));
 
   // GetPoint
-  // for (size_t i=0; i<grid.GetVertexCount(); ++i)
+  // for (Index i=0; i<grid.GetVertexCount(); ++i)
   // {
   //   std:: cout << i << ": " << grid.GetPoint(i) << std::endl;    
   // }
 
   // SetPoint
-  // for (size_t i=0; i<grid.GetVertexCount(); ++i)
+  // for (Index i=0; i<grid.GetVertexCount(); ++i)
   // {
   //   cgal::Point3 p = grid.GetPoint(i);
   //   p += cgal::Vector3(0, 0, 10); 
@@ -86,11 +87,11 @@ TEST(Grid, Constructor)
   // }
 
   // Triangles
-  // for (size_t iy=0; iy<ny; ++iy)
+  // for (Index iy=0; iy<ny; ++iy)
   // {
-  //   for (size_t ix=0; ix<nx; ++ix)
+  //   for (Index ix=0; ix<nx; ++ix)
   //   {
-  //     for (size_t k=0; k<2; ++k)
+  //     for (Index k=0; k<2; ++k)
   //     {
   //       std::cout 
   //         << "[" << ix << ", " << iy << ", " << k << "]: " 
@@ -103,19 +104,19 @@ TEST(Grid, Constructor)
 TEST(Grid, FindIntersectionIndex)
 {
   std::array<double, 2> size = { 4, 2 };
-  std::array<size_t, 2> cellCount = { 4, 2 };
+  std::array<Index, 2> cellCount = { 4, 2 };
   Grid grid(size, cellCount);
 
   // double Lx = size[0];
   // double Ly = size[1];
-  // size_t nx = cellCount[0];
-  // size_t ny = cellCount[1];
+  // Index nx = cellCount[0];
+  // Index ny = cellCount[1];
 
   // 16 cases to check...
   { // cell(0, 0)
     double x = -1.25;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 0);
@@ -125,7 +126,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(0, 0)
     double x = -1.75;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 0);
@@ -135,7 +136,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(1, 0)
     double x = -0.25;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 1);
@@ -145,7 +146,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(1, 0)
     double x = -0.75;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 1);
@@ -155,7 +156,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(2, 0)
     double x =  0.75;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 2);
@@ -165,7 +166,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(2, 0)
     double x =  0.25;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 2);
@@ -175,7 +176,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(3, 0)
     double x =  1.75;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 3);
@@ -185,7 +186,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(3, 0)
     double x =  1.25;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 3);
@@ -196,7 +197,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(0, 1)
     double x = -1.25;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 0);
@@ -206,7 +207,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(0, 1)
     double x = -1.75;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 0);
@@ -216,7 +217,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(1, 1)
     double x = -0.25;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 1);
@@ -226,7 +227,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(1, 1)
     double x = -0.75;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 1);
@@ -236,7 +237,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(2, 1)
     double x =  0.75;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 2);
@@ -246,7 +247,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(2, 1)
     double x =  0.25;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 2);
@@ -256,7 +257,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(3, 1)
     double x =  1.75;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 3);
@@ -266,7 +267,7 @@ TEST(Grid, FindIntersectionIndex)
   { // cell(3, 1)
     double x =  1.25;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
     EXPECT_EQ(isFound, true);
     EXPECT_EQ(index[0], 3);
@@ -278,20 +279,20 @@ TEST(Grid, FindIntersectionIndex)
 TEST(Grid, FindIntersectionTriangle)
 {
   std::array<double, 2> size = { 4, 2 };
-  std::array<size_t, 2> cellCount = { 4, 2 };
+  std::array<Index, 2> cellCount = { 4, 2 };
   Grid grid(size, cellCount);
 
   // double Lx = size[0];
   // double Ly = size[1];
-  // size_t nx = cellCount[0];
-  // size_t ny = cellCount[1];
+  // Index nx = cellCount[0];
+  // Index ny = cellCount[1];
 
   std::cout << std::endl;
 
   { // cell(0, 0)
     double x = -1.25;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
 
     // Initial guess
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
@@ -313,7 +314,7 @@ TEST(Grid, FindIntersectionTriangle)
   { // cell(0, 0)
     double x = -1.75;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
 
     // Initial guess
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
@@ -335,7 +336,7 @@ TEST(Grid, FindIntersectionTriangle)
   { // cell(2, 1)
     double x =  0.75;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
 
     // Initial guess
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
@@ -358,20 +359,20 @@ TEST(Grid, FindIntersectionTriangle)
 TEST(Grid, FindIntersectionCell)
 {
   std::array<double, 2> size = { 4, 2 };
-  std::array<size_t, 2> cellCount = { 4, 2 };
+  std::array<Index, 2> cellCount = { 4, 2 };
   Grid grid(size, cellCount);
 
   // double Lx = size[0];
   // double Ly = size[1];
-  // size_t nx = cellCount[0];
-  // size_t ny = cellCount[1];
+  // Index nx = cellCount[0];
+  // Index ny = cellCount[1];
 
   std::cout << std::endl;
 
   { // cell(0, 0)
     double x = -1.25;
     double y = -0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
 
     // Initial guess
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);
@@ -402,20 +403,20 @@ TEST(Grid, FindIntersectionCell)
 TEST(Grid, FindIntersectionGrid)
 {
   std::array<double, 2> size = { 4, 2 };
-  std::array<size_t, 2> cellCount = { 4, 2 };
+  std::array<Index, 2> cellCount = { 4, 2 };
   Grid grid(size, cellCount);
 
   // double Lx = size[0];
   // double Ly = size[1];
-  // size_t nx = cellCount[0];
-  // size_t ny = cellCount[1];
+  // Index nx = cellCount[0];
+  // Index ny = cellCount[1];
 
   std::cout << std::endl;
 
   { // cell(3, 1)
     double x =  1.75;
     double y =  0.50;
-    std::array<size_t, 3> index = { 0, 0, 0 };
+    std::array<Index, 3> index = { 0, 0, 0 };
 
     // Initial guess
     bool isFound = GridTools::FindIntersectionIndex(grid, x, y, index);

--- a/gz-waves/src/LinearRandomFFTWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulation.cc
@@ -26,6 +26,7 @@
 
 #include <gz/common.hh>
 
+#include "gz/waves/Types.hh"
 #include "gz/waves/WaveSpectrum.hh"
 #include "gz/waves/WaveSpreadingFunction.hh"
 #include "LinearRandomFFTWaveSimulationImpl.hh"
@@ -102,7 +103,7 @@ namespace waves
     }
 
     // change from row to column major storage
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     h = fft_out0_.reshaped<Eigen::ColMajor>(n2, 1);
   }
 
@@ -123,7 +124,7 @@ namespace waves
       fft_needs_update_[2] = false;
     }
     // change from row to column major storage
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     dhdy = fft_out1_.reshaped<Eigen::ColMajor>(n2, 1);
     dhdx = fft_out2_.reshaped<Eigen::ColMajor>(n2, 1);
   }
@@ -146,7 +147,7 @@ namespace waves
     }
 
     // change from row to column major storage
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     sy = fft_out3_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
     sx = fft_out4_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
   }
@@ -175,7 +176,7 @@ namespace waves
     }
 
     // change from row to column major storage
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     dsydy = fft_out5_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
     dsxdx = fft_out6_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
     dsxdy = fft_out7_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ *  1.0;
@@ -194,7 +195,7 @@ namespace waves
     }
 
     // change from row to column major storage
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     pressure = fft_out_p_[iz].reshaped<Eigen::ColMajor>(n2, 1);
   }
 
@@ -261,7 +262,7 @@ namespace waves
     InitPressureGrid();
 
     // initialise arrays - always update as algo switch may change shape.
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     {
       cap_psi_2s_root_  = Eigen::ArrayXd::Zero(n2);
       rho_              = Eigen::ArrayXd::Zero(n2);

--- a/gz-waves/src/LinearRandomFFTWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulation.cc
@@ -16,13 +16,13 @@
 
 #include "gz/waves/LinearRandomFFTWaveSimulation.hh"
 
-#include <complex>
-#include <random>
-#include <vector>
-
 #include <Eigen/Dense>
 
 #include <fftw3.h>
+
+#include <complex>
+#include <random>
+#include <vector>
 
 #include <gz/common.hh>
 
@@ -35,751 +35,747 @@ namespace gz
 {
 namespace waves
 {
-  //////////////////////////////////////////////////
-  LinearRandomFFTWaveSimulation::Impl::~Impl()
+//////////////////////////////////////////////////
+LinearRandomFFTWaveSimulation::Impl::~Impl()
+{
+  DestroyFFTWPlans();
+}
+
+//////////////////////////////////////////////////
+LinearRandomFFTWaveSimulation::Impl::Impl(
+  double lx, double ly, Index nx, Index ny) :
+  lx_(lx),
+  ly_(ly),
+  nx_(nx),
+  ny_(ny)
+{
+  CreateFFTWPlans();
+  ComputeBaseAmplitudes();
+}
+
+//////////////////////////////////////////////////
+LinearRandomFFTWaveSimulation::Impl::Impl(
+  double lx, double ly, double lz, Index nx, Index ny, Index nz) :
+  lx_(lx),
+  ly_(ly),
+  lz_(lz),
+  nx_(nx),
+  ny_(ny),
+  nz_(nz)
+{
+  CreateFFTWPlans();
+  ComputeBaseAmplitudes();
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::SetLambda(double value)
+{
+  lambda_ = value;
+  ComputeBaseAmplitudes();
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::SetWindVelocity(
+    double ux, double uy)
+{
+  // Update wind velocity and recompute base amplitudes.
+  u10_ = sqrt(ux*ux + uy *uy);
+  phi10_ = atan2(uy, ux);
+
+  ComputeBaseAmplitudes();
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::SetTime(double time)
+{
+  ComputeCurrentAmplitudes(time);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::ElevationAt(
+    Eigen::Ref<Eigen::ArrayXXd> h)
+{
+  // run the FFT
+  if (fft_needs_update_[0])
   {
-    DestroyFFTWPlans();
+    fftw_execute(fft_plan0_);
+    fft_needs_update_[0] = false;
   }
 
-  //////////////////////////////////////////////////
-  LinearRandomFFTWaveSimulation::Impl::Impl(
-    double lx, double ly, Index nx, Index ny) :
-    lx_(lx),
-    ly_(ly),
-    nx_(nx),
-    ny_(ny)
+  // change from row to column major storage
+  Index n2 = nx_ * ny_;
+  h = fft_out0_.reshaped<Eigen::ColMajor>(n2, 1);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::ElevationDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy)
+{
+  // run the FFTs
+  if (fft_needs_update_[1])
   {
-    CreateFFTWPlans();
-    ComputeBaseAmplitudes();
+    fftw_execute(fft_plan1_);
+    fft_needs_update_[1] = false;
+  }
+  if (fft_needs_update_[2])
+  {
+    fftw_execute(fft_plan2_);
+    fft_needs_update_[2] = false;
+  }
+  // change from row to column major storage
+  Index n2 = nx_ * ny_;
+  dhdy = fft_out1_.reshaped<Eigen::ColMajor>(n2, 1);
+  dhdx = fft_out2_.reshaped<Eigen::ColMajor>(n2, 1);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::DisplacementAt(
+    Eigen::Ref<Eigen::ArrayXXd> sx,
+    Eigen::Ref<Eigen::ArrayXXd> sy)
+{
+  // run the FFTs
+  if (fft_needs_update_[3])
+  {
+    fftw_execute(fft_plan3_);
+    fft_needs_update_[3] = false;
+  }
+  if (fft_needs_update_[4])
+  {
+    fftw_execute(fft_plan4_);
+    fft_needs_update_[4] = false;
   }
 
-  //////////////////////////////////////////////////
-  LinearRandomFFTWaveSimulation::Impl::Impl(
-    double lx, double ly, double lz, Index nx, Index ny, Index nz) :
-    lx_(lx),
-    ly_(ly),
-    lz_(lz),
-    nx_(nx),
-    ny_(ny),
-    nz_(nz)
+  // change from row to column major storage
+  Index n2 = nx_ * ny_;
+  sy = fft_out3_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
+  sx = fft_out4_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::DisplacementDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+    Eigen::Ref<Eigen::ArrayXXd> dsydy,
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+{
+  // run the FFTs
+  if (fft_needs_update_[5])
   {
-    CreateFFTWPlans();
-    ComputeBaseAmplitudes();
+    fftw_execute(fft_plan5_);
+    fft_needs_update_[5] = false;
+  }
+  if (fft_needs_update_[6])
+  {
+    fftw_execute(fft_plan6_);
+    fft_needs_update_[6] = false;
+  }
+  if (fft_needs_update_[7])
+  {
+    fftw_execute(fft_plan7_);
+    fft_needs_update_[7] = false;
   }
 
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::SetLambda(double value)
+  // change from row to column major storage
+  Index n2 = nx_ * ny_;
+  dsydy = fft_out5_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
+  dsxdx = fft_out6_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
+  dsxdy = fft_out7_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ *  1.0;
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::PressureAt(
+    Index iz,
+    Eigen::Ref<Eigen::ArrayXXd> pressure)
+{
+  // run the FFTs
+  if (fft_needs_update_[8 + iz])
   {
-    lambda_ = value;
-    ComputeBaseAmplitudes();
+    fftw_execute(fft_plan_p_[iz]);
+    fft_needs_update_[8 + iz] = false;
   }
 
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::SetWindVelocity(
-      double ux, double uy)
-  {
-    // Update wind velocity and recompute base amplitudes.
-    u10_ = sqrt(ux*ux + uy *uy);
-    phi10_ = atan2(uy, ux);
+  // change from row to column major storage
+  Index n2 = nx_ * ny_;
+  pressure = fft_out_p_[iz].reshaped<Eigen::ColMajor>(n2, 1);
+}
 
-    ComputeBaseAmplitudes();
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::ElevationAt(
+    Index ix, Index iy,
+    double &eta)
+{
+  /// \todo(srmainwaring) running the FFT destroys the inputs for c2r plans
+
+  // run the FFT
+  if (fft_needs_update_[0])
+  {
+    fftw_execute(fft_plan0_);
+    fft_needs_update_[0] = false;
   }
 
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::SetTime(double time)
+  // select value
+  eta = fft_out0_(ix, iy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::DisplacementAt(
+    Index ix, Index iy,
+    double &sx, double &sy)
+{
+  // run the FFTs
+  if (fft_needs_update_[3])
   {
-    ComputeCurrentAmplitudes(time);
+    fftw_execute(fft_plan3_);
+    fft_needs_update_[3] = false;
+  }
+  if (fft_needs_update_[4])
+  {
+    fftw_execute(fft_plan4_);
+    fft_needs_update_[4] = false;
   }
 
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h)
-  {
-    // run the FFT
-    if (fft_needs_update_[0])
-    {
-      fftw_execute(fft_plan0_);
-      fft_needs_update_[0] = false;
-    }
+  // change from row to column major storage and scale
+  sy = fft_out3_(ix, iy) * lambda_ * -1.0;
+  sx = fft_out4_(ix, iy) * lambda_ * -1.0;
+}
 
-    // change from row to column major storage
-    Index n2 = nx_ * ny_;
-    h = fft_out0_.reshaped<Eigen::ColMajor>(n2, 1);
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::PressureAt(
+    Index ix, Index iy, Index iz,
+    double &pressure)
+{
+  // run the FFT
+  if (fft_needs_update_[8 + iz])
+  {
+    fftw_execute(fft_plan_p_[iz]);
+    fft_needs_update_[8 + iz] = false;
   }
 
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::ElevationDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy)
+  // select value
+  pressure = fft_out_p_[iz](ix, iy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::ComputeBaseAmplitudes()
+{
+  InitWaveNumbers();
+  InitPressureGrid();
+
+  // initialise arrays - always update as algo switch may change shape.
+  Index n2 = nx_ * ny_;
   {
-    // run the FFTs
-    if (fft_needs_update_[1])
-    {
-      fftw_execute(fft_plan1_);
-      fft_needs_update_[1] = false;
-    }
-    if (fft_needs_update_[2])
-    {
-      fftw_execute(fft_plan2_);
-      fft_needs_update_[2] = false;
-    }
-    // change from row to column major storage
-    Index n2 = nx_ * ny_;
-    dhdy = fft_out1_.reshaped<Eigen::ColMajor>(n2, 1);
-    dhdx = fft_out2_.reshaped<Eigen::ColMajor>(n2, 1);
+    cap_psi_2s_root_  = Eigen::ArrayXd::Zero(n2);
+    rho_              = Eigen::ArrayXd::Zero(n2);
+    sigma_            = Eigen::ArrayXd::Zero(n2);
+    omega_k_          = Eigen::ArrayXd::Zero(n2);
+    zhat_             = Eigen::ArrayXd::Zero(n2);
+    cos_wt_           = Eigen::ArrayXd::Zero(n2);
+    sin_wt_           = Eigen::ArrayXd::Zero(n2);
   }
 
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::DisplacementAt(
-      Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy)
+  // spectrum and spreading functions
+  gz::waves::ECKVWaveSpectrum spectrum;
+  spectrum.SetGravity(gravity_);
+  spectrum.SetU10(u10_);
+  spectrum.SetCapOmegaC(cap_omega_c_);
+
+  // standing waves - symmetric spreading function
+  gz::waves::ECKVSpreadingFunction spreadingFn1;
+  spreadingFn1.SetGravity(gravity_);
+  spreadingFn1.SetU10(u10_);
+  spreadingFn1.SetCapOmegaC(cap_omega_c_);
+
+  // travelling waves - asymmetric spreading function
+  gz::waves::Cos2sSpreadingFunction spreadingFn2;
+  spreadingFn2.SetSpread(s_param_);
+
+  // normalisation for sqrt of two-sided discrete elevation variance spectrum
+  double cap_psi_norm = 0.5;
+  double delta_kx = kx_f_;
+  double delta_ky = ky_f_;
+
+  // iid random normals for real and imaginary parts of the amplitudes
+  auto seed = std::default_random_engine::default_seed;
+  std::default_random_engine generator(seed);
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  // calculate spectrum in fft-order
+  for (Index ikx = 0; ikx < nx_; ++ikx)
   {
-    // run the FFTs
-    if (fft_needs_update_[3])
+    double kx = kx_fft_(ikx);
+    double kx2 = kx*kx;
+    for (Index iky = 0; iky < ny_; ++iky)
     {
-      fftw_execute(fft_plan3_);
-      fft_needs_update_[3] = false;
-    }
-    if (fft_needs_update_[4])
-    {
-      fftw_execute(fft_plan4_);
-      fft_needs_update_[4] = false;
-    }
+      double ky = ky_fft_(iky);
+      double ky2 = ky*ky;
 
-    // change from row to column major storage
-    Index n2 = nx_ * ny_;
-    sy = fft_out3_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
-    sx = fft_out4_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
-  }
+      double k = sqrt(kx2 + ky2);
+      double phi = atan2(ky, kx);
 
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::DisplacementDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-      Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-  {
-    // run the FFTs
-    if (fft_needs_update_[5])
-    {
-      fftw_execute(fft_plan5_);
-      fft_needs_update_[5] = false;
-    }
-    if (fft_needs_update_[6])
-    {
-      fftw_execute(fft_plan6_);
-      fft_needs_update_[6] = false;
-    }
-    if (fft_needs_update_[7])
-    {
-      fftw_execute(fft_plan7_);
-      fft_needs_update_[7] = false;
-    }
+      // index for flattened array
+      Index idx = ikx * ny_ + iky;
 
-    // change from row to column major storage
-    Index n2 = nx_ * ny_;
-    dsydy = fft_out5_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
-    dsxdx = fft_out6_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ * -1.0;
-    dsxdy = fft_out7_.reshaped<Eigen::ColMajor>(n2, 1) * lambda_ *  1.0;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::PressureAt(
-      Index iz,
-      Eigen::Ref<Eigen::ArrayXXd> pressure)
-  {
-    // run the FFTs
-    if (fft_needs_update_[8 + iz])
-    {
-      fftw_execute(fft_plan_p_[iz]);
-      fft_needs_update_[8 + iz] = false;
-    }
-
-    // change from row to column major storage
-    Index n2 = nx_ * ny_;
-    pressure = fft_out_p_[iz].reshaped<Eigen::ColMajor>(n2, 1);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::ElevationAt(
-      Index ix, Index iy,
-      double &eta)
-  {
-    /// \todo(srmainwaring) running the FFT destroys the inputs for c2r plans 
-
-    // run the FFT
-    if (fft_needs_update_[0])
-    {
-      fftw_execute(fft_plan0_);
-      fft_needs_update_[0] = false;
-    }
-
-    // select value
-    eta = fft_out0_(ix, iy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::DisplacementAt(
-      Index ix, Index iy,
-      double &sx, double &sy)
-  {
-    // run the FFTs
-    if (fft_needs_update_[3])
-    {
-      fftw_execute(fft_plan3_);
-      fft_needs_update_[3] = false;
-    }
-    if (fft_needs_update_[4])
-    {
-      fftw_execute(fft_plan4_);
-      fft_needs_update_[4] = false;
-    }
-
-    // change from row to column major storage and scale
-    sy = fft_out3_(ix, iy) * lambda_ * -1.0;
-    sx = fft_out4_(ix, iy) * lambda_ * -1.0;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::PressureAt(
-      Index ix, Index iy, Index iz,
-      double &pressure)
-  {
-    // run the FFT
-    if (fft_needs_update_[8 + iz])
-    {
-      fftw_execute(fft_plan_p_[iz]);
-      fft_needs_update_[8 + iz] = false;
-    }
-
-    // select value
-    pressure = fft_out_p_[iz](ix, iy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::ComputeBaseAmplitudes()
-  {
-    InitWaveNumbers();
-    InitPressureGrid();
-
-    // initialise arrays - always update as algo switch may change shape.
-    Index n2 = nx_ * ny_;
-    {
-      cap_psi_2s_root_  = Eigen::ArrayXd::Zero(n2);
-      rho_              = Eigen::ArrayXd::Zero(n2);
-      sigma_            = Eigen::ArrayXd::Zero(n2);
-      omega_k_          = Eigen::ArrayXd::Zero(n2);
-      zhat_             = Eigen::ArrayXd::Zero(n2);
-      cos_wt_           = Eigen::ArrayXd::Zero(n2);
-      sin_wt_           = Eigen::ArrayXd::Zero(n2);
-    }
-
-    // spectrum and spreading functions
-    gz::waves::ECKVWaveSpectrum spectrum;
-    spectrum.SetGravity(gravity_);
-    spectrum.SetU10(u10_);
-    spectrum.SetCapOmegaC(cap_omega_c_);
-
-    // standing waves - symmetric spreading function
-    gz::waves::ECKVSpreadingFunction spreadingFn1;
-    spreadingFn1.SetGravity(gravity_);
-    spreadingFn1.SetU10(u10_);
-    spreadingFn1.SetCapOmegaC(cap_omega_c_);
-
-    // travelling waves - asymmetric spreading function
-    gz::waves::Cos2sSpreadingFunction spreadingFn2;
-    spreadingFn2.SetSpread(s_param_);
-
-    // normalisation for sqrt of two-sided discrete elevation variance spectrum
-    double cap_psi_norm = 0.5;
-    double delta_kx = kx_f_;
-    double delta_ky = ky_f_;
-
-    // iid random normals for real and imaginary parts of the amplitudes
-    auto seed = std::default_random_engine::default_seed;
-    std::default_random_engine generator(seed);
-    std::normal_distribution<double> distribution(0.0, 1.0);
-
-    // calculate spectrum in fft-order
-    for (Index ikx = 0; ikx < nx_; ++ikx)
-    {
-      double kx = kx_fft_(ikx);
-      double kx2 = kx*kx;
-      for (Index iky = 0; iky < ny_; ++iky)
+      double cap_psi = 0.0;
+      if (use_symmetric_spreading_fn_)
       {
-        double ky = ky_fft_(iky);
-        double ky2 = ky*ky;
-        
-        double k = sqrt(kx2 + ky2);
-        double phi = atan2(ky, kx);
-
-        // index for flattened array
-        Index idx = ikx * ny_ + iky;
-
-        double cap_psi = 0.0;
-        if (use_symmetric_spreading_fn_)
-        {
-          // standing waves - symmetric spreading function
-          cap_psi = spreadingFn1.Evaluate(phi, phi10_, k);
-        }
-        else
-        {
-          // travelling waves - asymmetric spreading function
-          cap_psi = spreadingFn2.Evaluate(phi, phi10_, k);
-        }
-        double cap_s = spectrum.Evaluate(k);
-        double cap_psi_2s_fft = cap_s * cap_psi / k;
-
-        // square-root of two-sided discrete elevation variance spectrum
-        cap_psi_2s_root_(idx) =
-            cap_psi_norm * sqrt(cap_psi_2s_fft * delta_kx * delta_ky);
-
-        // iid random normals
-        rho_(idx) = distribution(generator);
-        sigma_(idx) = distribution(generator);
-
-        // angular temporal frequency using deep water dispersion
-        omega_k_(idx) = sqrt(gravity_ * k);
+        // standing waves - symmetric spreading function
+        cap_psi = spreadingFn1.Evaluate(phi, phi10_, k);
+      } else {
+        // travelling waves - asymmetric spreading function
+        cap_psi = spreadingFn2.Evaluate(phi, phi10_, k);
       }
+      double cap_s = spectrum.Evaluate(k);
+      double cap_psi_2s_fft = cap_s * cap_psi / k;
+
+      // square-root of two-sided discrete elevation variance spectrum
+      cap_psi_2s_root_(idx) =
+          cap_psi_norm * sqrt(cap_psi_2s_fft * delta_kx * delta_ky);
+
+      // iid random normals
+      rho_(idx) = distribution(generator);
+      sigma_(idx) = distribution(generator);
+
+      // angular temporal frequency using deep water dispersion
+      omega_k_(idx) = sqrt(gravity_ * k);
     }
   }
+}
 
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::ComputeCurrentAmplitudes(
-      double time)
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::ComputeCurrentAmplitudes(
+    double time)
+{
+  // set all true
+  std::transform(
+    fft_needs_update_.cbegin(),
+    fft_needs_update_.cend(),
+    fft_needs_update_.begin(),
+    [] (bool) -> bool { return true; });
+
+  // create 1d views
+  auto r = rho_.reshaped();
+  auto s = sigma_.reshaped();
+  auto psi_root = cap_psi_2s_root_.reshaped();
+
+  // time update
+  for (Index idx = 0; idx < nx_ * ny_; ++idx)
   {
-    // set all true
-    std::transform(
-      fft_needs_update_.cbegin(),
-      fft_needs_update_.cend(),
-      fft_needs_update_.begin(),
-      [] (bool) -> bool { return true; });
+    double wt = omega_k_(idx) * time;
+    cos_wt_(idx) = cos(wt);
+    sin_wt_(idx) = sin(wt);
+  }
 
-    // create 1d views
-    auto r = rho_.reshaped();
-    auto s = sigma_.reshaped();
-    auto psi_root = cap_psi_2s_root_.reshaped();
-
-    // time update
-    for (Index idx = 0; idx < nx_ * ny_; ++idx)
-    {
-      double wt = omega_k_(idx) * time;
-      cos_wt_(idx) = cos(wt);
-      sin_wt_(idx) = sin(wt);
-    }
-
-    // flattened index version
-    for (Index ikx = 1; ikx < nx_; ++ikx)
-    {
-      for (Index iky = 1; iky < ny_/2 + 1; ++iky)
-      {
-        // index for flattened array (ikx, iky)
-        Index idx = ikx * ny_ + iky;
-
-        // index for conjugate (nx_-ikx, ny_-iky)
-        Index cdx = (nx_-ikx) * ny_ + (ny_-iky);
-
-        zhat_(idx) = complex(
-            + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_wt_(idx)
-            + ( s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx) ) * sin_wt_(idx),
-            - ( r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx) ) * sin_wt_(idx)
-            + ( s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx) ) * cos_wt_(idx));
-      }
-    }
-
+  // flattened index version
+  for (Index ikx = 1; ikx < nx_; ++ikx)
+  {
     for (Index iky = 1; iky < ny_/2 + 1; ++iky)
     {
-      Index ikx = 0;
-
       // index for flattened array (ikx, iky)
       Index idx = ikx * ny_ + iky;
 
-      // index for conjugate (ikx, ny_-iky)
-      Index cdx = ikx * ny_ + (ny_-iky);
+      // index for conjugate (nx_-ikx, ny_-iky)
+      Index cdx = (nx_-ikx) * ny_ + (ny_-iky);
 
       zhat_(idx) = complex(
-          + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_wt_(idx)
-          + ( s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx) ) * sin_wt_(idx),
-          - ( r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx) ) * sin_wt_(idx)
-          + ( s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx) ) * cos_wt_(idx));
-      zhat_(cdx, 0) = std::conj(zhat_(idx));
+          + (r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx)) * cos_wt_(idx)
+          + (s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx)) * sin_wt_(idx),
+          - (r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx)) * sin_wt_(idx)
+          + (s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx)) * cos_wt_(idx));
     }
+  }
 
-    for (Index ikx = 1; ikx < nx_/2 + 1; ++ikx)
+  for (Index iky = 1; iky < ny_/2 + 1; ++iky)
+  {
+    Index ikx = 0;
+
+    // index for flattened array (ikx, iky)
+    Index idx = ikx * ny_ + iky;
+
+    // index for conjugate (ikx, ny_-iky)
+    Index cdx = ikx * ny_ + (ny_-iky);
+
+    zhat_(idx) = complex(
+        + (r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx)) * cos_wt_(idx)
+        + (s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx)) * sin_wt_(idx),
+        - (r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx)) * sin_wt_(idx)
+        + (s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx)) * cos_wt_(idx));
+    zhat_(cdx, 0) = std::conj(zhat_(idx));
+  }
+
+  for (Index ikx = 1; ikx < nx_/2 + 1; ++ikx)
+  {
+    Index iky = 0;
+
+    // index for flattened array (ikx, iky)
+    Index idx = ikx * ny_ + iky;
+
+    // index for conjugate (nx_-ikx, iky)
+    Index cdx = (nx_-ikx) * ny_ + iky;
+
+    zhat_(idx) = complex(
+        + (r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx)) * cos_wt_(idx)
+        + (s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx)) * sin_wt_(idx),
+        - (r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx)) * sin_wt_(idx)
+        + (s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx)) * cos_wt_(idx));
+    zhat_(cdx, 0) = std::conj(zhat_(idx));
+  }
+
+  zhat_(0, 0) = complex(0.0, 0.0);
+
+  /// write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
+  /// \note the inner loop has iky < ny_ / 2 + 1
+  ///       as we exploit the Hermitian symmetry in the FFT
+  const complex iunit(0.0, 1.0);
+  const complex czero(0.0, 0.0);
+
+  for (Index ikx = 0; ikx < nx_; ++ikx)
+  {
+    double kx = kx_fft_(ikx);
+    double kx2 = kx*kx;
+    for (Index iky = 0; iky < ny_/2 + 1; ++iky)
     {
-      Index iky = 0;
+      double ky = ky_fft_(iky);
+      double ky2 = ky*ky;
+      double k = sqrt(kx2 + ky2);
 
-      // index for flattened array (ikx, iky)
+      // index for flattened arrays
       Index idx = ikx * ny_ + iky;
 
-      // index for conjugate (nx_-ikx, iky)
-      Index cdx = (nx_-ikx) * ny_ + iky;
+      complex h  = zhat_(idx);
+      complex hi = h * iunit;
+      complex hikx = hi * kx;
+      complex hiky = hi * ky;
 
-      zhat_(idx) = complex(
-          + ( r(idx) * psi_root(idx) + r(cdx) * psi_root(cdx) ) * cos_wt_(idx)
-          + ( s(idx) * psi_root(idx) + s(cdx) * psi_root(cdx) ) * sin_wt_(idx),
-          - ( r(idx) * psi_root(idx) - r(cdx) * psi_root(cdx) ) * sin_wt_(idx)
-          + ( s(idx) * psi_root(idx) - s(cdx) * psi_root(cdx) ) * cos_wt_(idx));
-      zhat_(cdx, 0) = std::conj(zhat_(idx));
-    }
+      // Nyquist terms for derivatives must be zero.
+      // For an explanation see:
+      // https://math.mit.edu/~stevenj/fft-deriv.pdf
+      if (ikx == nx_ / 2)
+        hikx = czero;
+      if (iky == ny_ / 2)
+        hiky = czero;
 
-    zhat_(0, 0) = complex(0.0, 0.0);
+      // elevation
+      fft_h_(ikx, iky) = h;
+      fft_h_ikx_(ikx, iky) = hikx;
+      fft_h_iky_(ikx, iky) = hiky;
 
-    /// write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
-    /// \note the inner loop has iky < ny_ / 2 + 1
-    ///       as we exploit the Hermitian symmetry in the FFT 
-    const complex iunit(0.0, 1.0);
-    const complex czero(0.0, 0.0);
+      /// \todo(srmainwaring) pressure optimisation - adjust so that the
+      /// entry for z = 0 is obtained from  fft_h_ / fft_out0_ / fft_plan0_
 
-    for (Index ikx = 0; ikx < nx_; ++ikx)
-    {
-      double kx = kx_fft_(ikx);
-      double kx2 = kx*kx;
-      for (Index iky = 0; iky < ny_/2 + 1; ++iky)
+      // pressure
+      for (Index iz = 0; iz < nz_; ++iz)
       {
-        double ky = ky_fft_(iky);
-        double ky2 = ky*ky;
-        double k = sqrt(kx2 + ky2);
+        double z = z_(iz);
+        double e = std::exp(k * z);
+        complex p = e * h;
+        fft_in_p_[iz](ikx, iky) = p;
+      }
 
-        // index for flattened arrays
-        Index idx = ikx * ny_ + iky;
+      // displacement and derivatives
+      if (std::abs(k) < 1.0E-8)
+      {
+        fft_sx_(ikx, iky)     = czero;
+        fft_sy_(ikx, iky)     = czero;
+        fft_h_kxkx_(ikx, iky) = czero;
+        fft_h_kyky_(ikx, iky) = czero;
+        fft_h_kxky_(ikx, iky) = czero;
+      } else {
+        complex ook = 1.0 / k;
+        complex hok = h * ook;
+        complex hiok = hi * ook;
+        complex dx = - hiok * kx;
+        complex dy = - hiok * ky;
+        complex hkxkx = hok * kx2;
+        complex hkyky = hok * ky2;
+        complex hkxky = hok * kx * ky;
 
-        complex h  = zhat_(idx);
-        complex hi = h * iunit;
-        complex hikx = hi * kx;
-        complex hiky = hi * ky;
-
-        // Nyquist terms for derivatives must be zero.
-        // For an explanation see:
-        // https://math.mit.edu/~stevenj/fft-deriv.pdf
         if (ikx == nx_ / 2)
-          hikx = czero;
+          dx = czero;
         if (iky == ny_ / 2)
-          hiky = czero;
+          dy = czero;
 
-        // elevation
-        fft_h_(ikx, iky) = h;
-        fft_h_ikx_(ikx, iky) = hikx;
-        fft_h_iky_(ikx, iky) = hiky;
-
-        /// \todo(srmainwaring) pressure optimisation - adjust so that the
-        /// entry for z = 0 is obtained from  fft_h_ / fft_out0_ / fft_plan0_
-
-        // pressure
-        for (Index iz = 0; iz < nz_; ++iz)
-        {
-          double z = z_(iz);
-          double e = std::exp(k * z);
-          complex p = e * h; 
-          fft_in_p_[iz](ikx, iky) = p;
-        }
-
-        // displacement and derivatives
-        if (std::abs(k) < 1.0E-8)
-        {
-          fft_sx_(ikx, iky)     = czero;
-          fft_sy_(ikx, iky)     = czero;
-          fft_h_kxkx_(ikx, iky) = czero;
-          fft_h_kyky_(ikx, iky) = czero;
-          fft_h_kxky_(ikx, iky) = czero;
-        }
-        else
-        {
-          complex ook = 1.0 / k;
-          complex hok = h * ook;
-          complex hiok = hi * ook;
-          complex dx = - hiok * kx;
-          complex dy = - hiok * ky;
-          complex hkxkx = hok * kx2;
-          complex hkyky = hok * ky2;
-          complex hkxky = hok * kx * ky;
-          
-          if (ikx == nx_ / 2)
-            dx = czero;
-          if (iky == ny_ / 2)
-            dy = czero;
-
-          fft_sx_(ikx, iky)     = dx;
-          fft_sy_(ikx, iky)     = dy;
-          fft_h_kxkx_(ikx, iky) = hkxkx;
-          fft_h_kyky_(ikx, iky) = hkyky;
-          fft_h_kxky_(ikx, iky) = hkxky;
-        }
+        fft_sx_(ikx, iky)     = dx;
+        fft_sy_(ikx, iky)     = dy;
+        fft_h_kxkx_(ikx, iky) = hkxkx;
+        fft_h_kyky_(ikx, iky) = hkyky;
+        fft_h_kxky_(ikx, iky) = hkxky;
       }
     }
   }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::InitWaveNumbers()
-  {
-    kx_fft_  = Eigen::ArrayXd::Zero(nx_);
-    ky_fft_  = Eigen::ArrayXd::Zero(ny_);
-
-    // wavenumbers in fft and math ordering
-    for(Index ikx = 0; ikx < nx_; ++ikx)
-    {
-      double kx = (ikx - nx_/2) * kx_f_;
-      kx_fft_((ikx + nx_/2) % nx_) = kx;
-    }
-
-    for(Index iky = 0; iky < ny_; ++iky)
-    {
-      double ky = (iky - ny_/2) * ky_f_;
-      ky_fft_((iky + ny_/2) % ny_) = ky;
-    }
-  }
-
- //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::InitPressureGrid()
-  {
-    // pressure sample points (z is below the free surface)
-    Eigen::ArrayXd zr = Eigen::ArrayXd::Zero(nz_);
-    if (nz_ > 1)
-    {
-      // first element is zero - fill nz - 1 remaining elements
-      Eigen::ArrayXd ln_z = Eigen::ArrayXd::LinSpaced(
-          nz_ - 1, -std::log(lz_), std::log(lz_));
-      zr(Eigen::seq(1, nz_ - 1)) = -1 * Eigen::exp(ln_z);
-    }
-    z_ = zr.reverse();
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::CreateFFTWPlans()
-  {
-    /// \note the input and output arrays may be overridden during
-    ///       planning, so allocate here before initialising.
-    ///       https://www.fftw.org/fftw3_doc/Complex-DFTs.html
-
-    // allocate storage for Fourier coefficients
-    fft_h_      = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
-    fft_h_ikx_  = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
-    fft_h_iky_  = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
-    fft_sx_     = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
-    fft_sy_     = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
-    fft_h_kxkx_ = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
-    fft_h_kyky_ = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
-    fft_h_kxky_ = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
-
-    // elevation
-    fft_out0_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
-    fft_out1_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
-    fft_out2_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
-
-    // xy-displacements
-    fft_out3_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
-    fft_out4_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
-    fft_out5_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
-    fft_out6_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
-    fft_out7_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
-
-    // elevation
-    fft_plan0_ = fftw_plan_dft_c2r_2d(nx_, ny_,
-        reinterpret_cast<fftw_complex*>(fft_h_.data()),
-        reinterpret_cast<double*>(fft_out0_.data()),
-        FFTW_ESTIMATE);
-    fft_plan1_ = fftw_plan_dft_c2r_2d(nx_, ny_,
-        reinterpret_cast<fftw_complex*>(fft_h_ikx_.data()),
-        reinterpret_cast<double*>(fft_out1_.data()),
-        FFTW_ESTIMATE);
-    fft_plan2_ = fftw_plan_dft_c2r_2d(nx_, ny_,
-        reinterpret_cast<fftw_complex*>(fft_h_iky_.data()),
-        reinterpret_cast<double*>(fft_out2_.data()),
-        FFTW_ESTIMATE);
-
-    // xy-displacements
-    fft_plan3_ = fftw_plan_dft_c2r_2d(nx_, ny_,
-        reinterpret_cast<fftw_complex*>(fft_sx_.data()),
-        reinterpret_cast<double*>(fft_out3_.data()),
-        FFTW_ESTIMATE);
-    fft_plan4_ = fftw_plan_dft_c2r_2d(nx_, ny_,
-        reinterpret_cast<fftw_complex*>(fft_sy_.data()),
-        reinterpret_cast<double*>(fft_out4_.data()),
-        FFTW_ESTIMATE);
-    fft_plan5_ = fftw_plan_dft_c2r_2d(nx_, ny_,
-        reinterpret_cast<fftw_complex*>(fft_h_kxkx_.data()),
-        reinterpret_cast<double*>(fft_out5_.data()),
-        FFTW_ESTIMATE);
-    fft_plan6_ = fftw_plan_dft_c2r_2d(nx_, ny_,
-        reinterpret_cast<fftw_complex*>(fft_h_kyky_.data()),
-        reinterpret_cast<double*>(fft_out6_.data()),
-        FFTW_ESTIMATE);
-    fft_plan7_ = fftw_plan_dft_c2r_2d(nx_, ny_,
-        reinterpret_cast<fftw_complex*>(fft_h_kxky_.data()),
-        reinterpret_cast<double*>(fft_out7_.data()),
-        FFTW_ESTIMATE);
-
-    /// \todo(srmainwaring) pressure optimisation - adjust so that the
-    /// entry for z = 0 is obtained from  fft_h_ / fft_out0_ / fft_plan0_
-
-    // pressure
-    for (Index iz=0; iz < nz_; ++iz)
-    {
-      fft_in_p_.push_back(Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1));
-      fft_out_p_.push_back(Eigen::ArrayXXdRowMajor::Zero(nx_, ny_));
-      fft_plan_p_.push_back(fftw_plan_dft_c2r_2d(nx_, ny_,
-          reinterpret_cast<fftw_complex*>(fft_in_p_[iz].data()),
-          reinterpret_cast<double*>(fft_out_p_[iz].data()),
-          FFTW_ESTIMATE));
-    }
-
-    // set lazy evaluation flags.
-    fft_needs_update_.resize(8 + nz_);
-    std::transform(
-      fft_needs_update_.cbegin(),
-      fft_needs_update_.cend(),
-      fft_needs_update_.begin(),
-      [] (bool) -> bool { return true; });
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::Impl::DestroyFFTWPlans()
-  {
-    fftw_destroy_plan(fft_plan0_);
-    fftw_destroy_plan(fft_plan1_);
-    fftw_destroy_plan(fft_plan2_);
-    fftw_destroy_plan(fft_plan3_);
-    fftw_destroy_plan(fft_plan4_);
-    fftw_destroy_plan(fft_plan5_);
-    fftw_destroy_plan(fft_plan6_);
-    fftw_destroy_plan(fft_plan7_);
-  }
-
-  //////////////////////////////////////////////////
-  //////////////////////////////////////////////////
-  LinearRandomFFTWaveSimulation::~LinearRandomFFTWaveSimulation()
-  {
-  }
-
-  //////////////////////////////////////////////////
-  LinearRandomFFTWaveSimulation::LinearRandomFFTWaveSimulation(
-      double lx, double ly, Index nx, Index ny) :
-    impl_(new LinearRandomFFTWaveSimulation::Impl(lx, ly, nx, ny))
-  {
-  }
-
-  //////////////////////////////////////////////////
-  LinearRandomFFTWaveSimulation::LinearRandomFFTWaveSimulation(
-      double lx, double ly, double lz, Index nx, Index ny, Index nz) :
-    impl_(new LinearRandomFFTWaveSimulation::Impl(lx, ly, lz, nx, ny, nz))
-  {
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::SetLambda(double value)
-  {
-    impl_->SetLambda(value);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::SetWindVelocity(double ux, double uy)
-  {
-    impl_->SetWindVelocity(ux, uy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::SetTime(double value)
-  {
-    impl_->SetTime(value);
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRandomFFTWaveSimulation::SizeX() const
-  {
-    return impl_->nx_;
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRandomFFTWaveSimulation::SizeY() const
-  {
-    return impl_->ny_;
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRandomFFTWaveSimulation::SizeZ() const
-  {
-    return impl_->nz_;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h)
-  {
-    impl_->ElevationAt(h);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::ElevationDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy)
-  {
-    impl_->ElevationDerivAt(dhdx, dhdy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::DisplacementAt(
-      Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy)
-  {
-    impl_->DisplacementAt(sx, sy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::DisplacementDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-      Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-  {
-    impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::DisplacementAndDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> h,
-      Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy,
-      Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-      Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-  {
-    impl_->ElevationAt(h);
-    impl_->ElevationDerivAt(dhdx, dhdy);
-    impl_->DisplacementAt(sx, sy);
-    impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::PressureAt(
-      Index iz,
-      Eigen::Ref<Eigen::ArrayXXd> pressure)
-  {
-    impl_->PressureAt(iz, pressure);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::ElevationAt(
-      Index ix, Index iy,
-      double &eta)
-  {
-    impl_->ElevationAt(ix, iy, eta);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::DisplacementAt(
-      Index ix, Index iy,
-      double &sx, double &sy)
-  {
-    impl_->DisplacementAt(ix, iy, sx, sy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulation::PressureAt(
-      Index ix, Index iy, Index iz,
-      double &pressure)
-  {
-    impl_->PressureAt(ix, iy, iz, pressure);
-  }
-
 }
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::InitWaveNumbers()
+{
+  kx_fft_  = Eigen::ArrayXd::Zero(nx_);
+  ky_fft_  = Eigen::ArrayXd::Zero(ny_);
+
+  // wavenumbers in fft and math ordering
+  for (Index ikx = 0; ikx < nx_; ++ikx)
+  {
+    double kx = (ikx - nx_/2) * kx_f_;
+    kx_fft_((ikx + nx_/2) % nx_) = kx;
+  }
+
+  for (Index iky = 0; iky < ny_; ++iky)
+  {
+    double ky = (iky - ny_/2) * ky_f_;
+    ky_fft_((iky + ny_/2) % ny_) = ky;
+  }
 }
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::InitPressureGrid()
+{
+  // pressure sample points (z is below the free surface)
+  Eigen::ArrayXd zr = Eigen::ArrayXd::Zero(nz_);
+  if (nz_ > 1)
+  {
+    // first element is zero - fill nz - 1 remaining elements
+    Eigen::ArrayXd ln_z = Eigen::ArrayXd::LinSpaced(
+        nz_ - 1, -std::log(lz_), std::log(lz_));
+    zr(Eigen::seq(1, nz_ - 1)) = -1 * Eigen::exp(ln_z);
+  }
+  z_ = zr.reverse();
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::CreateFFTWPlans()
+{
+  /// \note the input and output arrays may be overridden during
+  ///       planning, so allocate here before initialising.
+  ///       https://www.fftw.org/fftw3_doc/Complex-DFTs.html
+
+  // allocate storage for Fourier coefficients
+  fft_h_      = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
+  fft_h_ikx_  = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
+  fft_h_iky_  = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
+  fft_sx_     = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
+  fft_sy_     = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
+  fft_h_kxkx_ = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
+  fft_h_kyky_ = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
+  fft_h_kxky_ = Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1);
+
+  // elevation
+  fft_out0_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
+  fft_out1_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
+  fft_out2_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
+
+  // xy-displacements
+  fft_out3_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
+  fft_out4_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
+  fft_out5_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
+  fft_out6_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
+  fft_out7_ = Eigen::ArrayXXdRowMajor::Zero(nx_, ny_);
+
+  // elevation
+  fft_plan0_ = fftw_plan_dft_c2r_2d(nx_, ny_,
+      reinterpret_cast<fftw_complex*>(fft_h_.data()),
+      reinterpret_cast<double*>(fft_out0_.data()),
+      FFTW_ESTIMATE);
+  fft_plan1_ = fftw_plan_dft_c2r_2d(nx_, ny_,
+      reinterpret_cast<fftw_complex*>(fft_h_ikx_.data()),
+      reinterpret_cast<double*>(fft_out1_.data()),
+      FFTW_ESTIMATE);
+  fft_plan2_ = fftw_plan_dft_c2r_2d(nx_, ny_,
+      reinterpret_cast<fftw_complex*>(fft_h_iky_.data()),
+      reinterpret_cast<double*>(fft_out2_.data()),
+      FFTW_ESTIMATE);
+
+  // xy-displacements
+  fft_plan3_ = fftw_plan_dft_c2r_2d(nx_, ny_,
+      reinterpret_cast<fftw_complex*>(fft_sx_.data()),
+      reinterpret_cast<double*>(fft_out3_.data()),
+      FFTW_ESTIMATE);
+  fft_plan4_ = fftw_plan_dft_c2r_2d(nx_, ny_,
+      reinterpret_cast<fftw_complex*>(fft_sy_.data()),
+      reinterpret_cast<double*>(fft_out4_.data()),
+      FFTW_ESTIMATE);
+  fft_plan5_ = fftw_plan_dft_c2r_2d(nx_, ny_,
+      reinterpret_cast<fftw_complex*>(fft_h_kxkx_.data()),
+      reinterpret_cast<double*>(fft_out5_.data()),
+      FFTW_ESTIMATE);
+  fft_plan6_ = fftw_plan_dft_c2r_2d(nx_, ny_,
+      reinterpret_cast<fftw_complex*>(fft_h_kyky_.data()),
+      reinterpret_cast<double*>(fft_out6_.data()),
+      FFTW_ESTIMATE);
+  fft_plan7_ = fftw_plan_dft_c2r_2d(nx_, ny_,
+      reinterpret_cast<fftw_complex*>(fft_h_kxky_.data()),
+      reinterpret_cast<double*>(fft_out7_.data()),
+      FFTW_ESTIMATE);
+
+  /// \todo(srmainwaring) pressure optimisation - adjust so that the
+  /// entry for z = 0 is obtained from  fft_h_ / fft_out0_ / fft_plan0_
+
+  // pressure
+  for (Index iz=0; iz < nz_; ++iz)
+  {
+    fft_in_p_.push_back(Eigen::ArrayXXcdRowMajor::Zero(nx_, ny_/2+1));
+    fft_out_p_.push_back(Eigen::ArrayXXdRowMajor::Zero(nx_, ny_));
+    fft_plan_p_.push_back(fftw_plan_dft_c2r_2d(nx_, ny_,
+        reinterpret_cast<fftw_complex*>(fft_in_p_[iz].data()),
+        reinterpret_cast<double*>(fft_out_p_[iz].data()),
+        FFTW_ESTIMATE));
+  }
+
+  // set lazy evaluation flags.
+  fft_needs_update_.resize(8 + nz_);
+  std::transform(
+    fft_needs_update_.cbegin(),
+    fft_needs_update_.cend(),
+    fft_needs_update_.begin(),
+    [] (bool) -> bool { return true; });
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::DestroyFFTWPlans()
+{
+  fftw_destroy_plan(fft_plan0_);
+  fftw_destroy_plan(fft_plan1_);
+  fftw_destroy_plan(fft_plan2_);
+  fftw_destroy_plan(fft_plan3_);
+  fftw_destroy_plan(fft_plan4_);
+  fftw_destroy_plan(fft_plan5_);
+  fftw_destroy_plan(fft_plan6_);
+  fftw_destroy_plan(fft_plan7_);
+}
+
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+LinearRandomFFTWaveSimulation::~LinearRandomFFTWaveSimulation()
+{
+}
+
+//////////////////////////////////////////////////
+LinearRandomFFTWaveSimulation::LinearRandomFFTWaveSimulation(
+    double lx, double ly, Index nx, Index ny) :
+  impl_(new LinearRandomFFTWaveSimulation::Impl(lx, ly, nx, ny))
+{
+}
+
+//////////////////////////////////////////////////
+LinearRandomFFTWaveSimulation::LinearRandomFFTWaveSimulation(
+    double lx, double ly, double lz, Index nx, Index ny, Index nz) :
+  impl_(new LinearRandomFFTWaveSimulation::Impl(lx, ly, lz, nx, ny, nz))
+{
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::SetLambda(double value)
+{
+  impl_->SetLambda(value);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::SetWindVelocity(double ux, double uy)
+{
+  impl_->SetWindVelocity(ux, uy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::SetTime(double value)
+{
+  impl_->SetTime(value);
+}
+
+//////////////////////////////////////////////////
+Index LinearRandomFFTWaveSimulation::SizeX() const
+{
+  return impl_->nx_;
+}
+
+//////////////////////////////////////////////////
+Index LinearRandomFFTWaveSimulation::SizeY() const
+{
+  return impl_->ny_;
+}
+
+//////////////////////////////////////////////////
+Index LinearRandomFFTWaveSimulation::SizeZ() const
+{
+  return impl_->nz_;
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::ElevationAt(
+    Eigen::Ref<Eigen::ArrayXXd> h)
+{
+  impl_->ElevationAt(h);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::ElevationDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy)
+{
+  impl_->ElevationDerivAt(dhdx, dhdy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::DisplacementAt(
+    Eigen::Ref<Eigen::ArrayXXd> sx,
+    Eigen::Ref<Eigen::ArrayXXd> sy)
+{
+  impl_->DisplacementAt(sx, sy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::DisplacementDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+    Eigen::Ref<Eigen::ArrayXXd> dsydy,
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+{
+  impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::DisplacementAndDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> h,
+    Eigen::Ref<Eigen::ArrayXXd> sx,
+    Eigen::Ref<Eigen::ArrayXXd> sy,
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy,
+    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+    Eigen::Ref<Eigen::ArrayXXd> dsydy,
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+{
+  impl_->ElevationAt(h);
+  impl_->ElevationDerivAt(dhdx, dhdy);
+  impl_->DisplacementAt(sx, sy);
+  impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::PressureAt(
+    Index iz,
+    Eigen::Ref<Eigen::ArrayXXd> pressure)
+{
+  impl_->PressureAt(iz, pressure);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::ElevationAt(
+    Index ix, Index iy,
+    double& eta)
+{
+  impl_->ElevationAt(ix, iy, eta);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::DisplacementAt(
+    Index ix, Index iy,
+    double& sx, double& sy)
+{
+  impl_->DisplacementAt(ix, iy, sx, sy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::PressureAt(
+    Index ix, Index iy, Index iz,
+    double& pressure)
+{
+  impl_->PressureAt(ix, iy, iz, pressure);
+}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
@@ -13,15 +13,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef GZ_WAVES_LINEARRANDOMFFTWAVESIMULATION_IMPL_HH_
-#define GZ_WAVES_LINEARRANDOMFFTWAVESIMULATION_IMPL_HH_
-
-#include <complex>
-#include <vector>
+#ifndef GZ_WAVES_SRC_LINEARRANDOMFFTWAVESIMULATIONIMPL_HH_
+#define GZ_WAVES_SRC_LINEARRANDOMFFTWAVESIMULATIONIMPL_HH_
 
 #include <Eigen/Dense>
 
 #include <fftw3.h>
+
+#include <complex>
+#include <vector>
 
 #include "gz/waves/WaveSimulation.hh"
 #include "gz/waves/LinearRandomFFTWaveSimulation.hh"
@@ -32,7 +32,7 @@ using Eigen::ArrayXcd;
 using Eigen::ArrayXd;
 
 namespace Eigen
-{ 
+{
   typedef Eigen::Array<
     std::complex<double>,
     Eigen::Dynamic,
@@ -46,197 +46,199 @@ namespace Eigen
     Eigen::Dynamic,
     Eigen::RowMajor
   > ArrayXXdRowMajor;
-}
+}  // namespace Eigen
 
 namespace gz
 {
 namespace waves
 {
+//////////////////////////////////////////////////
+// LinearRandomFFTWaveSimulation::Impl
+
+typedef double fftw_data_type;
+typedef std::complex<fftw_data_type> complex;
+
+/// \brief Implementation of a FFT based wave simulation model
+///
+/// \note The FFT wave simulation mixes storage ordering which
+///       must be made consistent and should be column major
+///       which is the Eigen default..
+///
+class LinearRandomFFTWaveSimulation::Impl
+{
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /// \brief Destructor
+  ~Impl();
+
+  /// \brief Construct a wave simulation model
+  Impl(double lx, double ly, Index nx, Index ny);
+
+  /// \brief Construct a wave simulation model
+  Impl(double lx, double ly, double lz, Index nx, Index ny, Index nz);
+
+  /// \brief Set the components of the wind velocity (U10) in [m/s]
+  void SetWindVelocity(double ux, double uy);
+
+  /// \brief Set the current time in seconds
+  void SetTime(double value);
+
+  /// \brief Set the horizontal displacement scaling factor
+  void SetLambda(double value);
+
+  /// \brief Calculate the sea surface elevation
+  void ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h);
+
+  /// \brief Calculate the derivative of the elevation wrt x and y
+  void ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy);
+
+  /// \brief Calculate the sea surface horizontal displacements
+  void DisplacementAt(
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy);
+
+  /// \brief Calculate the derivative of the horizontal displacements
+  ///        wrt x and y
+  void DisplacementDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy);
+
+  void PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure);
+
+  void ElevationAt(
+      Index ix, Index iy,
+      double& eta);
+
+  void DisplacementAt(
+      Index ix, Index iy,
+      double& sx, double& sy);
+
+  void PressureAt(
+      Index ix, Index iy, Index iz,
+      double& pressure);
+
+  /// \brief Calculate the base (time-independent) Fourier amplitudes
+  void ComputeBaseAmplitudes();
+
+  /// \brief Calculate the time-independent Fourier amplitudes
+  void ComputeCurrentAmplitudes(double time);
+
+  void InitWaveNumbers();
+  void InitPressureGrid();
+
+  void CreateFFTWPlans();
+  void DestroyFFTWPlans();
+
+  /// \note FFTW expects the multi-dimensional arrays to be in row-major
+  ///       format. Eigen::ArrayXXcd is column-major, so here we
+  ///       explicity set the storage type.
+  ///
+  /// https://www.fftw.org/fftw3_doc/Row_002dmajor-Format.html
+  ///
+  Eigen::ArrayXXcdRowMajor fft_h_;       // FFT0 - height
+  Eigen::ArrayXXcdRowMajor fft_h_ikx_;   // FFT1 - d height / dx
+  Eigen::ArrayXXcdRowMajor fft_h_iky_;   // FFT1 - d height / dy
+  Eigen::ArrayXXcdRowMajor fft_sx_;      // FFT3 - displacement x
+  Eigen::ArrayXXcdRowMajor fft_sy_;      // FFT4 - displacement y
+  Eigen::ArrayXXcdRowMajor fft_h_kxkx_;  // FFT5 - d displacement x / dx
+  Eigen::ArrayXXcdRowMajor fft_h_kyky_;  // FFT6 - d displacement y / dy
+  Eigen::ArrayXXcdRowMajor fft_h_kxky_;  // FFT7 - d displacement x / dy
+
+  /// \note if using fftw_plan_dft_c2r_2d:
+  ///       complex input array has size: nx * ny / 2 + 1
+  ///       real output array has size:   nx * ny
+  ///
+  Eigen::ArrayXXdRowMajor  fft_out0_;
+  Eigen::ArrayXXdRowMajor  fft_out1_;
+  Eigen::ArrayXXdRowMajor  fft_out2_;
+  Eigen::ArrayXXdRowMajor  fft_out3_;
+  Eigen::ArrayXXdRowMajor  fft_out4_;
+  Eigen::ArrayXXdRowMajor  fft_out5_;
+  Eigen::ArrayXXdRowMajor  fft_out6_;
+  Eigen::ArrayXXdRowMajor  fft_out7_;
+
+  fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
+  fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
+
+  /// FFT storage and plans for pressure calculations
+  std::vector<Eigen::ArrayXXcdRowMajor>   fft_in_p_;
+  std::vector<Eigen::ArrayXXdRowMajor>    fft_out_p_;
+  std::vector<fftw_plan>                  fft_plan_p_;
+
+  /// \brief lazy evaluation flags
+  std::vector<bool> fft_needs_update_;
+
+  /// \brief Gravity acceleration [m/s^2]
+  double gravity_{9.81};
+
+  /// \brief Horizontal displacement scaling factor. Zero for no displacement
+  double lambda_{0.6};
+
+  // elevation and pressure grid parameters
+  double  lx_{1.0};
+  double  ly_{1.0};
+  double  lz_{0.0};
+  Index   nx_{2};
+  Index   ny_{2};
+  Index   nz_{1};
+
+  // points along z-axis at which pressure is sampled
+  Eigen::ArrayXd z_;
+
+  /// \brief Wind speed at 10m above mean sea level [m]
+  double  u10_{5.0};
+
+  /// \brief Direction of u10. Counter clockwise angle from x-axis [rad]
+  double  phi10_{0.0};
+
+  /// \brief Spreading parameter for the cosine-2S model
+  double  s_param_{5.0};
+
+  /// \brief Parameter controlling the maturity of the sea state.
+  double  cap_omega_c_{0.84};
+
+  // fundamental angular spatial frequency [rad/m]
+  double  kx_f_{2.0 * M_PI / lx_};
+  double  ky_f_{2.0 * M_PI / ly_};
+
+  // angular spatial frequencies in fft order (nx, ny)
+  Eigen::ArrayXd kx_fft_;
+  Eigen::ArrayXd ky_fft_;
+
+  /// \brief Set to 1 to use a symmetric spreading function (standing waves).
+  bool use_symmetric_spreading_fn_{false};
+
   //////////////////////////////////////////////////
-  // LinearRandomFFTWaveSimulation::Impl
+  // storage for current amplitudes (nx * ny)
+  Eigen::ArrayXcd zhat_;
+  Eigen::ArrayXd  cos_wt_;
+  Eigen::ArrayXd  sin_wt_;
 
-  typedef double fftw_data_type;
-  typedef std::complex<fftw_data_type> complex;
+  //////////////////////////////////////////////////
+  // storage for base amplitudes (fft order)
 
-  /// \brief Implementation of a FFT based wave simulation model
-  ///
-  /// \note The FFT wave simulation mixes storage ordering which
-  ///       must be made consistent and should be column major
-  ///       which is the Eigen default..
-  ///
-  class LinearRandomFFTWaveSimulation::Impl
-  {
-  public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    
-    /// \brief Destructor 
-    ~Impl();
+  // square-root of two-sided discrete elevation variance spectrum
+  Eigen::ArrayXd cap_psi_2s_root_;
 
-    /// \brief Construct a wave simulation model
-    Impl(double lx, double ly, Index nx, Index ny);
+  // iid random normals for real and imaginary parts of the amplitudes
+  Eigen::ArrayXd rho_;
+  Eigen::ArrayXd sigma_;
 
-    /// \brief Construct a wave simulation model
-    Impl(double lx, double ly, double lz, Index nx, Index ny, Index nz);
+  // angular temporal frequency
+  Eigen::ArrayXd omega_k_;
 
-    /// \brief Set the components of the wind velocity (U10) in [m/s]
-    void SetWindVelocity(double ux, double uy);
+  /// \brief For testing
+  friend class LinearRandomFFTWaveSimFixture;
+};
 
-    /// \brief Set the current time in seconds
-    void SetTime(double value);
+}  // namespace waves
+}  // namespace gz
 
-    /// \brief Set the horizontal displacement scaling factor
-    void SetLambda(double value);
-
-    /// \brief Calculate the sea surface elevation
-    void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> h);
-
-    /// \brief Calculate the derivative of the elevation wrt x and y
-    void ElevationDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy);
-
-    /// \brief Calculate the sea surface horizontal displacements
-    void DisplacementAt(
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy);
-
-    /// \brief Calculate the derivative of the horizontal displacements wrt x and y
-    void DisplacementDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy);
-
-    void PressureAt(
-        Index iz,
-        Eigen::Ref<Eigen::ArrayXXd> pressure);
-
-    void ElevationAt(
-        Index ix, Index iy,
-        double &eta);
-
-    void DisplacementAt(
-        Index ix, Index iy,
-        double &sx, double &sy);
-
-    void PressureAt(
-        Index ix, Index iy, Index iz,
-        double &pressure);
-
-    /// \brief Calculate the base (time-independent) Fourier amplitudes
-    void ComputeBaseAmplitudes();
-
-    /// \brief Calculate the time-independent Fourier amplitudes
-    void ComputeCurrentAmplitudes(double time);
-
-    void InitWaveNumbers();
-    void InitPressureGrid();
-
-    void CreateFFTWPlans();
-    void DestroyFFTWPlans();
-
-    /// \note FFTW expects the multi-dimensional arrays to be in row-major
-    ///       format. Eigen::ArrayXXcd is column-major, so here we
-    ///       explicity set the storage type.
-    ///
-    /// https://www.fftw.org/fftw3_doc/Row_002dmajor-Format.html 
-    ///
-    Eigen::ArrayXXcdRowMajor fft_h_;       // FFT0 - height
-    Eigen::ArrayXXcdRowMajor fft_h_ikx_;   // FFT1 - d height / dx
-    Eigen::ArrayXXcdRowMajor fft_h_iky_;   // FFT1 - d height / dy
-    Eigen::ArrayXXcdRowMajor fft_sx_;      // FFT3 - displacement x
-    Eigen::ArrayXXcdRowMajor fft_sy_;      // FFT4 - displacement y
-    Eigen::ArrayXXcdRowMajor fft_h_kxkx_;  // FFT5 - d displacement x / dx
-    Eigen::ArrayXXcdRowMajor fft_h_kyky_;  // FFT6 - d displacement y / dy
-    Eigen::ArrayXXcdRowMajor fft_h_kxky_;  // FFT7 - d displacement x / dy
-
-    /// \note if using fftw_plan_dft_c2r_2d:  
-    ///       complex input array has size: nx * ny / 2 + 1
-    ///       real output array has size:   nx * ny
-    ///
-    Eigen::ArrayXXdRowMajor  fft_out0_;
-    Eigen::ArrayXXdRowMajor  fft_out1_;
-    Eigen::ArrayXXdRowMajor  fft_out2_;
-    Eigen::ArrayXXdRowMajor  fft_out3_;
-    Eigen::ArrayXXdRowMajor  fft_out4_;
-    Eigen::ArrayXXdRowMajor  fft_out5_;
-    Eigen::ArrayXXdRowMajor  fft_out6_;
-    Eigen::ArrayXXdRowMajor  fft_out7_;
-
-    fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
-    fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
-
-    /// FFT storage and plans for pressure calculations
-    std::vector<Eigen::ArrayXXcdRowMajor>   fft_in_p_;
-    std::vector<Eigen::ArrayXXdRowMajor>    fft_out_p_;
-    std::vector<fftw_plan>                  fft_plan_p_;
-
-    /// \brief lazy evaluation flags
-    std::vector<bool> fft_needs_update_;
-
-    /// \brief Gravity acceleration [m/s^2]
-    double gravity_{9.81};
-
-    /// \brief Horizontal displacement scaling factor. Zero for no displacement
-    double lambda_{0.6};
-
-    // elevation and pressure grid parameters
-    double  lx_{1.0};
-    double  ly_{1.0};
-    double  lz_{0.0};
-    Index   nx_{2};
-    Index   ny_{2};
-    Index   nz_{1};
-
-    // points along z-axis at which pressure is sampled
-    Eigen::ArrayXd z_;
-
-    /// \brief Wind speed at 10m above mean sea level [m]
-    double  u10_{5.0};
-
-    /// \brief Direction of u10. Counter clockwise angle from x-axis [rad]
-    double  phi10_{0.0};
-
-    /// \brief Spreading parameter for the cosine-2S model
-    double  s_param_{5.0};
-
-    /// \brief Parameter controlling the maturity of the sea state.
-    double  cap_omega_c_{0.84};
-
-    // fundamental angular spatial frequency [rad/m]
-    double  kx_f_{2.0 * M_PI / lx_};
-    double  ky_f_{2.0 * M_PI / ly_};
-
-    // angular spatial frequencies in fft order (nx, ny)
-    Eigen::ArrayXd kx_fft_;
-    Eigen::ArrayXd ky_fft_;
-
-    /// \brief Set to 1 to use a symmetric spreading function (standing waves).
-    bool use_symmetric_spreading_fn_{false};
-
-    //////////////////////////////////////////////////
-    // storage for current amplitudes (nx * ny)
-    Eigen::ArrayXcd zhat_;
-    Eigen::ArrayXd  cos_wt_;
-    Eigen::ArrayXd  sin_wt_;
-
-    //////////////////////////////////////////////////
-    // storage for base amplitudes (fft order)
-
-    // square-root of two-sided discrete elevation variance spectrum
-    Eigen::ArrayXd cap_psi_2s_root_;
-
-    // iid random normals for real and imaginary parts of the amplitudes
-    Eigen::ArrayXd rho_;
-    Eigen::ArrayXd sigma_;
-
-    // angular temporal frequency   
-    Eigen::ArrayXd omega_k_;
-
-    /// \brief For testing
-    friend class LinearRandomFFTWaveSimFixture;
-  };
-}
-}
-
-#endif
+#endif  // GZ_WAVES_SRC_LINEARRANDOMFFTWAVESIMULATIONIMPL_HH_

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRef.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRef.cc
@@ -17,23 +17,25 @@
 // The time-dependent update step in ComputeCurrentAmplitudes is based
 // on the Curtis Mobley's IDL code cgAnimate_2D_SeaSurface.py
 
-//***************************************************************************************************
-//* This code is copyright (c) 2016 by Curtis D. Mobley.                                            *
-//* Permission is hereby given to reproduce and use this code for non-commercial academic research, *
-//* provided that the user suitably acknowledges Curtis D. Mobley in any presentations, reports,    *
-//* publications, or other works that make use of the code or its output.  Depending on the extent  *
-//* of use of the code or its outputs, suitable acknowledgement can range from a footnote to offer  *
-//* of coauthorship.  Further questions can be directed to curtis.mobley@sequoiasci.com.            *
-//***************************************************************************************************
+//*****************************************************************************
+//* This code is copyright (c) 2016 by Curtis D. Mobley.
+//* Permission is hereby given to reproduce and use this code for
+//* non-commercial academic research, provided that the user suitably
+//* acknowledges Curtis D. Mobley in any presentations, reports, publications,
+//* or other works that make use of the code or its output.  Depending on the
+//* extent of use of the code or its outputs, suitable acknowledgement can
+//* range from a footnote to offer of coauthorship.  Further questions can be
+//* directed to curtis.mobley@sequoiasci.com.
+//*****************************************************************************
 
 #include "LinearRandomFFTWaveSimulationRef.hh"
-
-#include <complex>
-#include <random>
 
 #include <Eigen/Dense>
 
 #include <fftw3.h>
+
+#include <complex>
+#include <random>
 
 #include <gz/common.hh>
 
@@ -71,7 +73,8 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
-  void LinearRandomFFTWaveSimulationRef::Impl::SetWindVelocity(double ux, double uy)
+  void LinearRandomFFTWaveSimulationRef::Impl::SetWindVelocity(
+      double ux, double uy)
   {
     // Update wind velocity and recompute base amplitudes.
     u10_ = sqrt(ux*ux + uy *uy);
@@ -164,11 +167,11 @@ namespace waves
     }
 
     // Guide to indexing conventions:  1. index, 2. math-order, 3. fft-order
-    // 
+    //
     // 1. [ 0,  1,  2,  3,  4,  5,  6,  7]
     // 2. [-4, -3, -2, -1,  0,  1,  2,  3]
     // 3.                 [ 0,  1,  2,  3, -4, -3, -2, -3]
-    // 
+    //
 
     // sample spacing [m]
     double  delta_x{lx_ / nx_};
@@ -240,9 +243,9 @@ namespace waves
     Eigen::ArrayXXd cap_psi_2s_math = Eigen::ArrayXXd::Zero(nx_, ny_);
 
     // calculate spectrum in math-order (not vectorised)
-    for (Index ikx = 0; ikx < nx_; ++ikx)
+    for (Index ikx=0; ikx < nx_; ++ikx)
     {
-      for (Index iky = 0; iky < ny_; ++iky)
+      for (Index iky=0; iky < ny_; ++iky)
       {
         double k = sqrt(kx_math_[ikx]*kx_math_[ikx]
             + ky_math_[iky]*ky_math_[iky]);
@@ -251,18 +254,14 @@ namespace waves
         if (std::abs(k) < 1.0E-8)
         {
           cap_psi_2s_math(ikx, iky) = 0.0;
-        }
-        else
-        {
+        } else {
           double cap_psi = 0.0;
           if (use_symmetric_spreading_fn_)
           {
             // standing waves - symmetric spreading function
             cap_psi = Impl::ECKVSpreadingFunction(
                 k, phi - phi10_, u10_, cap_omega_c_, gravity_);
-          }
-          else
-          {
+          } else {
             // travelling waves - asymmetric spreading function
             cap_psi = Impl::Cos2sSpreadingFunction(
                 s_param_, phi - phi10_, u10_, cap_omega_c_, gravity_);
@@ -296,10 +295,10 @@ namespace waves
 
     // convert to fft-order
     Eigen::ArrayXXd cap_psi_2s_fft = Eigen::ArrayXXd::Zero(nx_, ny_);
-    for (Index ikx = 0; ikx < nx_; ++ikx)
+    for (Index ikx=0; ikx < nx_; ++ikx)
     {
       Index ikx_fft = (ikx + nx_/2) % nx_;
-      for (Index iky = 0; iky < ny_; ++iky)
+      for (Index iky=0; iky < ny_; ++iky)
       {
         Index iky_fft = (iky + ny_/2) % ny_;
         cap_psi_2s_fft(ikx_fft, iky_fft) = cap_psi_2s_math(ikx, iky);
@@ -311,9 +310,9 @@ namespace waves
     double delta_kx = kx_f_;
     double delta_ky = ky_f_;
 
-    for (Index ikx = 0; ikx < nx_; ++ikx)
+    for (Index ikx=0; ikx < nx_; ++ikx)
     {
-      for (Index iky = 0; iky < ny_; ++iky)
+      for (Index iky=0; iky < ny_; ++iky)
       {
         cap_psi_2s_root_(ikx, iky) =
             cap_psi_norm * sqrt(cap_psi_2s_fft(ikx, iky) * delta_kx * delta_ky);
@@ -325,9 +324,9 @@ namespace waves
     std::default_random_engine generator(seed);
     std::normal_distribution<double> distribution(0.0, 1.0);
 
-    for (Index ikx = 0; ikx < nx_; ++ikx)
+    for (Index ikx=0; ikx < nx_; ++ikx)
     {
-      for (Index iky = 0; iky < ny_; ++iky)
+      for (Index iky=0; iky < ny_; ++iky)
       {
         rho_(ikx, iky) = distribution(generator);
         sigma_(ikx, iky) = distribution(generator);
@@ -339,7 +338,7 @@ namespace waves
     {
       double kx = kx_fft_[ikx];
       double kx2 = kx*kx;
-      for (Index iky = 0; iky < ny_; ++iky)
+      for (Index iky=0; iky < ny_; ++iky)
       {
         double ky = ky_fft_[iky];
         double ky2 = ky*ky;
@@ -361,9 +360,9 @@ namespace waves
     // time update
     Eigen::ArrayXXd cos_omega_k = Eigen::ArrayXXd::Zero(nx_, ny_);
     Eigen::ArrayXXd sin_omega_k = Eigen::ArrayXXd::Zero(nx_, ny_);
-    for (Index ikx = 0; ikx < nx_; ++ikx)
+    for (Index ikx=0; ikx < nx_; ++ikx)
     {
-      for (Index iky = 0; iky < ny_; ++iky)
+      for (Index iky=0; iky < ny_; ++iky)
       {
         cos_omega_k(ikx, iky) = cos(omega_k_(ikx, iky) * time);
         sin_omega_k(ikx, iky) = sin(omega_k_(ikx, iky) * time);
@@ -372,15 +371,23 @@ namespace waves
 
     // non-vectorised reference version
     Eigen::ArrayXXcd zhat = Eigen::ArrayXXcd::Zero(nx_, ny_);
-    for (Index ikx = 1; ikx < nx_; ++ikx)
+    for (Index ikx=1; ikx < nx_; ++ikx)
     {
-      for (Index iky = 1; iky < ny_; ++iky)
+      for (Index iky=1; iky < ny_; ++iky)
       {
         zhat(ikx, iky) = complex(
-            + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * cos_omega_k(ikx, iky)
-            + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * sin_omega_k(ikx, iky),
-            - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * sin_omega_k(ikx, iky)
-            + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky) ) * cos_omega_k(ikx, iky));
+            + (r(ikx, iky) * psi_root(ikx, iky)
+            + r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky))
+            * cos_omega_k(ikx, iky)
+            + (s(ikx, iky) * psi_root(ikx, iky)
+            + s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky))
+            * sin_omega_k(ikx, iky),
+            - (r(ikx, iky) * psi_root(ikx, iky)
+            - r(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky))
+            * sin_omega_k(ikx, iky)
+            + (s(ikx, iky) * psi_root(ikx, iky)
+            - s(nx_-ikx, ny_-iky) * psi_root(nx_-ikx, ny_-iky))
+            * cos_omega_k(ikx, iky));
       }
     }
 
@@ -388,10 +395,14 @@ namespace waves
     {
       Index ikx = 0;
       zhat(ikx, iky) = complex(
-          + ( r(ikx, iky) * psi_root(ikx, iky) + r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * cos_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) + s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * sin_omega_k(ikx, iky),
-          - ( r(ikx, iky) * psi_root(ikx, iky) - r(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * sin_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) - s(ikx, ny_-iky) * psi_root(ikx, ny_-iky) ) * cos_omega_k(ikx, iky));
+          + (r(ikx, iky) * psi_root(ikx, iky)
+          + r(ikx, ny_-iky) * psi_root(ikx, ny_-iky)) * cos_omega_k(ikx, iky)
+          + (s(ikx, iky) * psi_root(ikx, iky)
+          + s(ikx, ny_-iky) * psi_root(ikx, ny_-iky)) * sin_omega_k(ikx, iky),
+          - (r(ikx, iky) * psi_root(ikx, iky)
+          - r(ikx, ny_-iky) * psi_root(ikx, ny_-iky)) * sin_omega_k(ikx, iky)
+          + (s(ikx, iky) * psi_root(ikx, iky)
+          - s(ikx, ny_-iky) * psi_root(ikx, ny_-iky)) * cos_omega_k(ikx, iky));
       zhat(ikx, ny_-iky) = std::conj(zhat(ikx, iky));
     }
 
@@ -399,10 +410,14 @@ namespace waves
     {
       Index iky = 0;
       zhat(ikx, iky) = complex(
-          + ( r(ikx, iky) * psi_root(ikx, iky) + r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * cos_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) + s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * sin_omega_k(ikx, iky),
-          - ( r(ikx, iky) * psi_root(ikx, iky) - r(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * sin_omega_k(ikx, iky)
-          + ( s(ikx, iky) * psi_root(ikx, iky) - s(nx_-ikx, iky) * psi_root(nx_-ikx, iky) ) * cos_omega_k(ikx, iky));
+          + (r(ikx, iky) * psi_root(ikx, iky)
+          + r(nx_-ikx, iky) * psi_root(nx_-ikx, iky)) * cos_omega_k(ikx, iky)
+          + (s(ikx, iky) * psi_root(ikx, iky)
+          + s(nx_-ikx, iky) * psi_root(nx_-ikx, iky)) * sin_omega_k(ikx, iky),
+          - (r(ikx, iky) * psi_root(ikx, iky)
+          - r(nx_-ikx, iky) * psi_root(nx_-ikx, iky)) * sin_omega_k(ikx, iky)
+          + (s(ikx, iky) * psi_root(ikx, iky)
+          - s(nx_-ikx, iky) * psi_root(nx_-ikx, iky)) * cos_omega_k(ikx, iky));
       zhat(nx_-ikx, iky) = std::conj(zhat(ikx, iky));
     }
 
@@ -411,11 +426,11 @@ namespace waves
     // write into fft_h_, fft_h_ikx_, fft_h_iky_, etc.
     const complex iunit(0.0, 1.0);
     const complex czero(0.0, 0.0);
-    for (Index ikx = 0; ikx < nx_; ++ikx)
+    for (Index ikx=0; ikx < nx_; ++ikx)
     {
       double kx = kx_fft_[ikx];
       double kx2 = kx*kx;
-      for (Index iky = 0; iky < ny_; ++iky)
+      for (Index iky=0; iky < ny_; ++iky)
       {
         double ky = ky_fft_[iky];
         double ky2 = ky*ky;
@@ -433,7 +448,7 @@ namespace waves
         // height derivatives
         complex hikx = hi * kx;
         complex hiky = hi * ky;
-        
+
         // Nyquist terms for derivatives must be zero.
         // For an explanation see:
         // https://math.mit.edu/~stevenj/fft-deriv.pdf
@@ -453,9 +468,7 @@ namespace waves
           fft_h_kxkx_(ikx, iky) = czero;
           fft_h_kyky_(ikx, iky) = czero;
           fft_h_kxky_(ikx, iky) = czero;
-        }
-        else
-        {
+        } else {
           complex dx  = - hiok * kx;
           complex dy  = - hiok * ky;
           complex hkxkx = hok * kx2;
@@ -508,14 +521,14 @@ namespace waves
     ky_math_ = Eigen::ArrayXd::Zero(ny_);
 
     // wavenumbers in fft and math ordering
-    for(Index ikx = 0; ikx < nx_; ++ikx)
+    for (Index ikx = 0; ikx < nx_; ++ikx)
     {
       double kx = (ikx - nx_/2) * kx_f_;
       kx_math_(ikx) = kx;
       kx_fft_((ikx + nx_/2) % nx_) = kx;
     }
 
-    for(Index iky = 0; iky < ny_; ++iky)
+    for (Index iky = 0; iky < ny_; ++iky)
     {
       double ky = (iky - ny_/2) * ky_f_;
       ky_math_(iky) = ky;
@@ -608,27 +621,23 @@ namespace waves
     double km = 370.0;
     double cm = 0.23;
     // double am = 0.13 * u_star / cm;
-    
+
     double gamma = 1.7;
     if (cap_omega_c < 1.0)
     {
       gamma = 1.7;
-    }
-    else
-    {
+    } else {
       gamma = 1.7 + 6.0 * log10(cap_omega_c);
     }
 
     double sigma = 0.08 * (1.0 + 4.0 * pow(cap_omega_c, -3.0));
     double alpha_p = 0.006 * pow(cap_omega_c, 0.55);
 
-    double alpha_m; 
+    double alpha_m;
     if (u_star <= cm)
     {
       alpha_m = 0.01 * (1.0 + log(u_star / cm));
-    }
-    else
-    {
+    } else {
       alpha_m = 0.01 * (1.0 + 3.0 * log(u_star / cm));
     }
 
@@ -637,20 +646,22 @@ namespace waves
 
     double cp = sqrt(g / kp);
     double c  = sqrt((g / k) * (1.0 + pow(k / km, 2.0)));
-        
+
     double L_PM = exp(-1.25 * pow(kp / k, 2.0));
-    
-    double Gamma = exp(-1.0/(2.0 * pow(sigma, 2.0)) * pow(sqrt(k / kp) - 1.0, 2.0));
-    
+
+    double Gamma = exp(-1.0/(2.0 * pow(sigma, 2.0))
+        * pow(sqrt(k / kp) - 1.0, 2.0));
+
     double J_p = pow(gamma, Gamma);
-    
-    double F_p = L_PM * J_p * exp(-0.3162 * cap_omega_c * (sqrt(k / kp) - 1.0));
+
+    double F_p = L_PM * J_p * exp(-0.3162 * cap_omega_c
+        * (sqrt(k / kp) - 1.0));
 
     double F_m = L_PM * J_p * exp(-0.25 * pow(k / km - 1.0, 2.0));
 
     double B_l = 0.5 * alpha_p * (cp / c) * F_p;
     double B_h = 0.5 * alpha_m * (cm / c) * F_m;
-    
+
     double k3 = k * k * k;
     double S = (B_l + B_h) / k3;
 
@@ -679,7 +690,7 @@ namespace waves
     // gzmsg << "Bl:      " << B_l << "\n";
     // gzmsg << "Fm:      " << F_m << "\n";
     // gzmsg << "Bh:      " << B_h << "\n";
-    
+
     return S;
   }
 
@@ -819,5 +830,5 @@ namespace waves
     impl_->DisplacementAt(sx, sy);
     impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
   }
-}
-}
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRef.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRef.cc
@@ -37,6 +37,7 @@
 
 #include <gz/common.hh>
 
+#include "gz/waves/Types.hh"
 #include "LinearRandomFFTWaveSimulationRefImpl.hh"
 
 namespace gz
@@ -93,7 +94,7 @@ namespace waves
     fftw_execute(fft_plan0_);
 
     // change from row to column major storage
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     h = fft_out0_.reshaped<Eigen::ColMajor>(n2, 1).real();
   }
 
@@ -107,7 +108,7 @@ namespace waves
     fftw_execute(fft_plan2_);
 
     // change from row to column major storage
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     dhdy = fft_out1_.reshaped<Eigen::ColMajor>(n2, 1).real();
     dhdx = fft_out2_.reshaped<Eigen::ColMajor>(n2, 1).real();
   }
@@ -122,7 +123,7 @@ namespace waves
     fftw_execute(fft_plan4_);
 
     // change from row to column major storage
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     sy = fft_out3_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ * -1.0;
     sx = fft_out4_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ * -1.0;
   }
@@ -139,7 +140,7 @@ namespace waves
     fftw_execute(fft_plan7_);
 
     // change from row to column major storage
-    size_t n2 = nx_ * ny_;
+    Index n2 = nx_ * ny_;
     dsydy = fft_out5_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ * -1.0;
     dsxdx = fft_out6_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ * -1.0;
     dsxdy = fft_out7_.reshaped<Eigen::ColMajor>(n2, 1).real() * lambda_ *  1.0;
@@ -151,7 +152,7 @@ namespace waves
     InitFFTCoeffStorage();
     InitWaveNumbers();
 
-    // size_t n2 = nx_ * ny_;
+    // Index n2 = nx_ * ny_;
 
     // arrays for reference version
     if (cap_psi_2s_root_.size() == 0)

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRef.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRef.hh
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef GZ_WAVES_WAVESIMULATIONFFT_HH_
-#define GZ_WAVES_WAVESIMULATIONFFT_HH_
+#ifndef GZ_WAVES_SRC_LINEARRANDOMFFTWAVESIMULATIONREF_HH_
+#define GZ_WAVES_SRC_LINEARRANDOMFFTWAVESIMULATIONREF_HH_
 
 #include <memory>
 
@@ -26,60 +26,60 @@ namespace gz
 {
 namespace waves
 {
-  class LinearRandomFFTWaveSimulationRef :
-      public IWaveSimulation
-  {
-    public:
-      virtual ~LinearRandomFFTWaveSimulationRef();
+class LinearRandomFFTWaveSimulationRef :
+    public IWaveSimulation
+{
+ public:
+    virtual ~LinearRandomFFTWaveSimulationRef();
 
-      LinearRandomFFTWaveSimulationRef(double lx, double ly,
-          Index nx, Index ny);
+    LinearRandomFFTWaveSimulationRef(double lx, double ly,
+        Index nx, Index ny);
 
-      void SetLambda(double lambda);
+    void SetLambda(double lambda);
 
-      virtual void SetWindVelocity(double ux, double uy) override;
+    void SetWindVelocity(double ux, double uy) override;
 
-      virtual void SetTime(double value) override;
+    void SetTime(double value) override;
 
-      virtual Index SizeX() const override;
+    Index SizeX() const override;
 
-      virtual Index SizeY() const override;
+    Index SizeY() const override;
 
-      virtual Index SizeZ() const override;
+    Index SizeZ() const override;
 
-      virtual void ElevationAt(
-          Eigen::Ref<Eigen::ArrayXXd> h) override;
+    void ElevationAt(
+        Eigen::Ref<Eigen::ArrayXXd> h) override;
 
-      virtual void ElevationDerivAt(
-          Eigen::Ref<Eigen::ArrayXXd> dhdx,
-          Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+    void ElevationDerivAt(
+        Eigen::Ref<Eigen::ArrayXXd> dhdx,
+        Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
 
-      virtual void DisplacementAt(
-          Eigen::Ref<Eigen::ArrayXXd> sx,
-          Eigen::Ref<Eigen::ArrayXXd> sy) override;
+    void DisplacementAt(
+        Eigen::Ref<Eigen::ArrayXXd> sx,
+        Eigen::Ref<Eigen::ArrayXXd> sy) override;
 
-      virtual void DisplacementDerivAt(
-          Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-          Eigen::Ref<Eigen::ArrayXXd> dsydy,
-          Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+    void DisplacementDerivAt(
+        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+        Eigen::Ref<Eigen::ArrayXXd> dsydy,
+        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-      virtual void DisplacementAndDerivAt(
-          Eigen::Ref<Eigen::ArrayXXd> h,
-          Eigen::Ref<Eigen::ArrayXXd> sx,
-          Eigen::Ref<Eigen::ArrayXXd> sy,
-          Eigen::Ref<Eigen::ArrayXXd> dhdx,
-          Eigen::Ref<Eigen::ArrayXXd> dhdy,
-          Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-          Eigen::Ref<Eigen::ArrayXXd> dsydy,
-          Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+    void DisplacementAndDerivAt(
+        Eigen::Ref<Eigen::ArrayXXd> h,
+        Eigen::Ref<Eigen::ArrayXXd> sx,
+        Eigen::Ref<Eigen::ArrayXXd> sy,
+        Eigen::Ref<Eigen::ArrayXXd> dhdx,
+        Eigen::Ref<Eigen::ArrayXXd> dhdy,
+        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+        Eigen::Ref<Eigen::ArrayXXd> dsydy,
+        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
 
-    // public class declaration - for testing
-    class Impl;
+  // public class declaration - for testing
+  class Impl;
 
-    private:
-      std::unique_ptr<Impl> impl_;
-  };
-}
-}
+ private:
+    std::unique_ptr<Impl> impl_;
+};
+}  // namespace waves
+}  // namespace gz
 
-#endif
+#endif  // GZ_WAVES_SRC_LINEARRANDOMFFTWAVESIMULATIONREF_HH_

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRefImpl.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRefImpl.hh
@@ -13,14 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#ifndef GZ_WAVES_LINEARRANDOMFTWAVESIMULATION_REF_IMPL_HH_
-#define GZ_WAVES_LINEARRANDOMFTWAVESIMULATION_REF_IMPL_HH_
-
-#include <complex>
+#ifndef GZ_WAVES_SRC_LINEARRANDOMFFTWAVESIMULATIONREFIMPL_HH_
+#define GZ_WAVES_SRC_LINEARRANDOMFFTWAVESIMULATIONREFIMPL_HH_
 
 #include <Eigen/Dense>
 
 #include <fftw3.h>
+
+#include <complex>
 
 #include "gz/waves/WaveSimulation.hh"
 #include "LinearRandomFFTWaveSimulationRef.hh"
@@ -31,174 +31,176 @@ using Eigen::ArrayXcd;
 using Eigen::ArrayXd;
 
 namespace Eigen
-{ 
+{
   typedef Eigen::Array<
     std::complex<double>,
     Eigen::Dynamic,
     Eigen::Dynamic,
     Eigen::RowMajor
   > ArrayXXcdRowMajor;
-}
+}  // namespace Eigen
 
 namespace gz
 {
 namespace waves
 {
+//////////////////////////////////////////////////
+// LinearRandomFFTWaveSimulationRef::Impl
+
+typedef double fftw_data_type;
+typedef std::complex<fftw_data_type> complex;
+
+/// \brief Implementation of a FFT based wave simulation model
+///
+/// \note The FFT wave simulation mixes storage ordering which
+///       must be made consistent and should be column major
+///       which is the Eigen default..
+///
+class LinearRandomFFTWaveSimulationRef::Impl
+{
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /// \brief Destructor
+  ~Impl();
+
+  /// \brief Construct a wave simulation model
+  Impl(double lx, double ly, Index nx, Index ny);
+
+  /// \brief Set the components of the wind velocity (U10) in [m/s]
+  void SetWindVelocity(double ux, double uy);
+
+  /// \brief Set the current time in seconds
+  void SetTime(double value);
+
+  /// \brief Set the horizontal displacement scaling factor
+  void SetLambda(double value);
+
+  /// \brief Calculate the sea surface elevation
+  void ElevationAt(
+    Eigen::Ref<Eigen::ArrayXXd> h);
+
+  /// \brief Calculate the derivative of the elevation wrt x and y
+  void ElevationDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy);
+
+  /// \brief Calculate the sea surface horizontal displacements
+  void DisplacementAt(
+    Eigen::Ref<Eigen::ArrayXXd> sx,
+    Eigen::Ref<Eigen::ArrayXXd> sy);
+
+  /// \brief Calculate the derivative of the horizontal displacements
+  ///        wrt x and y
+  void DisplacementDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+    Eigen::Ref<Eigen::ArrayXXd> dsydy,
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy);
+
+  /// \brief Base amplitude calculation
+  void ComputeBaseAmplitudes();
+
+  /// \brief Time-dependent amplitude calculation
+  void ComputeCurrentAmplitudes(double time);
+
+  void InitFFTCoeffStorage();
+  void InitWaveNumbers();
+
+  void CreateFFTWPlans();
+  void DestroyFFTWPlans();
+
+  /// \note FFTW expects the multi-dimensional arrays to be in row-major
+  ///       format. Eigen::ArrayXXcd is column-major, so here we
+  ///       explicity set the storage type.
+  ///
+  /// https://www.fftw.org/fftw3_doc/Row_002dmajor-Format.html
+  ///
+  Eigen::ArrayXXcdRowMajor fft_h_;       // FFT0 - height
+  Eigen::ArrayXXcdRowMajor fft_h_ikx_;   // FFT1 - d height / dx
+  Eigen::ArrayXXcdRowMajor fft_h_iky_;   // FFT1 - d height / dy
+  Eigen::ArrayXXcdRowMajor fft_sx_;      // FFT3 - displacement x
+  Eigen::ArrayXXcdRowMajor fft_sy_;      // FFT4 - displacement y
+  Eigen::ArrayXXcdRowMajor fft_h_kxkx_;  // FFT5 - d displacement x / dx
+  Eigen::ArrayXXcdRowMajor fft_h_kyky_;  // FFT6 - d displacement y / dy
+  Eigen::ArrayXXcdRowMajor fft_h_kxky_;  // FFT7 - d displacement x / dy
+
+  Eigen::ArrayXXcdRowMajor fft_out0_;
+  Eigen::ArrayXXcdRowMajor fft_out1_;
+  Eigen::ArrayXXcdRowMajor fft_out2_;
+  Eigen::ArrayXXcdRowMajor fft_out3_;
+  Eigen::ArrayXXcdRowMajor fft_out4_;
+  Eigen::ArrayXXcdRowMajor fft_out5_;
+  Eigen::ArrayXXcdRowMajor fft_out6_;
+  Eigen::ArrayXXcdRowMajor fft_out7_;
+
+  fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
+  fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
+
+  /// \brief Gravity acceleration [m/s^2]
+  double gravity_{9.81};
+
+  /// \brief Horizontal displacement scaling factor. Zero for no displacement
+  double lambda_{0.0};
+
+  // grid parameters
+  double  lx_{1.0};
+  double  ly_{1.0};
+  Index   nx_{2};
+  Index   ny_{2};
+
+  /// \brief Wind speed at 10m above mean sea level [m]
+  double  u10_{5.0};
+
+  /// \brief Direction of u10. Counter clockwise angle from x-axis [rad]
+  double  phi10_{0.0};
+
+  /// \brief Spreading parameter for the cosine-2S model
+  double  s_param_{5.0};
+
+  /// \brief Parameter controlling the maturity of the sea state.
+  double  cap_omega_c_{0.84};
+
+  // fundamental angular spatial frequency [rad/m]
+  double  kx_f_{2.0 * M_PI / lx_};
+  double  ky_f_{2.0 * M_PI / ly_};
+
+  // angular spatial frequencies in fft and math order
+  Eigen::ArrayXd kx_fft_;
+  Eigen::ArrayXd ky_fft_;
+  Eigen::ArrayXd kx_math_;
+  Eigen::ArrayXd ky_math_;
+
+  /// \brief Set to 1 to use a symmetric spreading function (standing waves).
+  bool use_symmetric_spreading_fn_{false};
+
   //////////////////////////////////////////////////
-  // LinearRandomFFTWaveSimulationRef::Impl
+  /// \note: use 2d array storage for reference version, resized if required
 
-  typedef double fftw_data_type;
-  typedef std::complex<fftw_data_type> complex;
+  // square-root of two-sided discrete elevation variance spectrum
+  Eigen::ArrayXXd cap_psi_2s_root_;
 
-  /// \brief Implementation of a FFT based wave simulation model
-  ///
-  /// \note The FFT wave simulation mixes storage ordering which
-  ///       must be made consistent and should be column major
-  ///       which is the Eigen default..
-  ///
-  class LinearRandomFFTWaveSimulationRef::Impl
-  {
-  public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    
-    /// \brief Destructor 
-    ~Impl();
+  // iid random normals for real and imaginary parts of the amplitudes
+  Eigen::ArrayXXd rho_;
+  Eigen::ArrayXXd sigma_;
 
-    /// \brief Construct a wave simulation model
-    Impl(double lx, double ly, Index nx, Index ny);
+  // angular temporal frequency
+  Eigen::ArrayXXd omega_k_;
 
-    /// \brief Set the components of the wind velocity (U10) in [m/s]
-    void SetWindVelocity(double ux, double uy);
+  static double ECKVOmniDirectionalSpectrum(
+      double k, double u10, double cap_omega_c = 0.84,
+      double gravity = 9.81);
+  static double ECKVSpreadingFunction(
+      double k, double phi, double u10, double cap_omega_c = 0.84,
+      double gravity = 9.81);
+  static double Cos2sSpreadingFunction(
+      double s_param, double phi, double u10, double cap_omega_c = 0.84,
+      double gravity = 9.81);
 
-    /// \brief Set the current time in seconds
-    void SetTime(double value);
+  /// \brief For testing
+  friend class LinearRandomFFTWaveSimFixture;
+};
 
-    /// \brief Set the horizontal displacement scaling factor
-    void SetLambda(double value);
+}  // namespace waves
+}  // namespace gz
 
-    /// \brief Calculate the sea surface elevation
-    void ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h);
-
-    /// \brief Calculate the derivative of the elevation wrt x and y
-    void ElevationDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy);
-
-    /// \brief Calculate the sea surface horizontal displacements
-    void DisplacementAt(
-      Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy);
-
-    /// \brief Calculate the derivative of the horizontal displacements wrt x and y
-    void DisplacementDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-      Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy);
-
-    /// \brief Base amplitude calculation
-    void ComputeBaseAmplitudes();
-
-    /// \brief Time-dependent amplitude calculation
-    void ComputeCurrentAmplitudes(double time);
-
-    void InitFFTCoeffStorage();
-    void InitWaveNumbers();
-
-    void CreateFFTWPlans();
-    void DestroyFFTWPlans();
-
-    /// \note FFTW expects the multi-dimensional arrays to be in row-major
-    ///       format. Eigen::ArrayXXcd is column-major, so here we
-    ///       explicity set the storage type.
-    ///
-    /// https://www.fftw.org/fftw3_doc/Row_002dmajor-Format.html 
-    ///
-    Eigen::ArrayXXcdRowMajor fft_h_;       // FFT0 - height
-    Eigen::ArrayXXcdRowMajor fft_h_ikx_;   // FFT1 - d height / dx
-    Eigen::ArrayXXcdRowMajor fft_h_iky_;   // FFT1 - d height / dy
-    Eigen::ArrayXXcdRowMajor fft_sx_;      // FFT3 - displacement x
-    Eigen::ArrayXXcdRowMajor fft_sy_;      // FFT4 - displacement y
-    Eigen::ArrayXXcdRowMajor fft_h_kxkx_;  // FFT5 - d displacement x / dx
-    Eigen::ArrayXXcdRowMajor fft_h_kyky_;  // FFT6 - d displacement y / dy
-    Eigen::ArrayXXcdRowMajor fft_h_kxky_;  // FFT7 - d displacement x / dy
-
-    Eigen::ArrayXXcdRowMajor fft_out0_;
-    Eigen::ArrayXXcdRowMajor fft_out1_;
-    Eigen::ArrayXXcdRowMajor fft_out2_;
-    Eigen::ArrayXXcdRowMajor fft_out3_;
-    Eigen::ArrayXXcdRowMajor fft_out4_;
-    Eigen::ArrayXXcdRowMajor fft_out5_;
-    Eigen::ArrayXXcdRowMajor fft_out6_;
-    Eigen::ArrayXXcdRowMajor fft_out7_;
-
-    fftw_plan fft_plan0_, fft_plan1_, fft_plan2_, fft_plan3_;
-    fftw_plan fft_plan4_, fft_plan5_, fft_plan6_, fft_plan7_;
-
-    /// \brief Gravity acceleration [m/s^2]
-    double gravity_{9.81};
-
-    /// \brief Horizontal displacement scaling factor. Zero for no displacement
-    double lambda_{0.0};
-
-    // grid parameters
-    double  lx_{1.0};
-    double  ly_{1.0};
-    Index   nx_{2};
-    Index   ny_{2};
-
-    /// \brief Wind speed at 10m above mean sea level [m]
-    double  u10_{5.0};
-
-    /// \brief Direction of u10. Counter clockwise angle from x-axis [rad]
-    double  phi10_{0.0};
-
-    /// \brief Spreading parameter for the cosine-2S model
-    double  s_param_{5.0};
-
-    /// \brief Parameter controlling the maturity of the sea state.
-    double  cap_omega_c_{0.84};
-
-    // fundamental angular spatial frequency [rad/m]
-    double  kx_f_{2.0 * M_PI / lx_};
-    double  ky_f_{2.0 * M_PI / ly_};
-
-    // angular spatial frequencies in fft and math order
-    Eigen::ArrayXd kx_fft_;
-    Eigen::ArrayXd ky_fft_;
-    Eigen::ArrayXd kx_math_;
-    Eigen::ArrayXd ky_math_;
-
-    /// \brief Set to 1 to use a symmetric spreading function (standing waves).
-    bool use_symmetric_spreading_fn_{false};
-
-    //////////////////////////////////////////////////
-    /// \note: use 2d array storage for reference version, resized if required
-
-    // square-root of two-sided discrete elevation variance spectrum
-    Eigen::ArrayXXd cap_psi_2s_root_;
-
-    // iid random normals for real and imaginary parts of the amplitudes
-    Eigen::ArrayXXd rho_;
-    Eigen::ArrayXXd sigma_;
-
-    // angular temporal frequency
-    Eigen::ArrayXXd omega_k_;
-
-    static double ECKVOmniDirectionalSpectrum(
-        double k, double u10, double cap_omega_c=0.84,
-        double gravity=9.81);
-    static double ECKVSpreadingFunction(
-        double k, double phi, double u10, double cap_omega_c=0.84,
-        double gravity=9.81);
-    static double Cos2sSpreadingFunction(
-        double s_param, double phi, double u10, double cap_omega_c=0.84,
-        double gravity=9.81);
-
-    /// \brief For testing
-    friend class LinearRandomFFTWaveSimFixture;
-  };
-}
-}
-
-#endif
+#endif  // GZ_WAVES_SRC_LINEARRANDOMFFTWAVESIMULATIONREFIMPL_HH_

--- a/gz-waves/src/LinearRandomFFTWaveSimulation_TEST.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulation_TEST.cc
@@ -13,53 +13,36 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "gz/waves/LinearRandomFFTWaveSimulation.hh"
-
-#include "LinearRandomFFTWaveSimulationImpl.hh"
-#include "LinearRandomFFTWaveSimulationRefImpl.hh"
-
 #include <gtest/gtest.h>
 
 #include <Eigen/Dense>
 
+#include <complex>
 #include <iostream>
 #include <memory>
 #include <string>
 
+#include "gz/waves/LinearRandomFFTWaveSimulation.hh"
+#include "LinearRandomFFTWaveSimulationImpl.hh"
+#include "LinearRandomFFTWaveSimulationRefImpl.hh"
+
 using Eigen::ArrayXXd;
 
-using namespace gz;
-using namespace waves;
+using gz::waves::Index;
+using gz::waves::LinearRandomFFTWaveSimulation;
+using gz::waves::LinearRandomFFTWaveSimulationRef;
 
 #define DISABLE_FOR_REAL_DFT 1
 
 //////////////////////////////////////////////////
 // Define fixture
 class LinearRandomFFTWaveSimFixture: public ::testing::Test
-{ 
-public: 
-  virtual ~LinearRandomFFTWaveSimFixture()
-  {
-    // cleanup any pending stuff, but no exceptions allowed
-  }
+{
+ public:
+  virtual ~LinearRandomFFTWaveSimFixture() = default;
+  LinearRandomFFTWaveSimFixture() = default;
 
-  LinearRandomFFTWaveSimFixture()
-  {
-    // initialization code here
-  } 
-
-  virtual void SetUp() override
-  { 
-    // code here will execute just before the test ensues 
-  }
-
-  virtual void TearDown() override
-  {
-    // code here will be called just after the test completes
-    // ok to through exceptions from here if need be
-  }
-
-  // put in any custom data members that you need 
+  // put in any custom data members that you need
   double lx_ = 200.0;
   double ly_ = 100.0;
   Index  nx_ = 16;
@@ -85,12 +68,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, AngularSpatialWavenumber)
   };
 
   // check kx fft-ordering
-  for (Index i=0; i<nx_; ++i)
+  for (Index i=0; i < nx_; ++i)
   {
     EXPECT_DOUBLE_EQ(model.kx_fft_[i] / model.kx_f_, ikx_fft[i]);
   }
   // check ky fft-ordering
-  for (Index i=0; i<ny_; ++i)
+  for (Index i=0; i < ny_; ++i)
   {
     EXPECT_DOUBLE_EQ(model.ky_fft_[i] / model.ky_f_, iky_fft[i]);
   }
@@ -104,9 +87,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianHTimeZeroReference)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (Index ikx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky)
+    for (Index iky=0; iky < ny_; ++iky)
     {
       // index for conjugate
       Index ckx = 0;
@@ -118,12 +101,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianHTimeZeroReference)
         cky = ny_ - iky;
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_(ikx, iky);
-      complex hc = model.fft_h_(ckx, cky);
+      std::complex h  = model.fft_h_(ikx, iky);
+      std::complex hc = model.fft_h_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -137,9 +120,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDhDxTimeZeroReference)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (Index ikx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky)
+    for (Index iky=0; iky < ny_; ++iky)
     {
       // index for conjugate
       Index ckx = 0;
@@ -151,12 +134,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDhDxTimeZeroReference)
         cky = ny_ - iky;
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_ikx_(ikx, iky);
-      complex hc = model.fft_h_ikx_(ckx, cky);
+      std::complex h  = model.fft_h_ikx_(ikx, iky);
+      std::complex hc = model.fft_h_ikx_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -170,9 +153,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDhDyTimeZeroReference)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (Index ikx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky)
+    for (Index iky=0; iky < ny_; ++iky)
     {
       // index for conjugate
       Index ckx = 0;
@@ -184,12 +167,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDhDyTimeZeroReference)
         cky = ny_ - iky;
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_iky_(ikx, iky);
-      complex hc = model.fft_h_iky_(ckx, cky);
+      std::complex h  = model.fft_h_iky_(ikx, iky);
+      std::complex hc = model.fft_h_iky_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -203,9 +186,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianSxTimeZeroReference)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (Index ikx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky)
+    for (Index iky=0; iky < ny_; ++iky)
     {
       // index for conjugate
       Index ckx = 0;
@@ -217,12 +200,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianSxTimeZeroReference)
         cky = ny_ - iky;
 
       // look up amplitude and conjugate
-      complex h  = model.fft_sx_(ikx, iky);
-      complex hc = model.fft_sx_(ckx, cky);
+      std::complex h  = model.fft_sx_(ikx, iky);
+      std::complex hc = model.fft_sx_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -236,9 +219,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianSyTimeZeroReference)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (Index ikx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky)
+    for (Index iky=0; iky < ny_; ++iky)
     {
       // index for conjugate
       Index ckx = 0;
@@ -250,12 +233,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianSyTimeZeroReference)
         cky = ny_ - iky;
 
       // look up amplitude and conjugate
-      complex h  = model.fft_sy_(ikx, iky);
-      complex hc = model.fft_sy_(ckx, cky);
+      std::complex h  = model.fft_sy_(ikx, iky);
+      std::complex hc = model.fft_sy_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -269,9 +252,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDsxDxTimeZeroReference)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (Index ikx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky)
+    for (Index iky=0; iky < ny_; ++iky)
     {
       // index for conjugate
       Index ckx = 0;
@@ -283,12 +266,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDsxDxTimeZeroReference)
         cky = ny_ - iky;
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_kxkx_(ikx, iky);
-      complex hc = model.fft_h_kxkx_(ckx, cky);
+      std::complex h  = model.fft_h_kxkx_(ikx, iky);
+      std::complex hc = model.fft_h_kxkx_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -302,9 +285,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDsyDyTimeZeroReference)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (Index ikx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky)
+    for (Index iky=0; iky < ny_; ++iky)
     {
       // index for conjugate
       Index ckx = 0;
@@ -316,12 +299,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDsyDyTimeZeroReference)
         cky = ny_ - iky;
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_kyky_(ikx, iky);
-      complex hc = model.fft_h_kyky_(ckx, cky);
+      std::complex h  = model.fft_h_kyky_(ikx, iky);
+      std::complex hc = model.fft_h_kyky_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -335,9 +318,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDsxDyTimeZeroReference)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (Index ikx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky)
+    for (Index iky=0; iky < ny_; ++iky)
     {
       // index for conjugate
       Index ckx = 0;
@@ -349,12 +332,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianDsxDyTimeZeroReference)
         cky = ny_ - iky;
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_kxky_(ikx, iky);
-      complex hc = model.fft_h_kxky_(ckx, cky);
+      std::complex h  = model.fft_h_kxky_(ikx, iky);
+      std::complex hc = model.fft_h_kxky_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -368,9 +351,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianTimeNonZeroReference)
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(11.2);
 
-  for (Index ikx=0, idx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0, idx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky, ++idx)
+    for (Index iky=0; iky < ny_; ++iky, ++idx)
     {
       // index for conjugate
       // Index cdx = 0;
@@ -388,12 +371,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianTimeNonZeroReference)
       }
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_(ikx, iky);
-      complex hc = model.fft_h_(ckx, cky);
+      std::complex h  = model.fft_h_(ikx, iky);
+      std::complex hc = model.fft_h_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -416,9 +399,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, ParsevalsIdentityTimeZeroReference)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (Index ikx=0, idx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0, idx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky, ++idx)
+    for (Index iky=0; iky < ny_; ++iky, ++idx)
     {
       sum_z2 += z(idx, 0) * z(idx, 0);
       sum_h2 += norm(model.fft_h_(ikx, iky));
@@ -443,9 +426,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, ParsevalsIdentityTimeNonZeroReference)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (Index ikx=0, idx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0, idx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky, ++idx)
+    for (Index iky=0; iky < ny_; ++iky, ++idx)
     {
       sum_z2 += z(idx, 0) * z(idx, 0);
       sum_h2 += norm(model.fft_h_(ikx, iky));
@@ -456,7 +439,8 @@ TEST_F(LinearRandomFFTWaveSimFixture, ParsevalsIdentityTimeNonZeroReference)
 }
 
 //////////////////////////////////////////////////
-TEST_F(LinearRandomFFTWaveSimFixture, HorizontalDisplacementsLambdaZeroReference)
+TEST_F(LinearRandomFFTWaveSimFixture,
+    HorizontalDisplacementsLambdaZeroReference)
 {
   Index n2 = nx_ * ny_;
 
@@ -474,7 +458,7 @@ TEST_F(LinearRandomFFTWaveSimFixture, HorizontalDisplacementsLambdaZeroReference
   EXPECT_EQ(sx.size(), n2);
   EXPECT_EQ(sy.size(), n2);
 
-  for (Index i=0; i<n2; ++i)
+  for (Index i=0; i < n2; ++i)
   {
     EXPECT_DOUBLE_EQ(sx(i, 0), 0.0);
     EXPECT_DOUBLE_EQ(sy(i, 0), 0.0);
@@ -484,16 +468,16 @@ TEST_F(LinearRandomFFTWaveSimFixture, HorizontalDisplacementsLambdaZeroReference
 //////////////////////////////////////////////////
 // Optimised version checks
 #if !DISABLE_FOR_REAL_DFT
-/// \note test disabled - optimised version does not store HC 
+/// \note test disabled - optimised version does not store HC
 TEST_F(LinearRandomFFTWaveSimFixture, HermitianTimeZero)
 {
   LinearRandomFFTWaveSimulation::Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(0.0);
 
-  for (Index ikx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky)
+    for (Index iky=0; iky < ny_; ++iky)
     {
       // index for conjugate
       Index ckx = 0;
@@ -508,12 +492,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianTimeZero)
       }
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_(ikx, iky);
-      complex hc = model.fft_h_(ckx, cky);
+      std::complex h  = model.fft_h_(ikx, iky);
+      std::complex hc = model.fft_h_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -523,16 +507,16 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianTimeZero)
 
 //////////////////////////////////////////////////
 #if !DISABLE_FOR_REAL_DFT
-/// \note test disabled - optimised version does not store HC 
+/// \note test disabled - optimised version does not store HC
 TEST_F(LinearRandomFFTWaveSimFixture, HermitianTimeNonZero)
 {
   LinearRandomFFTWaveSimulation::Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
   model.ComputeCurrentAmplitudes(11.2);
 
-  for (Index ikx=0, idx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0, idx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky, ++idx)
+    for (Index iky=0; iky < ny_; ++iky, ++idx)
     {
       // index for conjugate
       Index cdx = 0;
@@ -550,12 +534,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, HermitianTimeNonZero)
       }
 
       // look up amplitude and conjugate
-      complex h  = model.fft_h_(ikx, iky);
-      complex hc = model.fft_h_(ckx, cky);
+      std::complex h  = model.fft_h_(ikx, iky);
+      std::complex hc = model.fft_h_(ckx, cky);
 
       // real part symmetric
       EXPECT_DOUBLE_EQ(h.real(), hc.real());
-      
+
       // imaginary part anti-symmetric
       EXPECT_DOUBLE_EQ(h.imag(), -1.0 * hc.imag());
     }
@@ -580,9 +564,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, ParsevalsIdentityTimeZero)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (Index ikx=0, idx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0, idx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky, ++idx)
+    for (Index iky=0; iky < ny_; ++iky, ++idx)
     {
       sum_z2 += z(idx, 0) * z(idx, 0);
       sum_h2 += norm(model.fft_h_(ikx, iky));
@@ -610,9 +594,9 @@ TEST_F(LinearRandomFFTWaveSimFixture, ParsevalsIdentityTimeNonZero)
 
   double sum_z2 = 0.0;
   double sum_h2 = 0.0;
-  for (Index ikx=0, idx=0; ikx<nx_; ++ikx)
+  for (Index ikx=0, idx=0; ikx < nx_; ++ikx)
   {
-    for (Index iky=0; iky<ny_; ++iky, ++idx)
+    for (Index iky=0; iky < ny_; ++iky, ++idx)
     {
       sum_z2 += z(idx, 0) * z(idx, 0);
       sum_h2 += norm(model.fft_h_(ikx, iky));
@@ -642,7 +626,7 @@ TEST_F(LinearRandomFFTWaveSimFixture, HorizontalDisplacementsLambdaZero)
   EXPECT_EQ(sx.size(), n2);
   EXPECT_EQ(sy.size(), n2);
 
-  for (Index i=0; i<n2; ++i)
+  for (Index i=0; i < n2; ++i)
   {
     EXPECT_DOUBLE_EQ(sx(i, 0), 0.0);
     EXPECT_DOUBLE_EQ(sy(i, 0), 0.0);
@@ -650,7 +634,7 @@ TEST_F(LinearRandomFFTWaveSimFixture, HorizontalDisplacementsLambdaZero)
 }
 
 //////////////////////////////////////////////////
-// Cross-check optimised version against reference 
+// Cross-check optimised version against reference
 TEST_F(LinearRandomFFTWaveSimFixture, ElevationTimeZero)
 {
   Index n2 = nx_ * ny_;
@@ -672,7 +656,7 @@ TEST_F(LinearRandomFFTWaveSimFixture, ElevationTimeZero)
   EXPECT_EQ(ref_z.size(), n2);
   EXPECT_EQ(z.size(), n2);
 
-  for (Index i=0; i<n2; ++i)
+  for (Index i=0; i < n2; ++i)
   {
     EXPECT_NEAR(z(i, 0), ref_z(i, 0), 1.0E-15);
   }
@@ -700,7 +684,7 @@ TEST_F(LinearRandomFFTWaveSimFixture, ElevationTimeNonZero)
   EXPECT_EQ(ref_z.size(), n2);
   EXPECT_EQ(z.size(), n2);
 
-  for (Index i=0; i<n2; ++i)
+  for (Index i=0; i < n2; ++i)
   {
     EXPECT_NEAR(z(i, 0), ref_z(i, 0), 1.0E-15);
   }
@@ -732,7 +716,7 @@ TEST_F(LinearRandomFFTWaveSimFixture, Displacement)
   EXPECT_EQ(sx.size(), n2);
   EXPECT_EQ(sy.size(), n2);
 
-  for (Index i=0; i<n2; ++i)
+  for (Index i=0; i < n2; ++i)
   {
     EXPECT_NEAR(sx(i, 0), ref_sx(i, 0), 1.0E-15);
     EXPECT_NEAR(sy(i, 0), ref_sy(i, 0), 1.0E-15);
@@ -765,7 +749,7 @@ TEST_F(LinearRandomFFTWaveSimFixture, ElevationDerivatives)
   EXPECT_EQ(dhdx.size(), n2);
   EXPECT_EQ(dhdy.size(), n2);
 
-  for (Index i=0; i<n2; ++i)
+  for (Index i=0; i < n2; ++i)
   {
     EXPECT_DOUBLE_EQ(dhdx(i, 0), ref_dhdx(i, 0));
     EXPECT_DOUBLE_EQ(dhdy(i, 0), ref_dhdy(i, 0));
@@ -802,7 +786,7 @@ TEST_F(LinearRandomFFTWaveSimFixture, DisplacementDerivatives)
   EXPECT_EQ(dsydy.size(), n2);
   EXPECT_EQ(dsxdy.size(), n2);
 
-  for (Index i=0; i<n2; ++i)
+  for (Index i=0; i < n2; ++i)
   {
     EXPECT_DOUBLE_EQ(dsxdx(i, 0), ref_dsxdx(i, 0));
     EXPECT_DOUBLE_EQ(dsydy(i, 0), ref_dsydy(i, 0));
@@ -819,7 +803,7 @@ TEST_F(LinearRandomFFTWaveSimFixture, Indexing)
 
   // column major storage
   std::vector<std::vector<double>> a1(nyy, std::vector<double>(nxx, 0.0));
-  
+
   for (Index iky = 0, idx = 0; iky < nyy; ++iky)
   {
     for (Index ikx = 0; ikx < nxx; ++ikx, ++idx)
@@ -829,12 +813,12 @@ TEST_F(LinearRandomFFTWaveSimFixture, Indexing)
   }
 
   // column major storage - fastest index over rows
-  // 
-  //  M = 0   4   8 
+  //
+  //  M = 0   4   8
   //      1   5   9
   //      2   6  10
   //      3   7  11
-  // 
+  //
   std::vector<std::vector<double>> a2 = {
     { 0, 1, 2, 3},
     { 4, 5, 6, 7},
@@ -862,7 +846,6 @@ TEST_F(LinearRandomFFTWaveSimFixture, Indexing)
       EXPECT_EQ(a3[idx], a2[iky][ikx]);
     }
   }
-
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -16,10 +16,10 @@
 
 #include "gz/waves/LinearRandomWaveSimulation.hh"
 
+#include <Eigen/Dense>
+
 #include <random>
 #include <vector>
-
-#include <Eigen/Dense>
 
 #include <gz/common.hh>
 
@@ -30,599 +30,599 @@ namespace gz
 {
 namespace waves
 {
-  //////////////////////////////////////////////////
-  class LinearRandomWaveSimulation::Impl
+//////////////////////////////////////////////////
+class LinearRandomWaveSimulation::Impl
+{
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  ~Impl();
+
+  Impl(double lx, double ly, Index nx, Index ny);
+
+  Impl(double lx, double ly, double lz, Index nx, Index ny, Index nz);
+
+  void SetTime(double value);
+
+  // interpolation interface
+  void Elevation(
+      double x, double y,
+      double& eta);
+
+  void ElevationDeriv(
+      double x, double y,
+      double& deta_dx, double& deta_dy);
+
+  void Elevation(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      Eigen::Ref<Eigen::ArrayXd> eta);
+
+  void Pressure(
+      double x, double y, double z,
+      double& pressure);
+
+  void Pressure(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      const Eigen::Ref<const Eigen::ArrayXd>& z,
+      Eigen::Ref<Eigen::ArrayXd> pressure);
+
+  // lookup interface - scalar
+  void ElevationAt(
+      Index ix, Index iy,
+      double& h);
+
+  void ElevationDerivAt(
+      Index ix, Index iy,
+      double& dhdx, double& dhdy);
+
+  void PressureAt(
+      Index ix, Index iy, Index iz,
+      double& pressure);
+
+  // lookup interface - array
+  void ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h);
+
+  void ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy);
+
+  void PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure);
+
+  void InitGrid();
+
+  void ComputeAmplitudes();
+
+  // elevation and pressure grid params
+  Index nx_{2};
+  Index ny_{2};
+  Index nz_{1};
+  double lx_{1.0};
+  double ly_{1.0};
+  double lz_{0.0};
+
+  // simulation parameters
+  double gravity_{9.81};
+  double fluid_rho_{1025.0};
+
+  // parameters
+  Index num_waves_{100};
+  double max_w_{6.0};
+  double u19_{5.0};
+  double wave_angle_{0.0};
+
+  bool needs_update_{true};
+
+  Eigen::ArrayXd spectrum_;
+  Eigen::ArrayXd amplitude_;
+  Eigen::ArrayXd w_;
+  Eigen::ArrayXd k_;
+  Eigen::ArrayXd phase_;
+
+  // update
+  double time_{0.0};
+
+  // derived
+  double dx_{0.0};
+  double dy_{0.0};
+  double lx_max_{0.0};
+  double lx_min_{0.0};
+  double ly_max_{0.0};
+  double ly_min_{0.0};
+
+  // pressure sample points
+  Eigen::ArrayXd z_;
+};
+
+//////////////////////////////////////////////////
+LinearRandomWaveSimulation::Impl::~Impl() = default;
+
+//////////////////////////////////////////////////
+LinearRandomWaveSimulation::Impl::Impl(
+  double lx, double ly, Index nx, Index ny) :
+  lx_(lx),
+  ly_(ly),
+  nx_(nx),
+  ny_(ny)
+{
+  InitGrid();
+}
+
+//////////////////////////////////////////////////
+LinearRandomWaveSimulation::Impl::Impl(
+  double lx, double ly, double lz, Index nx, Index ny, Index nz) :
+  lx_(lx),
+  ly_(ly),
+  lz_(lz),
+  nx_(nx),
+  ny_(ny),
+  nz_(nz)
+{
+  InitGrid();
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::SetTime(double value)
+{
+  time_ = value;
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::Elevation(
+    double x, double y,
+    double& eta)
+{
+  ComputeAmplitudes();
+
+  double cd = std::cos(wave_angle_);
+  double sd = std::sin(wave_angle_);
+  double xd = x * cd + y * sd;
+
+  double h = 0;
+  for (Index ik = 0; ik < num_waves_; ++ik)
   {
-  public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    double wt = w_(ik) * time_;
+    double a  = k_(ik) * xd - wt + phase_(ik);
+    double ca = std::cos(a);
+    h += amplitude_(ik) * ca;
+  }
+  eta = h;
+}
 
-    ~Impl();
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::ElevationDeriv(
+    double x, double y,
+    double& deta_dx, double& deta_dy)
+{
+  ComputeAmplitudes();
 
-    Impl(double lx, double ly, Index nx, Index ny);
+  double cd = std::cos(wave_angle_);
+  double sd = std::sin(wave_angle_);
+  double xd  = x * cd + y * sd;
 
-    Impl(double lx, double ly, double lz, Index nx, Index ny, Index nz);
+  double dhdx = 0;
+  double dhdy = 0;
+  for (Index ik = 0; ik < num_waves_; ++ik)
+  {
+    double wt = w_(ik) * time_;
+    double a  = k_(ik) * xd - wt + phase_(ik);
+    double sa = std::sin(a);
+    double dadx = k_(ik) * cd;
+    double dady = k_(ik) * sd;
 
-    void SetTime(double value);
+    dhdx += - dadx * amplitude_(ik) * sa;
+    dhdy += - dady * amplitude_(ik) * sa;
+  }
+  deta_dx = dhdx;
+  deta_dy = dhdx;
+}
 
-    // interpolation interface
-    void Elevation(
-        double x, double y,
-        double &eta);
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::Elevation(
+    const Eigen::Ref<const Eigen::ArrayXd>& x,
+    const Eigen::Ref<const Eigen::ArrayXd>& y,
+    Eigen::Ref<Eigen::ArrayXd> eta)
+{
+  auto xit = x.cbegin();
+  auto yit = y.cbegin();
+  auto eit = eta.begin();
+  for ( ; xit != x.cend() && yit != y.cend() && eit != eta.end();
+    ++xit, ++yit, ++eit)
+  {
+    Elevation(*xit, *yit, *eit);
+  }
+}
 
-    void ElevationDeriv(
-        double x, double y,
-        double &deta_dx, double &deta_dy);
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::Pressure(
+    double x, double y, double z,
+    double& pressure)
+{
+  ComputeAmplitudes();
 
-    void Elevation(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        Eigen::Ref<Eigen::ArrayXd> eta);
+  double cd = std::cos(wave_angle_);
+  double sd = std::sin(wave_angle_);
+  double xd = x * cd + y * sd;
 
-    void Pressure(
-        double x, double y, double z,
-        double &pressure);
+  double p = 0;
+  for (Index ik = 0; ik < num_waves_; ++ik)
+  {
+    double wt = w_(ik) * time_;
+    double a  = k_(ik) * xd - wt + phase_(ik);
+    double ca = std::cos(a);
+    double h1 = amplitude_(ik) * ca;
+    double e  = std::exp(k_(ik) * z);
+    p += e * h1;
+  }
+  pressure = p;
+}
 
-    void Pressure(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        const Eigen::Ref<const Eigen::ArrayXd> &z,
-        Eigen::Ref<Eigen::ArrayXd> pressure);
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::Pressure(
+    const Eigen::Ref<const Eigen::ArrayXd>& x,
+    const Eigen::Ref<const Eigen::ArrayXd>& y,
+    const Eigen::Ref<const Eigen::ArrayXd>& z,
+    Eigen::Ref<Eigen::ArrayXd> pressure)
+{
+  auto xit = x.cbegin();
+  auto yit = y.cbegin();
+  auto zit = z.cbegin();
+  auto pit = pressure.begin();
+  for ( ; xit != x.cend() && yit != y.cend() && pit != pressure.end();
+    ++xit, ++yit, ++zit, ++pit)
+  {
+    Pressure(*xit, *yit, *zit, *pit);
+  }
+}
 
-    // lookup interface - scalar
-    void ElevationAt(
-        Index ix, Index iy,
-        double &h);
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::ElevationAt(
+    Index ix, Index iy,
+    double& h)
+{
+  double x = ix * dx_ + lx_min_;
+  double y = iy * dy_ + ly_min_;
+  Elevation(x, y, h);
+}
 
-    void ElevationDerivAt(
-        Index ix, Index iy,
-        double &dhdx, double &dhdy);
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::ElevationDerivAt(
+    Index ix, Index iy,
+    double& dhdx, double& dhdy)
+{
+  double x = ix * dx_ + lx_min_;
+  double y = iy * dy_ + ly_min_;
+  ElevationDeriv(x, y, dhdx, dhdy);
+}
 
-    void PressureAt(
-        Index ix, Index iy, Index iz,
-        double &pressure);
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::PressureAt(
+    Index ix, Index iy, Index iz,
+    double& pressure)
+{
+  double x = ix * dx_ + lx_min_;
+  double y = iy * dy_ + ly_min_;
+  double z = z_(iz);
+  Pressure(x, y, z, pressure);
+}
 
-    // lookup interface - array
-    void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> h);
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::ElevationAt(
+    Eigen::Ref<Eigen::ArrayXXd> h)
+{
+  for (Index ix = 0; ix < nx_; ++ix)
+  {
+    for (Index iy = 0; iy < ny_; ++iy)
+    {
+      double h1{0.0};
+      ElevationAt(ix, iy, h1);
 
-    void ElevationDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy);
+      // column major
+      Index idx = iy * nx_ + ix;
+      h(idx, 0) = h1;
+    }
+  }
+}
 
-    void PressureAt(
-        Index iz,
-        Eigen::Ref<Eigen::ArrayXXd> pressure);
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::ElevationDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy)
+{
+  for (Index ix = 0; ix < nx_; ++ix)
+  {
+    for (Index iy = 0; iy < ny_; ++iy)
+    {
+      double dhdx1{0.0};
+      double dhdy1{0.0};
+      ElevationDerivAt(ix, iy, dhdx1, dhdy1);
 
-    void InitGrid();
+      // column major
+      Index idx = iy * nx_ + ix;
+      dhdx(idx, 0) = dhdx1;
+      dhdy(idx, 0) = dhdy1;
+    }
+  }
+}
 
-    void ComputeAmplitudes();
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::PressureAt(
+    Index iz,
+    Eigen::Ref<Eigen::ArrayXXd> pressure)
+{
+  for (Index ix = 0; ix < nx_; ++ix)
+  {
+    for (Index iy = 0; iy < ny_; ++iy)
+    {
+      double p1{0.0};
+      PressureAt(ix, iy, iz, p1);
 
-    // elevation and pressure grid params
-    Index nx_{2};
-    Index ny_{2};
-    Index nz_{1};
-    double lx_{1.0};
-    double ly_{1.0};
-    double lz_{0.0};
+      // column major
+      Index idx = iy * nx_ + ix;
+      pressure(idx, 0) = p1;
+    }
+  }
+}
 
-    // simulation parameters
-    double gravity_{9.81};
-    double fluid_rho_{1025.0};
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::InitGrid()
+{
+  // grid spacing
+  dx_ = lx_ / nx_;
+  dy_ = ly_ / ny_;
 
-    // parameters
-    Index num_waves_{100};
-    double max_w_{6.0};
-    double u19_{5.0};
-    double wave_angle_{0.0};
+  // x and y coordinates
+  lx_min_ = - lx_ / 2.0;
+  lx_max_ =   lx_ / 2.0;
+  ly_min_ = - ly_ / 2.0;
+  ly_max_ =   ly_ / 2.0;
 
-    bool needs_update_{true};
+  // pressure sample points (z is below the free surface)
+  Eigen::ArrayXd zr = Eigen::ArrayXd::Zero(nz_);
+  if (nz_ > 1)
+  {
+    // first element is zero - fill nz - 1 remaining elements
+    Eigen::ArrayXd ln_z = Eigen::ArrayXd::LinSpaced(
+        nz_ - 1, -std::log(lz_), std::log(lz_));
+    zr(Eigen::seq(1, nz_ - 1)) = -1 * Eigen::exp(ln_z);
+  }
+  z_ = zr.reverse();
+}
 
-    Eigen::ArrayXd spectrum_;
-    Eigen::ArrayXd amplitude_;
-    Eigen::ArrayXd w_;
-    Eigen::ArrayXd k_;
-    Eigen::ArrayXd phase_;
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::Impl::ComputeAmplitudes()
+{
+  if (!needs_update_)
+    return;
 
-    // update
-    double time_{0.0};
+  // resize workspace
+  spectrum_.resize(num_waves_);
+  amplitude_.resize(num_waves_);
+  w_.resize(num_waves_);
+  k_.resize(num_waves_);
+  phase_.resize(num_waves_);
 
-    // derived
-    double dx_{0.0};
-    double dy_{0.0};
-    double lx_max_{0.0};
-    double lx_min_{0.0};
-    double ly_max_{0.0};
-    double ly_min_{0.0};
+  // set spectrum and parameters
+  PiersonMoskowitzWaveSpectrum spectrum;
+  spectrum.SetU19(u19_);
 
-    // pressure sample points
-    Eigen::ArrayXd z_;
-  };
-  
-  //////////////////////////////////////////////////
-  LinearRandomWaveSimulation::Impl::~Impl() = default;
+  // angular frequency step size
+  double dw = max_w_ / num_waves_;
 
-  //////////////////////////////////////////////////
-  LinearRandomWaveSimulation::Impl::Impl(
+  // random uniforms for phase
+  auto seed = std::default_random_engine::default_seed;
+  std::default_random_engine generator(seed);
+  std::uniform_real_distribution<> distribution(0.0, 2.0 * M_PI);
+
+  /// \todo(srmainwaring) check spectrum
+  double k_prev = 0.0;
+  for (Index ik = 0; ik < num_waves_; ++ik)
+  {
+    // equally-spaced w => variably-spaced k
+    w_(ik) = dw * (ik + 1);
+    k_(ik) = w_(ik) * w_(ik) / gravity_;
+    double dk = k_(ik) - k_prev;
+    k_prev = k_(ik);
+
+    // spectrum variable is k
+    spectrum_(ik) = spectrum.Evaluate(k_(ik));
+    amplitude_(ik) = std::sqrt(2.0 * dk * spectrum_(ik));
+    phase_(ik) = distribution(generator);
+  }
+
+  needs_update_ = false;
+}
+
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+LinearRandomWaveSimulation::~LinearRandomWaveSimulation() = default;
+
+//////////////////////////////////////////////////
+LinearRandomWaveSimulation::LinearRandomWaveSimulation(
     double lx, double ly, Index nx, Index ny) :
-    lx_(lx),
-    ly_(ly),
-    nx_(nx),
-    ny_(ny)
-  {
-    InitGrid();
-  }
+  impl_(new LinearRandomWaveSimulation::Impl(lx, ly, nx, ny))
+{
+}
 
-  //////////////////////////////////////////////////
-  LinearRandomWaveSimulation::Impl::Impl(
+//////////////////////////////////////////////////
+LinearRandomWaveSimulation::LinearRandomWaveSimulation(
     double lx, double ly, double lz, Index nx, Index ny, Index nz) :
-    lx_(lx),
-    ly_(ly),
-    lz_(lz),
-    nx_(nx),
-    ny_(ny),
-    nz_(nz)
-  {
-    InitGrid();
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::SetTime(double value)
-  {
-    time_ = value;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::Elevation(
-      double x, double y,
-      double &eta)
-  {
-    ComputeAmplitudes();
-
-    double cd = std::cos(wave_angle_);
-    double sd = std::sin(wave_angle_);
-    double xd = x * cd + y * sd;
-
-    double h = 0;
-    for (Index ik = 0; ik < num_waves_; ++ik)
-    {
-      double wt = w_(ik) * time_;
-      double a  = k_(ik) * xd - wt + phase_(ik);
-      double ca = std::cos(a);
-      h += amplitude_(ik) * ca;
-    }
-    eta = h;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::ElevationDeriv(
-      double x, double y,
-      double &deta_dx, double &deta_dy)
-  {
-    ComputeAmplitudes();
-
-    double cd = std::cos(wave_angle_);
-    double sd = std::sin(wave_angle_);
-    double xd  = x * cd + y * sd;
-
-    double dhdx = 0;
-    double dhdy = 0;
-    for (Index ik = 0; ik < num_waves_; ++ik)
-    {
-      double wt = w_(ik) * time_;
-      double a  = k_(ik) * xd - wt + phase_(ik);
-      double sa = std::sin(a);
-      double dadx = k_(ik) * cd;
-      double dady = k_(ik) * sd;
-
-      dhdx += - dadx * amplitude_(ik) * sa;
-      dhdy += - dady * amplitude_(ik) * sa;
-    }
-    deta_dx = dhdx;
-    deta_dy = dhdx;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::Elevation(
-      const Eigen::Ref<const Eigen::ArrayXd> &x,
-      const Eigen::Ref<const Eigen::ArrayXd> &y,
-      Eigen::Ref<Eigen::ArrayXd> eta)
-  {
-    auto xit = x.cbegin();
-    auto yit = y.cbegin();
-    auto eit = eta.begin();
-    for ( ; xit != x.cend() && yit != y.cend() && eit != eta.end();
-      ++xit, ++yit, ++eit)
-    {
-      Elevation(*xit, *yit, *eit);
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::Pressure(
-      double x, double y, double z,
-      double &pressure)
-  {
-    ComputeAmplitudes();
-
-    double cd = std::cos(wave_angle_);
-    double sd = std::sin(wave_angle_);
-    double xd = x * cd + y * sd;
-
-    double p = 0;
-    for (Index ik = 0; ik < num_waves_; ++ik)
-    {
-      double wt = w_(ik) * time_;
-      double a  = k_(ik) * xd - wt + phase_(ik);
-      double ca = std::cos(a);
-      double h1 = amplitude_(ik) * ca;
-      double e  = std::exp(k_(ik) * z);
-      p += e * h1;
-    }
-    pressure = p;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::Pressure(
-      const Eigen::Ref<const Eigen::ArrayXd> &x,
-      const Eigen::Ref<const Eigen::ArrayXd> &y,
-      const Eigen::Ref<const Eigen::ArrayXd> &z,
-      Eigen::Ref<Eigen::ArrayXd> pressure)
-  {
-    auto xit = x.cbegin();
-    auto yit = y.cbegin();
-    auto zit = z.cbegin(); 
-    auto pit = pressure.begin();
-    for ( ; xit != x.cend() && yit != y.cend() && pit != pressure.end();
-      ++xit, ++yit, ++zit, ++pit)
-    {
-      Pressure(*xit, *yit, *zit, *pit);
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::ElevationAt(
-      Index ix, Index iy,
-      double &h)
-  {
-    double x = ix * dx_ + lx_min_;
-    double y = iy * dy_ + ly_min_;
-    Elevation(x, y, h);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::ElevationDerivAt(
-      Index ix, Index iy,
-      double &dhdx, double &dhdy)
-  {
-    double x = ix * dx_ + lx_min_;
-    double y = iy * dy_ + ly_min_;
-    ElevationDeriv(x, y, dhdx, dhdy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::PressureAt(
-      Index ix, Index iy, Index iz,
-      double &pressure)
-  {
-    double x = ix * dx_ + lx_min_;
-    double y = iy * dy_ + ly_min_;
-    double z = z_(iz);
-    Pressure(x, y, z, pressure);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h)
-  {
-    for (Index ix = 0; ix < nx_; ++ix)
-    {
-      for (Index iy = 0; iy < ny_; ++iy)
-      {
-        double h1{0.0};
-        ElevationAt(ix, iy, h1);
-
-        // column major
-        Index idx = iy * nx_ + ix;
-        h(idx, 0) = h1;
-      }
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::ElevationDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy)
-  {
-    for (Index ix = 0; ix < nx_; ++ix)
-    {
-      for (Index iy = 0; iy < ny_; ++iy)
-      {
-        double dhdx1{0.0};
-        double dhdy1{0.0};
-        ElevationDerivAt(ix, iy, dhdx1, dhdy1);
-
-        // column major
-        Index idx = iy * nx_ + ix;
-        dhdx(idx, 0) = dhdx1;
-        dhdy(idx, 0) = dhdy1;
-      }
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::PressureAt(
-      Index iz,
-      Eigen::Ref<Eigen::ArrayXXd> pressure)
-  {
-    for (Index ix = 0; ix < nx_; ++ix)
-    {
-      for (Index iy = 0; iy < ny_; ++iy)
-      {
-        double p1{0.0};
-        PressureAt(ix, iy, iz, p1);
-
-        // column major
-        Index idx = iy * nx_ + ix;
-        pressure(idx, 0) = p1;
-      }
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::InitGrid()
-  {
-    // grid spacing
-    dx_ = lx_ / nx_;
-    dy_ = ly_ / ny_;
-
-    // x and y coordinates
-    lx_min_ = - lx_ / 2.0;
-    lx_max_ =   lx_ / 2.0;
-    ly_min_ = - ly_ / 2.0;
-    ly_max_ =   ly_ / 2.0;
-
-    // pressure sample points (z is below the free surface)
-    Eigen::ArrayXd zr = Eigen::ArrayXd::Zero(nz_);
-    if (nz_ > 1)
-    {
-      // first element is zero - fill nz - 1 remaining elements
-      Eigen::ArrayXd ln_z = Eigen::ArrayXd::LinSpaced(
-          nz_ - 1, -std::log(lz_), std::log(lz_));
-      zr(Eigen::seq(1, nz_ - 1)) = -1 * Eigen::exp(ln_z);
-    }
-    z_ = zr.reverse();
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::Impl::ComputeAmplitudes()
-  {
-    if (!needs_update_)
-      return;
-
-    // resize workspace
-    spectrum_.resize(num_waves_);
-    amplitude_.resize(num_waves_);
-    w_.resize(num_waves_);
-    k_.resize(num_waves_);
-    phase_.resize(num_waves_);
-
-    // set spectrum and parameters
-    PiersonMoskowitzWaveSpectrum spectrum;
-    spectrum.SetU19(u19_);
-
-    // angular frequency step size
-    double dw = max_w_ / num_waves_;
-
-    // random uniforms for phase
-    auto seed = std::default_random_engine::default_seed;
-    std::default_random_engine generator(seed);
-    std::uniform_real_distribution<> distribution(0.0, 2.0 * M_PI);
-
-    /// \todo(srmainwaring) check spectrum
-    double k_prev = 0.0;
-    for (Index ik = 0; ik < num_waves_; ++ik)
-    {
-      // equally-spaced w => variably-spaced k
-      w_(ik) = dw * (ik + 1);
-      k_(ik) = w_(ik) * w_(ik) / gravity_;
-      double dk = k_(ik) - k_prev;
-      k_prev = k_(ik);
-
-      // spectrum variable is k
-      spectrum_(ik) = spectrum.Evaluate(k_(ik));
-      amplitude_(ik) = std::sqrt(2.0 * dk * spectrum_(ik));
-      phase_(ik) = distribution(generator);
-    }
-
-    needs_update_ = false;
-  }
-
-  //////////////////////////////////////////////////
-  //////////////////////////////////////////////////
-  LinearRandomWaveSimulation::~LinearRandomWaveSimulation() = default;
-
-  //////////////////////////////////////////////////
-  LinearRandomWaveSimulation::LinearRandomWaveSimulation(
-      double lx, double ly, Index nx, Index ny) :
-    impl_(new LinearRandomWaveSimulation::Impl(lx, ly, nx, ny))
-  {
-  }
-
-  //////////////////////////////////////////////////
-  LinearRandomWaveSimulation::LinearRandomWaveSimulation(
-      double lx, double ly, double lz, Index nx, Index ny, Index nz) :
-    impl_(new LinearRandomWaveSimulation::Impl(lx, ly, lz, nx, ny, nz))
-  {
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRandomWaveSimulation::NumWaves() const
-  {
-    return impl_->num_waves_;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::SetNumWaves(Index value)
-  {
-    impl_->num_waves_ = value;
-    impl_->needs_update_ = true;
-  }
-
-  //////////////////////////////////////////////////
-  double LinearRandomWaveSimulation::MaxOmega() const
-  {
-    return impl_->max_w_;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::SetMaxOmega(double value)
-  {
-    impl_->max_w_ = value;
-    impl_->needs_update_ = true;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::SetWindVelocity(double ux, double uy)
-  {
-    /// \todo(srmainwaring) standardise reference level for wind
-    impl_->u19_ = std::sqrt(ux * ux + uy * uy);
-    impl_->wave_angle_ = std::atan2(uy, ux);
-    impl_->needs_update_ = true;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::SetTime(double value)
-  {
-    impl_->SetTime(value);
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRandomWaveSimulation::SizeX() const
-  {
-    return impl_->nx_;
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRandomWaveSimulation::SizeY() const
-  {
-    return impl_->ny_;
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRandomWaveSimulation::SizeZ() const
-  {
-    return impl_->nz_;
-  }
-
-  void LinearRandomWaveSimulation::Elevation(
-      double x, double y,
-      double &eta)
-  {
-    impl_->Elevation(x, y, eta);
-  }
-
-  void LinearRandomWaveSimulation::Elevation(
-      const Eigen::Ref<const Eigen::ArrayXd> &x,
-      const Eigen::Ref<const Eigen::ArrayXd> &y,
-      Eigen::Ref<Eigen::ArrayXd> eta)
-  {
-    impl_->Elevation(x, y, eta);
-  }
-
-  void LinearRandomWaveSimulation::Pressure(
-      double x, double y, double z,
-      double &pressure)
-  {
-    impl_->Pressure(x, y, z, pressure);
-  }
-
-  void LinearRandomWaveSimulation::Pressure(
-      const Eigen::Ref<const Eigen::ArrayXd> &x,
-      const Eigen::Ref<const Eigen::ArrayXd> &y,
-      const Eigen::Ref<const Eigen::ArrayXd> &z,
-      Eigen::Ref<Eigen::ArrayXd> pressure)
-  {
-    impl_->Pressure(x, y, z, pressure);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h)
-  {
-    impl_->ElevationAt(h);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::ElevationDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy)
-  {
-    impl_->ElevationDerivAt(dhdx, dhdy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::DisplacementAt(
-      Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
-      Eigen::Ref<Eigen::ArrayXXd> /*sy*/)
-  {
-    // no xy-displacement
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::DisplacementDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
-      Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
-      Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
-  {
-    // no xy-displacement
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::DisplacementAndDerivAt(
-      Eigen::Ref<Eigen::ArrayXXd> h,
-      Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
-      Eigen::Ref<Eigen::ArrayXXd> /*sy*/,
-      Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy,
-      Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
-      Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
-      Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
-  {
-    impl_->ElevationAt(h);
-    impl_->ElevationDerivAt(dhdx, dhdy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::PressureAt(
-      Index iz,
-      Eigen::Ref<Eigen::ArrayXXd> pressure)
-  {
-    impl_->PressureAt(iz, pressure);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::ElevationAt(
-      Index ix, Index iy,
-      double &eta)
-  {
-    impl_->ElevationAt(ix, iy, eta);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::DisplacementAt(
-      Index /*ix*/, Index /*iy*/,
-      double &/*sx*/, double &/*sy*/)
-  {
-    // no xy-displacement
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRandomWaveSimulation::PressureAt(
-      Index ix, Index iy, Index iz,
-      double &pressure)
-  {
-    impl_->PressureAt(ix, iy, iz, pressure);
-  }
-
+  impl_(new LinearRandomWaveSimulation::Impl(lx, ly, lz, nx, ny, nz))
+{
 }
+
+//////////////////////////////////////////////////
+Index LinearRandomWaveSimulation::NumWaves() const
+{
+  return impl_->num_waves_;
 }
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::SetNumWaves(Index value)
+{
+  impl_->num_waves_ = value;
+  impl_->needs_update_ = true;
+}
+
+//////////////////////////////////////////////////
+double LinearRandomWaveSimulation::MaxOmega() const
+{
+  return impl_->max_w_;
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::SetMaxOmega(double value)
+{
+  impl_->max_w_ = value;
+  impl_->needs_update_ = true;
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::SetWindVelocity(double ux, double uy)
+{
+  /// \todo(srmainwaring) standardise reference level for wind
+  impl_->u19_ = std::sqrt(ux * ux + uy * uy);
+  impl_->wave_angle_ = std::atan2(uy, ux);
+  impl_->needs_update_ = true;
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::SetTime(double value)
+{
+  impl_->SetTime(value);
+}
+
+//////////////////////////////////////////////////
+Index LinearRandomWaveSimulation::SizeX() const
+{
+  return impl_->nx_;
+}
+
+//////////////////////////////////////////////////
+Index LinearRandomWaveSimulation::SizeY() const
+{
+  return impl_->ny_;
+}
+
+//////////////////////////////////////////////////
+Index LinearRandomWaveSimulation::SizeZ() const
+{
+  return impl_->nz_;
+}
+
+void LinearRandomWaveSimulation::Elevation(
+    double x, double y,
+    double &eta)
+{
+  impl_->Elevation(x, y, eta);
+}
+
+void LinearRandomWaveSimulation::Elevation(
+    const Eigen::Ref<const Eigen::ArrayXd>& x,
+    const Eigen::Ref<const Eigen::ArrayXd>& y,
+    Eigen::Ref<Eigen::ArrayXd> eta)
+{
+  impl_->Elevation(x, y, eta);
+}
+
+void LinearRandomWaveSimulation::Pressure(
+    double x, double y, double z,
+    double& pressure)
+{
+  impl_->Pressure(x, y, z, pressure);
+}
+
+void LinearRandomWaveSimulation::Pressure(
+    const Eigen::Ref<const Eigen::ArrayXd>& x,
+    const Eigen::Ref<const Eigen::ArrayXd>& y,
+    const Eigen::Ref<const Eigen::ArrayXd>& z,
+    Eigen::Ref<Eigen::ArrayXd> pressure)
+{
+  impl_->Pressure(x, y, z, pressure);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::ElevationAt(
+    Eigen::Ref<Eigen::ArrayXXd> h)
+{
+  impl_->ElevationAt(h);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::ElevationDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy)
+{
+  impl_->ElevationDerivAt(dhdx, dhdy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::DisplacementAt(
+    Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
+    Eigen::Ref<Eigen::ArrayXXd> /*sy*/)
+{
+  // no xy-displacement
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::DisplacementDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
+    Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
+    Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+{
+  // no xy-displacement
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::DisplacementAndDerivAt(
+    Eigen::Ref<Eigen::ArrayXXd> h,
+    Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
+    Eigen::Ref<Eigen::ArrayXXd> /*sy*/,
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy,
+    Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
+    Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
+    Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+{
+  impl_->ElevationAt(h);
+  impl_->ElevationDerivAt(dhdx, dhdy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::PressureAt(
+    Index iz,
+    Eigen::Ref<Eigen::ArrayXXd> pressure)
+{
+  impl_->PressureAt(iz, pressure);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::ElevationAt(
+    Index ix, Index iy,
+    double& eta)
+{
+  impl_->ElevationAt(ix, iy, eta);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::DisplacementAt(
+    Index /*ix*/, Index /*iy*/,
+    double& /*sx*/, double& /*sy*/)
+{
+  // no xy-displacement
+}
+
+//////////////////////////////////////////////////
+void LinearRandomWaveSimulation::PressureAt(
+    Index ix, Index iy, Index iz,
+    double& pressure)
+{
+  impl_->PressureAt(ix, iy, iz, pressure);
+}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/LinearRegularWaveSimulation.cc
+++ b/gz-waves/src/LinearRegularWaveSimulation.cc
@@ -14,9 +14,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/LinearRegularWaveSimulation.hh"
-#include "gz/waves/Physics.hh"
 
 #include <Eigen/Dense>
+
+#include "gz/waves/Physics.hh"
 
 using Eigen::ArrayXXd;
 using Eigen::ArrayXd;
@@ -25,717 +26,710 @@ namespace gz
 {
 namespace waves
 {
-  /// \todo Proposed changes
-  ///
-  /// 1. set wind velocity as magnitude v (m/s) and direction theta (rad).
-  ///
-  /// 2. set wave height H or amplitude A = H/2
-  ///
-  /// 4. allow the dispersion relation to be configured - or set depth
-  ///
+/// \todo Proposed changes
+///
+/// 1. set wind velocity as magnitude v (m/s) and direction theta (rad).
+///
+/// 2. set wave height H or amplitude A = H/2
+///
+/// 4. allow the dispersion relation to be configured - or set depth
+///
 
-  //////////////////////////////////////////////////
-  // LinearRegularWaveSimulation::Impl
+//////////////////////////////////////////////////
+// LinearRegularWaveSimulation::Impl
 
-  /// model description
-  ///
-  /// Waves are defined on a lx x ly mesh with nx x ny samples.
-  ///
-  /// H       - wave height
-  /// A       - wave amplitide = H/2
-  /// T       - wave period
-  /// w       - wave angular frequency = 2 pi / T
-  /// k       - wave number = w^2 / g for infinite depth
-  /// (x, y)  - position
-  /// eta     - wave height
-  ///
-  /// eta(x, y, t) = A cos(k (x cos(theta) + y sin(theta)) - w t)
-  ///
-  /// cd = cos(theta) - projection of wave direction on x-axis
-  /// sd = sin(theta) - projection of wave direction on y-axis
-  ///
-  /// a = k (x cd + y sd) - w t
-  /// sa = sin(a)
-  /// ca = cos(a)
-  ///
-  /// da/dx = k cd
-  /// da/dy = k sd
-  /// 
-  /// h = eta(x, y, y) = A ca
-  /// dh/dx = - da/dx A sa
-  /// dh/dx = - da/dy A sa
-  ///
+/// model description
+///
+/// Waves are defined on a lx x ly mesh with nx x ny samples.
+///
+/// H       - wave height
+/// A       - wave amplitide = H/2
+/// T       - wave period
+/// w       - wave angular frequency = 2 pi / T
+/// k       - wave number = w^2 / g for infinite depth
+/// (x, y)  - position
+/// eta     - wave height
+///
+/// eta(x, y, t) = A cos(k (x cos(theta) + y sin(theta)) - w t)
+///
+/// cd = cos(theta) - projection of wave direction on x-axis
+/// sd = sin(theta) - projection of wave direction on y-axis
+///
+/// a = k (x cd + y sd) - w t
+/// sa = sin(a)
+/// ca = cos(a)
+///
+/// da/dx = k cd
+/// da/dy = k sd
+///
+/// h = eta(x, y, y) = A ca
+/// dh/dx = - da/dx A sa
+/// dh/dx = - da/dy A sa
+///
 
-  //////////////////////////////////////////////////
-  class LinearRegularWaveSimulation::Impl
-  {
-  public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+//////////////////////////////////////////////////
+class LinearRegularWaveSimulation::Impl
+{
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    ~Impl();
+  ~Impl();
 
-    Impl(double lx, double ly, Index nx, Index ny);
+  Impl(double lx, double ly, Index nx, Index ny);
 
-    Impl(double lx, double ly, double lz, Index nx, Index ny, Index nz);
+  Impl(double lx, double ly, double lz, Index nx, Index ny, Index nz);
 
-    void InitGrid();
+  void InitGrid();
 
-    void SetUseVectorised(bool value);
+  void SetUseVectorised(bool value);
 
-    void SetDirection(double dir_x, double dir_y);
+  void SetDirection(double dir_x, double dir_y);
 
-    void SetAmplitude(double value);
+  void SetAmplitude(double value);
 
-    void SetPeriod(double value);
+  void SetPeriod(double value);
 
-    void SetWindVelocity(double ux, double uy);
+  void SetWindVelocity(double ux, double uy);
 
-    void SetTime(double value);
+  void SetTime(double value);
 
-    // interpolation interface
-    void Elevation(
-        double x, double y,
-        double &eta);
-
-    void Elevation(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        Eigen::Ref<Eigen::ArrayXd> eta);
-
-    void Pressure(
-        double x, double y, double z,
-        double &pressure);
-
-    void Pressure(
-        const Eigen::Ref<const Eigen::ArrayXd> &x,
-        const Eigen::Ref<const Eigen::ArrayXd> &y,
-        const Eigen::Ref<const Eigen::ArrayXd> &z,
-        Eigen::Ref<Eigen::ArrayXd> pressure);
-
-    // lookup interface
-    void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> h);
-
-    void ElevationDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy);
-
-    void DisplacementAndDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> h,
-        Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy,
-        Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy);
-
-    void ElevationAt(
-        Index ix, Index iy,
-        double &h);
-
-    void PressureAt(
-        Index ix, Index iy, Index iz,
-        double &pressure);
-
-    void PressureAt(
-        Index iz,
-        Eigen::Ref<Eigen::ArrayXXd> pressure);
-
-    static inline void PreComputeCoeff(
-      double period, double t, double wave_angle,
-      double &w, double &wt, double &k, double &cos_angle, double &sin_angle)
-    {
-      w = 2.0 * M_PI / period;
-      wt = w * t;
-      k = Physics::DeepWaterDispersionToWavenumber(w);
-      cos_angle = std::cos(wave_angle);
-      sin_angle = std::sin(wave_angle);
-    }
-
-    bool use_vectorised_{true};
-
-    // elevation and pressure grid params
-    Index nx_{2};
-    Index ny_{2};
-    Index nz_{1};
-    double lx_{1.0};
-    double ly_{1.0};
-    double lz_{0.0};
-    
-    // wave params
-    double wave_angle_{0.0};
-    double amplitude_{1.0};
-    double period_{1.0};
-    double time_{0.0};
-
-    // derived
-    double dx_{0.0};
-    double dy_{0.0};
-    double lx_max_{0.0};
-    double lx_min_{0.0};
-    double ly_max_{0.0};
-    double ly_min_{0.0};
-
-    // vectorised
-    Eigen::ArrayXd x_;
-    Eigen::ArrayXd y_;
-    Eigen::ArrayXXd x_grid_;
-    Eigen::ArrayXXd y_grid_;
-    Eigen::ArrayXd z_;
-  };
-
-  //////////////////////////////////////////////////
-  LinearRegularWaveSimulation::Impl::~Impl()
-  {
-  }
-
-  //////////////////////////////////////////////////
-  LinearRegularWaveSimulation::Impl::Impl(
-      double lx, double ly, Index nx, Index ny) :
-    nx_(nx),
-    ny_(ny),
-    lx_(lx),
-    ly_(ly)
-  {
-    InitGrid();
-  }
-
-  //////////////////////////////////////////////////
-  LinearRegularWaveSimulation::Impl::Impl(
-      double lx, double ly, double lz, Index nx, Index ny, Index nz) :
-    nx_(nx),
-    ny_(ny),
-    nz_(nz),
-    lx_(lx),
-    ly_(ly),
-    lz_(lz)
-  {
-    InitGrid();
-  }
-
- //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::InitGrid()
-  {
-    // grid spacing
-    dx_ = lx_ / nx_;
-    dy_ = ly_ / ny_;
-
-    // x and y coordinates
-    lx_min_ = - lx_ / 2.0;
-    lx_max_ =   lx_ / 2.0;
-    ly_min_ = - ly_ / 2.0;
-    ly_max_ =   ly_ / 2.0;
-
-    // linspaced is on closed interval (unlike Python which is open to right)
-    x_ = Eigen::ArrayXd::LinSpaced(nx_, lx_min_, lx_max_ - dx_);
-    y_ = Eigen::ArrayXd::LinSpaced(ny_, ly_min_, ly_max_ - dy_);
-
-    // broadcast to matrices (aka meshgrid)
-    x_grid_ = Eigen::ArrayXXd::Zero(nx_, ny_);
-    y_grid_ = Eigen::ArrayXXd::Zero(nx_, ny_);
-    x_grid_.colwise() += x_;
-    y_grid_.rowwise() += y_.transpose();
-
-    // pressure sample points (z is below the free surface)
-    Eigen::ArrayXd zr = Eigen::ArrayXd::Zero(nz_);
-    if (nz_ > 1)
-    {
-      // first element is zero - fill nz - 1 remaining elements
-      Eigen::ArrayXd ln_z = Eigen::ArrayXd::LinSpaced(
-          nz_ - 1, -std::log(lz_), std::log(lz_));
-      zr(Eigen::seq(1, nz_ - 1)) = -1 * Eigen::exp(ln_z);
-    }
-    z_ = zr.reverse();
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::SetUseVectorised(bool value)
-  {
-    use_vectorised_ = value;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::SetDirection(double dir_x, double dir_y)
-  {
-    wave_angle_ = std::atan2(dir_y, dir_x);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::SetAmplitude(double value)
-  {
-    amplitude_ = value;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::SetPeriod(double value)
-  {
-    period_ = value;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::SetWindVelocity(
-      double /*_ux*/, double /*_uy*/)
-  {
-    // @TODO NO IMPLEMENTATION
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::SetTime(double value)
-  {
-    time_ = value;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::Elevation(
+  // interpolation interface
+  void Elevation(
       double x, double y,
-      double &eta)
-  {
-    double w, wt, k, cd, sd;
-    PreComputeCoeff(
-      period_, time_, wave_angle_, w, wt, k, cd, sd);
+      double &eta);
 
-    double a  = k * (x * cd + y * sd) - wt;
-    double ca = std::cos(a);
-    double h1 = amplitude_ * ca;
-    eta = h1;
-  }
+  void Elevation(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      Eigen::Ref<Eigen::ArrayXd> eta);
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::Elevation(
-      const Eigen::Ref<const Eigen::ArrayXd> &x,
-      const Eigen::Ref<const Eigen::ArrayXd> &y,
-      Eigen::Ref<Eigen::ArrayXd> eta)
-  {
-    auto xit = x.cbegin();
-    auto yit = y.cbegin();
-    auto eit = eta.begin();
-    for ( ; xit != x.cend() && yit != y.cend() && eit != eta.end();
-      ++xit, ++yit, ++eit)
-    {
-      Elevation(*xit, *yit, *eit);
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::Pressure(
+  void Pressure(
       double x, double y, double z,
-      double &pressure)
+      double &pressure);
+
+  void Pressure(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      const Eigen::Ref<const Eigen::ArrayXd>& z,
+      Eigen::Ref<Eigen::ArrayXd> pressure);
+
+  // lookup interface
+  void ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> h);
+
+  void ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy);
+
+  void DisplacementAndDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> h,
+      Eigen::Ref<Eigen::ArrayXXd> sx,
+      Eigen::Ref<Eigen::ArrayXXd> sy,
+      Eigen::Ref<Eigen::ArrayXXd> dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> dhdy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy);
+
+  void ElevationAt(
+      Index ix, Index iy,
+      double &h);
+
+  void PressureAt(
+      Index ix, Index iy, Index iz,
+      double &pressure);
+
+  void PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure);
+
+  static inline void PreComputeCoeff(
+    double period, double t, double wave_angle,
+    double& w, double& wt, double& k, double& cos_angle, double& sin_angle)
   {
-    double w, wt, k, cd, sd;
-    PreComputeCoeff(
-      period_, time_, wave_angle_, w, wt, k, cd, sd);
-
-    // linear wave deep water pressure scaling factor
-    double e = std::exp(k * z);
-
-    double a  = k * (x * cd + y * sd) - wt;
-    double ca = std::cos(a);
-    double h1 = amplitude_ * ca;
-    double p1 = e * h1;
-    pressure = p1;
+    w = 2.0 * M_PI / period;
+    wt = w * t;
+    k = Physics::DeepWaterDispersionToWavenumber(w);
+    cos_angle = std::cos(wave_angle);
+    sin_angle = std::sin(wave_angle);
   }
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::Pressure(
-    const Eigen::Ref<const Eigen::ArrayXd> &x,
-    const Eigen::Ref<const Eigen::ArrayXd> &y,
-    const Eigen::Ref<const Eigen::ArrayXd> &z,
-    Eigen::Ref<Eigen::ArrayXd> pressure)
+  bool use_vectorised_{true};
+
+  // elevation and pressure grid params
+  Index nx_{2};
+  Index ny_{2};
+  Index nz_{1};
+  double lx_{1.0};
+  double ly_{1.0};
+  double lz_{0.0};
+
+  // wave params
+  double wave_angle_{0.0};
+  double amplitude_{1.0};
+  double period_{1.0};
+  double time_{0.0};
+
+  // derived
+  double dx_{0.0};
+  double dy_{0.0};
+  double lx_max_{0.0};
+  double lx_min_{0.0};
+  double ly_max_{0.0};
+  double ly_min_{0.0};
+
+  // vectorised
+  Eigen::ArrayXd x_;
+  Eigen::ArrayXd y_;
+  Eigen::ArrayXXd x_grid_;
+  Eigen::ArrayXXd y_grid_;
+  Eigen::ArrayXd z_;
+};
+
+//////////////////////////////////////////////////
+LinearRegularWaveSimulation::Impl::~Impl()
+{
+}
+
+//////////////////////////////////////////////////
+LinearRegularWaveSimulation::Impl::Impl(
+    double lx, double ly, Index nx, Index ny) :
+  nx_(nx),
+  ny_(ny),
+  lx_(lx),
+  ly_(ly)
+{
+  InitGrid();
+}
+
+//////////////////////////////////////////////////
+LinearRegularWaveSimulation::Impl::Impl(
+    double lx, double ly, double lz, Index nx, Index ny, Index nz) :
+  nx_(nx),
+  ny_(ny),
+  nz_(nz),
+  lx_(lx),
+  ly_(ly),
+  lz_(lz)
+{
+  InitGrid();
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::InitGrid()
+{
+  // grid spacing
+  dx_ = lx_ / nx_;
+  dy_ = ly_ / ny_;
+
+  // x and y coordinates
+  lx_min_ = - lx_ / 2.0;
+  lx_max_ =   lx_ / 2.0;
+  ly_min_ = - ly_ / 2.0;
+  ly_max_ =   ly_ / 2.0;
+
+  // linspaced is on closed interval (unlike Python which is open to right)
+  x_ = Eigen::ArrayXd::LinSpaced(nx_, lx_min_, lx_max_ - dx_);
+  y_ = Eigen::ArrayXd::LinSpaced(ny_, ly_min_, ly_max_ - dy_);
+
+  // broadcast to matrices (aka meshgrid)
+  x_grid_ = Eigen::ArrayXXd::Zero(nx_, ny_);
+  y_grid_ = Eigen::ArrayXXd::Zero(nx_, ny_);
+  x_grid_.colwise() += x_;
+  y_grid_.rowwise() += y_.transpose();
+
+  // pressure sample points (z is below the free surface)
+  Eigen::ArrayXd zr = Eigen::ArrayXd::Zero(nz_);
+  if (nz_ > 1)
   {
-    auto xit = x.cbegin();
-    auto yit = y.cbegin();
-    auto zit = z.cbegin(); 
-    auto pit = pressure.begin();
-    for ( ; xit != x.cend() && yit != y.cend() && pit != pressure.end();
-      ++xit, ++yit, ++zit, ++pit)
-    {
-      Pressure(*xit, *yit, *zit, *pit);
-    }
+    // first element is zero - fill nz - 1 remaining elements
+    Eigen::ArrayXd ln_z = Eigen::ArrayXd::LinSpaced(
+        nz_ - 1, -std::log(lz_), std::log(lz_));
+    zr(Eigen::seq(1, nz_ - 1)) = -1 * Eigen::exp(ln_z);
   }
+  z_ = zr.reverse();
+}
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::ElevationAt(
-    Eigen::Ref<Eigen::ArrayXXd> h)
-  {
-    // derived wave properties
-    double w, wt, k, cd, sd;
-    PreComputeCoeff(
-      period_, time_, wave_angle_, w, wt, k, cd, sd);
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::SetUseVectorised(bool value)
+{
+  use_vectorised_ = value;
+}
 
-    if (use_vectorised_)
-    {
-      Eigen::ArrayXXd a = k * (x_grid_ * cd
-          + y_grid_ * sd) - wt;
-      Eigen::ArrayXXd ca = Eigen::cos(a);
-      Eigen::ArrayXXd h1 = amplitude_ * ca;
-      h = h1.reshaped();
-    }
-    else
-    {
-      for (Index iy=0, idx=0; iy<ny_; ++iy)
-      {
-        double y = iy * dy_ + ly_min_;
-        for (Index ix=0; ix<nx_; ++ix, ++idx)
-        {
-          double x = ix * dx_ + lx_min_;
-          double a  = k * (x * cd + y * sd) - wt;
-          double ca = std::cos(a);
-          double h1 = amplitude_ * ca;
-          h(idx, 0) = h1;
-        }
-      }
-    }
-  }
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::SetDirection(double dir_x, double dir_y)
+{
+  wave_angle_ = std::atan2(dir_y, dir_x);
+}
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::ElevationDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> dhdx,
-    Eigen::Ref<Eigen::ArrayXXd> dhdy)
-  {
-    // derived wave properties
-    double w, wt, k, cd, sd;
-    PreComputeCoeff(
-      period_, time_, wave_angle_, w, wt, k, cd, sd);
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::SetAmplitude(double value)
+{
+  amplitude_ = value;
+}
 
-    double dadx = k * cd;
-    double dady = k * sd;
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::SetPeriod(double value)
+{
+  period_ = value;
+}
 
-    if (use_vectorised_)
-    {
-      Eigen::ArrayXXd a = k * (x_grid_ * cd
-          + y_grid_ * sd) - wt;
-      Eigen::ArrayXXd sa = Eigen::sin(a);
-      Eigen::ArrayXXd dhdx1 = - dadx * amplitude_ * sa;
-      Eigen::ArrayXXd dhdy1 = - dady * amplitude_ * sa;
-      dhdx = dhdx1.reshaped();
-      dhdy = dhdy1.reshaped();
-    }
-    else
-    {
-      for (Index iy=0, idx=0; iy<ny_; ++iy)
-      {
-        double y = iy * dy_ + ly_min_;
-        for (Index ix=0; ix<nx_; ++ix, ++idx)
-        {
-          double x = ix * dx_ + lx_min_;
-          double a  = k * (x * cd + y * sd) - wt;
-          double sa = std::sin(a);
-          double dhdx1 = - dadx * amplitude_ * sa;
-          double dhdy1 = - dady * amplitude_ * sa;
-          dhdx(idx, 0) = dhdx1;
-          dhdy(idx, 0) = dhdy1;
-        }
-      }
-    }
-  }
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::SetWindVelocity(
+    double /*_ux*/, double /*_uy*/)
+{
+  // @TODO NO IMPLEMENTATION
+}
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::DisplacementAndDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> h,
-    Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*sy*/,
-    Eigen::Ref<Eigen::ArrayXXd> dhdx,
-    Eigen::Ref<Eigen::ArrayXXd> dhdy,
-    Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
-  {
-    // derived wave properties
-    double w, wt, k, cd, sd;
-    PreComputeCoeff(
-      period_, time_, wave_angle_, w, wt, k, cd, sd);
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::SetTime(double value)
+{
+  time_ = value;
+}
 
-    double dadx = k * cd;
-    double dady = k * sd;
-
-    if (use_vectorised_)
-    {
-      Eigen::ArrayXXd a = k * (x_grid_ * cd
-          + y_grid_ * sd) - wt;
-      Eigen::ArrayXXd ca = Eigen::cos(a);
-      Eigen::ArrayXXd sa = Eigen::sin(a);
-      Eigen::ArrayXXd h1 = amplitude_ * ca;
-      Eigen::ArrayXXd dhdx1 = - dadx * amplitude_ * sa;
-      Eigen::ArrayXXd dhdy1 = - dady * amplitude_ * sa;
-      h = h1.reshaped();
-      dhdx = dhdx1.reshaped();
-      dhdy = dhdy1.reshaped();
-    }
-    else
-    {
-      for (Index iy=0, idx=0; iy<ny_; ++iy)
-      {
-        double y = iy * dy_ + ly_min_;
-        for (Index ix=0; ix<nx_; ++ix, ++idx)
-        {
-          double x = ix * dx_ + lx_min_;
-          double a  = k * (x * cd + y * sd) - wt;
-          double ca = std::cos(a);
-          double sa = std::sin(a);
-          double h1 = amplitude_ * ca;
-          double dhdx1 = - dadx * amplitude_ * sa;
-          double dhdy1 = - dady * amplitude_ * sa;
-          h(idx, 0) = h1;
-          dhdx(idx, 0) = dhdx1;
-          dhdy(idx, 0) = dhdy1;
-        }
-      }
-    }
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::ElevationAt(
-      Index ix, Index iy, double &h)
-  {
-    double x = ix * dx_ + lx_min_;
-    double y = iy * dy_ + ly_min_;
-    Elevation(x, y, h);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::PressureAt(
-    Index ix, Index iy, Index iz,
-    double &pressure)
-  {
-    double x = ix * dx_ + lx_min_;
-    double y = iy * dy_ + ly_min_;
-    double z = z_(iz);
-    Pressure(x, y, z, pressure);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Impl::PressureAt(
-    Index iz,
-    Eigen::Ref<Eigen::ArrayXXd> pressure)
-  {
-    // derived wave properties
-    double w, wt, k, cd, sd;
-    PreComputeCoeff(
-      period_, time_, wave_angle_, w, wt, k, cd, sd);
-
-    // value of z at index iz
-    double z = z_(iz);
-
-    // linear wave deep water pressure scaling factor
-    double e = std::exp(k * z);
-
-    if (use_vectorised_)
-    {
-      Eigen::ArrayXXd a = k * (x_grid_ * cd
-          + y_grid_ * sd) - wt;
-      Eigen::ArrayXXd ca = Eigen::cos(a);
-      Eigen::ArrayXXd p  = e * amplitude_ * ca;
-      pressure = p.reshaped();
-    }
-    else
-    {
-      for (Index iy=0, idx=0; iy<ny_; ++iy)
-      {
-        double y = iy * dy_ + ly_min_;
-        for (Index ix=0; ix<nx_; ++ix, ++idx)
-        {
-          double x = ix * dx_ + lx_min_;
-          double a  = k * (x * cd + y * sd) - wt;
-          double ca = std::cos(a);
-          double h1 = amplitude_ * ca;
-          double p = e * h1;
-          pressure(idx, 0) = p;
-        }
-      }
-    }
-  }
-
-  //////////////////////////////////////////////////
-  //////////////////////////////////////////////////
-  LinearRegularWaveSimulation::~LinearRegularWaveSimulation()
-  {
-  }
-
-  //////////////////////////////////////////////////
-  LinearRegularWaveSimulation::LinearRegularWaveSimulation(
-      double lx, double ly, Index nx, Index ny) :
-    impl_(new LinearRegularWaveSimulation::Impl(lx, ly, nx, ny))
-  {
-  }
-
-  //////////////////////////////////////////////////
-  LinearRegularWaveSimulation::LinearRegularWaveSimulation(
-      double lx, double ly, double lz, Index nx, Index ny, Index nz) :
-    impl_(new LinearRegularWaveSimulation::Impl(lx, ly, lz, nx, ny, nz))
-  {
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::SetUseVectorised(bool value)
-  {
-    impl_->SetUseVectorised(value);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::SetDirection(double dir_x, double dir_y)
-  {
-    impl_->SetDirection(dir_x, dir_y);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::SetAmplitude(double value)
-  {
-    impl_->SetAmplitude(value);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::SetPeriod(double value)
-  {
-    impl_->SetPeriod(value);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::SetWindVelocity(double ux, double uy)
-  {
-    impl_->SetWindVelocity(ux, uy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::SetTime(double value)
-  {
-    impl_->SetTime(value);
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRegularWaveSimulation::SizeX() const
-  {
-    return impl_->nx_;
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRegularWaveSimulation::SizeY() const
-  {
-    return impl_->ny_;
-  }
-
-  //////////////////////////////////////////////////
-  Index LinearRegularWaveSimulation::SizeZ() const
-  {
-    return impl_->nz_;
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Elevation(
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::Elevation(
     double x, double y,
-    double &eta)
-  {
-    impl_->Elevation(x, y, eta);
-  }
+    double& eta)
+{
+  double w, wt, k, cd, sd;
+  PreComputeCoeff(
+    period_, time_, wave_angle_, w, wt, k, cd, sd);
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Elevation(
-    const Eigen::Ref<const Eigen::ArrayXd> &x,
-    const Eigen::Ref<const Eigen::ArrayXd> &y,
+  double a  = k * (x * cd + y * sd) - wt;
+  double ca = std::cos(a);
+  double h1 = amplitude_ * ca;
+  eta = h1;
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::Elevation(
+    const Eigen::Ref<const Eigen::ArrayXd>& x,
+    const Eigen::Ref<const Eigen::ArrayXd>& y,
     Eigen::Ref<Eigen::ArrayXd> eta)
+{
+  auto xit = x.cbegin();
+  auto yit = y.cbegin();
+  auto eit = eta.begin();
+  for ( ; xit != x.cend() && yit != y.cend() && eit != eta.end();
+    ++xit, ++yit, ++eit)
   {
-    impl_->Elevation(x, y, eta);
+    Elevation(*xit, *yit, *eit);
   }
+}
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Pressure(
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::Pressure(
     double x, double y, double z,
-    double &pressure)
-  {
-    impl_->Pressure(x, y, z, pressure);
-  }
+    double& pressure)
+{
+  double w, wt, k, cd, sd;
+  PreComputeCoeff(
+    period_, time_, wave_angle_, w, wt, k, cd, sd);
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::Pressure(
-    const Eigen::Ref<const Eigen::ArrayXd> &x,
-    const Eigen::Ref<const Eigen::ArrayXd> &y,
-    const Eigen::Ref<const Eigen::ArrayXd> &z,
-    Eigen::Ref<Eigen::ArrayXd> pressure)
-  {
-    impl_->Pressure(x, y, z, pressure);
-  }
+  // linear wave deep water pressure scaling factor
+  double e = std::exp(k * z);
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::ElevationAt(
-    Eigen::Ref<Eigen::ArrayXXd> h)
-  {
-    impl_->ElevationAt(h);
-  }
+  double a  = k * (x * cd + y * sd) - wt;
+  double ca = std::cos(a);
+  double h1 = amplitude_ * ca;
+  double p1 = e * h1;
+  pressure = p1;
+}
 
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::ElevationDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> dhdx,
-    Eigen::Ref<Eigen::ArrayXXd> dhdy)
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::Pressure(
+  const Eigen::Ref<const Eigen::ArrayXd>& x,
+  const Eigen::Ref<const Eigen::ArrayXd>& y,
+  const Eigen::Ref<const Eigen::ArrayXd>& z,
+  Eigen::Ref<Eigen::ArrayXd> pressure)
+{
+  auto xit = x.cbegin();
+  auto yit = y.cbegin();
+  auto zit = z.cbegin();
+  auto pit = pressure.begin();
+  for ( ; xit != x.cend() && yit != y.cend() && pit != pressure.end();
+    ++xit, ++yit, ++zit, ++pit)
   {
-    impl_->ElevationDerivAt(dhdx, dhdy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::DisplacementAt(
-    Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*sy*/)
-  {
-    // No xy-displacement
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::DisplacementDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
-  {
-    // No xy-displacement
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::DisplacementAndDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> h,
-    Eigen::Ref<Eigen::ArrayXXd> sx,
-    Eigen::Ref<Eigen::ArrayXXd> sy,
-    Eigen::Ref<Eigen::ArrayXXd> dhdx,
-    Eigen::Ref<Eigen::ArrayXXd> dhdy,
-    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-    Eigen::Ref<Eigen::ArrayXXd> dsydy,
-    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-  {
-    // impl_->DisplacementAndDerivAt(
-    //     h, sx, sy, dhdx, dhdy, dsxdx, dsydy, dsxdy);
-
-    /// \todo undo flip of dhdx <---> dhdy once render plugin fixed
-    impl_->DisplacementAndDerivAt(
-        h, sx, sy, dhdy, dhdx, dsxdx, dsydy, dsxdy);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::ElevationAt(
-    Index ix, Index iy,
-    double &eta)
-  {
-    impl_->ElevationAt(ix, iy, eta);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::DisplacementAt(
-    Index /*ix*/, Index /*iy*/,
-    double &/*sx*/, double &/*sy*/)
-  {
-    // No xy-displacement
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::PressureAt(
-    Index ix, Index iy, Index iz,
-    double &pressure)
-  {
-    impl_->PressureAt(ix, iy, iz, pressure);
-  }
-
-  //////////////////////////////////////////////////
-  void LinearRegularWaveSimulation::PressureAt(
-    Index iz,
-    Eigen::Ref<Eigen::ArrayXXd> pressure)
-  {
-    impl_->PressureAt(iz, pressure);
+    Pressure(*xit, *yit, *zit, *pit);
   }
 }
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::ElevationAt(
+  Eigen::Ref<Eigen::ArrayXXd> h)
+{
+  // derived wave properties
+  double w, wt, k, cd, sd;
+  PreComputeCoeff(
+    period_, time_, wave_angle_, w, wt, k, cd, sd);
+
+  if (use_vectorised_)
+  {
+    Eigen::ArrayXXd a = k * (x_grid_ * cd
+        + y_grid_ * sd) - wt;
+    Eigen::ArrayXXd ca = Eigen::cos(a);
+    Eigen::ArrayXXd h1 = amplitude_ * ca;
+    h = h1.reshaped();
+  } else {
+    for (Index iy=0, idx=0; iy < ny_; ++iy)
+    {
+      double y = iy * dy_ + ly_min_;
+      for (Index ix=0; ix < nx_; ++ix, ++idx)
+      {
+        double x = ix * dx_ + lx_min_;
+        double a  = k * (x * cd + y * sd) - wt;
+        double ca = std::cos(a);
+        double h1 = amplitude_ * ca;
+        h(idx, 0) = h1;
+      }
+    }
+  }
 }
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::ElevationDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> dhdx,
+  Eigen::Ref<Eigen::ArrayXXd> dhdy)
+{
+  // derived wave properties
+  double w, wt, k, cd, sd;
+  PreComputeCoeff(
+    period_, time_, wave_angle_, w, wt, k, cd, sd);
+
+  double dadx = k * cd;
+  double dady = k * sd;
+
+  if (use_vectorised_)
+  {
+    Eigen::ArrayXXd a = k * (x_grid_ * cd
+        + y_grid_ * sd) - wt;
+    Eigen::ArrayXXd sa = Eigen::sin(a);
+    Eigen::ArrayXXd dhdx1 = - dadx * amplitude_ * sa;
+    Eigen::ArrayXXd dhdy1 = - dady * amplitude_ * sa;
+    dhdx = dhdx1.reshaped();
+    dhdy = dhdy1.reshaped();
+  } else {
+    for (Index iy=0, idx=0; iy < ny_; ++iy)
+    {
+      double y = iy * dy_ + ly_min_;
+      for (Index ix=0; ix < nx_; ++ix, ++idx)
+      {
+        double x = ix * dx_ + lx_min_;
+        double a  = k * (x * cd + y * sd) - wt;
+        double sa = std::sin(a);
+        double dhdx1 = - dadx * amplitude_ * sa;
+        double dhdy1 = - dady * amplitude_ * sa;
+        dhdx(idx, 0) = dhdx1;
+        dhdy(idx, 0) = dhdy1;
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::DisplacementAndDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> h,
+  Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
+  Eigen::Ref<Eigen::ArrayXXd> /*sy*/,
+  Eigen::Ref<Eigen::ArrayXXd> dhdx,
+  Eigen::Ref<Eigen::ArrayXXd> dhdy,
+  Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
+  Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
+  Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+{
+  // derived wave properties
+  double w, wt, k, cd, sd;
+  PreComputeCoeff(
+    period_, time_, wave_angle_, w, wt, k, cd, sd);
+
+  double dadx = k * cd;
+  double dady = k * sd;
+
+  if (use_vectorised_)
+  {
+    Eigen::ArrayXXd a = k * (x_grid_ * cd
+        + y_grid_ * sd) - wt;
+    Eigen::ArrayXXd ca = Eigen::cos(a);
+    Eigen::ArrayXXd sa = Eigen::sin(a);
+    Eigen::ArrayXXd h1 = amplitude_ * ca;
+    Eigen::ArrayXXd dhdx1 = - dadx * amplitude_ * sa;
+    Eigen::ArrayXXd dhdy1 = - dady * amplitude_ * sa;
+    h = h1.reshaped();
+    dhdx = dhdx1.reshaped();
+    dhdy = dhdy1.reshaped();
+  } else {
+    for (Index iy=0, idx=0; iy < ny_; ++iy)
+    {
+      double y = iy * dy_ + ly_min_;
+      for (Index ix=0; ix < nx_; ++ix, ++idx)
+      {
+        double x = ix * dx_ + lx_min_;
+        double a  = k * (x * cd + y * sd) - wt;
+        double ca = std::cos(a);
+        double sa = std::sin(a);
+        double h1 = amplitude_ * ca;
+        double dhdx1 = - dadx * amplitude_ * sa;
+        double dhdy1 = - dady * amplitude_ * sa;
+        h(idx, 0) = h1;
+        dhdx(idx, 0) = dhdx1;
+        dhdy(idx, 0) = dhdy1;
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::ElevationAt(
+    Index ix, Index iy, double& h)
+{
+  double x = ix * dx_ + lx_min_;
+  double y = iy * dy_ + ly_min_;
+  Elevation(x, y, h);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::PressureAt(
+  Index ix, Index iy, Index iz,
+  double& pressure)
+{
+  double x = ix * dx_ + lx_min_;
+  double y = iy * dy_ + ly_min_;
+  double z = z_(iz);
+  Pressure(x, y, z, pressure);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Impl::PressureAt(
+  Index iz,
+  Eigen::Ref<Eigen::ArrayXXd> pressure)
+{
+  // derived wave properties
+  double w, wt, k, cd, sd;
+  PreComputeCoeff(
+    period_, time_, wave_angle_, w, wt, k, cd, sd);
+
+  // value of z at index iz
+  double z = z_(iz);
+
+  // linear wave deep water pressure scaling factor
+  double e = std::exp(k * z);
+
+  if (use_vectorised_)
+  {
+    Eigen::ArrayXXd a = k * (x_grid_ * cd
+        + y_grid_ * sd) - wt;
+    Eigen::ArrayXXd ca = Eigen::cos(a);
+    Eigen::ArrayXXd p  = e * amplitude_ * ca;
+    pressure = p.reshaped();
+  } else {
+    for (Index iy=0, idx=0; iy < ny_; ++iy)
+    {
+      double y = iy * dy_ + ly_min_;
+      for (Index ix=0; ix < nx_; ++ix, ++idx)
+      {
+        double x = ix * dx_ + lx_min_;
+        double a  = k * (x * cd + y * sd) - wt;
+        double ca = std::cos(a);
+        double h1 = amplitude_ * ca;
+        double p = e * h1;
+        pressure(idx, 0) = p;
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+LinearRegularWaveSimulation::~LinearRegularWaveSimulation()
+{
+}
+
+//////////////////////////////////////////////////
+LinearRegularWaveSimulation::LinearRegularWaveSimulation(
+    double lx, double ly, Index nx, Index ny) :
+  impl_(new LinearRegularWaveSimulation::Impl(lx, ly, nx, ny))
+{
+}
+
+//////////////////////////////////////////////////
+LinearRegularWaveSimulation::LinearRegularWaveSimulation(
+    double lx, double ly, double lz, Index nx, Index ny, Index nz) :
+  impl_(new LinearRegularWaveSimulation::Impl(lx, ly, lz, nx, ny, nz))
+{
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::SetUseVectorised(bool value)
+{
+  impl_->SetUseVectorised(value);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::SetDirection(double dir_x, double dir_y)
+{
+  impl_->SetDirection(dir_x, dir_y);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::SetAmplitude(double value)
+{
+  impl_->SetAmplitude(value);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::SetPeriod(double value)
+{
+  impl_->SetPeriod(value);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::SetWindVelocity(double ux, double uy)
+{
+  impl_->SetWindVelocity(ux, uy);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::SetTime(double value)
+{
+  impl_->SetTime(value);
+}
+
+//////////////////////////////////////////////////
+Index LinearRegularWaveSimulation::SizeX() const
+{
+  return impl_->nx_;
+}
+
+//////////////////////////////////////////////////
+Index LinearRegularWaveSimulation::SizeY() const
+{
+  return impl_->ny_;
+}
+
+//////////////////////////////////////////////////
+Index LinearRegularWaveSimulation::SizeZ() const
+{
+  return impl_->nz_;
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Elevation(
+  double x, double y,
+  double &eta)
+{
+  impl_->Elevation(x, y, eta);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Elevation(
+  const Eigen::Ref<const Eigen::ArrayXd>& x,
+  const Eigen::Ref<const Eigen::ArrayXd>& y,
+  Eigen::Ref<Eigen::ArrayXd> eta)
+{
+  impl_->Elevation(x, y, eta);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Pressure(
+  double x, double y, double z,
+  double& pressure)
+{
+  impl_->Pressure(x, y, z, pressure);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::Pressure(
+  const Eigen::Ref<const Eigen::ArrayXd>& x,
+  const Eigen::Ref<const Eigen::ArrayXd>& y,
+  const Eigen::Ref<const Eigen::ArrayXd>& z,
+  Eigen::Ref<Eigen::ArrayXd> pressure)
+{
+  impl_->Pressure(x, y, z, pressure);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::ElevationAt(
+  Eigen::Ref<Eigen::ArrayXXd> h)
+{
+  impl_->ElevationAt(h);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::ElevationDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> dhdx,
+  Eigen::Ref<Eigen::ArrayXXd> dhdy)
+{
+  impl_->ElevationDerivAt(dhdx, dhdy);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::DisplacementAt(
+  Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
+  Eigen::Ref<Eigen::ArrayXXd> /*sy*/)
+{
+  // No xy-displacement
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::DisplacementDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
+  Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
+  Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+{
+  // No xy-displacement
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::DisplacementAndDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> h,
+  Eigen::Ref<Eigen::ArrayXXd> sx,
+  Eigen::Ref<Eigen::ArrayXXd> sy,
+  Eigen::Ref<Eigen::ArrayXXd> dhdx,
+  Eigen::Ref<Eigen::ArrayXXd> dhdy,
+  Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+  Eigen::Ref<Eigen::ArrayXXd> dsydy,
+  Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+{
+  // impl_->DisplacementAndDerivAt(
+  //     h, sx, sy, dhdx, dhdy, dsxdx, dsydy, dsxdy);
+
+  /// \todo undo flip of dhdx <---> dhdy once render plugin fixed
+  impl_->DisplacementAndDerivAt(
+      h, sx, sy, dhdy, dhdx, dsxdx, dsydy, dsxdy);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::ElevationAt(
+  Index ix, Index iy,
+  double& eta)
+{
+  impl_->ElevationAt(ix, iy, eta);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::DisplacementAt(
+  Index /*ix*/, Index /*iy*/,
+  double& /*sx*/, double& /*sy*/)
+{
+  // No xy-displacement
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::PressureAt(
+  Index ix, Index iy, Index iz,
+  double& pressure)
+{
+  impl_->PressureAt(ix, iy, iz, pressure);
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::PressureAt(
+  Index iz,
+  Eigen::Ref<Eigen::ArrayXXd> pressure)
+{
+  impl_->PressureAt(iz, pressure);
+}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/LinearRegularWaveSimulation_TEST.cc
+++ b/gz-waves/src/LinearRegularWaveSimulation_TEST.cc
@@ -21,6 +21,7 @@
 #include "gz/waves/WaveSimulation.hh"
 #include "gz/waves/LinearRegularWaveSimulation.hh"
 #include "gz/waves/TrochoidIrregularWaveSimulation.hh"
+#include "gz/waves/Types.hh"
 #include "gz/waves/WaveSpectrum.hh"
 
 #include <Eigen/Dense>
@@ -494,7 +495,7 @@ TEST(OceanTile, LinearRegularWaveSimulation)
     for (Index ix=0; ix<NPlus1; ++ix)
     {
       double vx = ix * dl + lm;
-      size_t idx = iy * NPlus1 + ix;
+      Index idx = iy * NPlus1 + ix;
       auto& v = oceanTile->Vertices()[idx];
       EXPECT_DOUBLE_EQ(v.x, vx);
       EXPECT_DOUBLE_EQ(v.y, vy);
@@ -515,7 +516,7 @@ TEST(OceanTile, LinearRegularWaveSimulation)
     for (Index ix=0; ix<NPlus1; ++ix)
     {
       double vx = ix * dl + lm;
-      size_t idx = iy * NPlus1 + ix;
+      Index idx = iy * NPlus1 + ix;
       auto& v = oceanTile->Vertices()[idx];
 
       // @TODO: DISABLED - not working, requires investigation.

--- a/gz-waves/src/MeshTools.cc
+++ b/gz-waves/src/MeshTools.cc
@@ -14,115 +14,115 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/MeshTools.hh"
-#include "gz/waves/CGALTypes.hh"
-
-#include <gz/common.hh>
-#include <gz/math.hh>
 
 #include <array>
 #include <iostream>
 #include <iterator>
 #include <string>
 
+#include <gz/common.hh>
+#include <gz/math.hh>
+
+#include "gz/waves/CGALTypes.hh"
+
 namespace gz
 {
 namespace waves
 {
-///////////////////////////////////////////////////////////////////////////////
-// MeshTools
 
-  /// Vertex and Index conventions used by gz::common::Mesh 
-  ///
-  /// Mesh::GetVertexCount()
-  ///   returns the number of vertices in the mesh, which means that
-  ///   the size of _vertices will be 3 * Mesh::GetVertexCount()
-  ///
-  /// Mesh::GetIndexCount()
-  ///   returns the number of indices in the mesh, which means that
-  ///   the size of _indices will be Mesh::GetIndexCount()
-  ///
-  void MeshTools::FillArrays(
-    const gz::common::Mesh& _source,
-    std::vector<float>& _vertices,
-    std::vector<int>& _indices
-  )
-  {    
-    double *vertices = nullptr;
-    int   *indices  = nullptr;
+//////////////////////////////////////////////////
+/// Vertex and Index conventions used by gz::common::Mesh
+///
+/// Mesh::GetVertexCount()
+///   returns the number of vertices in the mesh, which means that
+///   the size of _vertices will be 3 * Mesh::GetVertexCount()
+///
+/// Mesh::GetIndexCount()
+///   returns the number of indices in the mesh, which means that
+///   the size of _indices will be Mesh::GetIndexCount()
+///
+void MeshTools::FillArrays(
+  const gz::common::Mesh& _source,
+  std::vector<float>& _vertices,
+  std::vector<int>& _indices
+)
+{
+  double *vertices = nullptr;
+  int   *indices  = nullptr;
 
-    // No leaks...
-    try
-    {
-      size_t nv = _source.VertexCount();
-      size_t ni = _source.IndexCount();
-
-      // @DEBUG_INFO
-      // gzmsg << "nv: " << nv << std::endl; 
-      // gzmsg << "ni: " << ni << std::endl; 
-
-      _source.FillArrays(&vertices, &indices);
-      
-      _vertices.insert(_vertices.end(), vertices, vertices + 3 * nv);
-      _indices.insert(_indices.end(), indices, indices + ni);
-    }
-    catch(...) 
-    {
-      gzerr << "Unknown Error in Mesh::FillArrays" << std::endl;
-    }
-    // Clean up
-    if (vertices)
-      delete[] vertices;
-    if (indices)
-      delete[] indices;
-  }
-
-  void MeshTools::MakeSurfaceMesh(const gz::common::Mesh& _source, cgal::Mesh& _target)
+  // No leaks...
+  try
   {
-    std::vector<float> vertices;
-    std::vector<int>   indices;
+    size_t nv = _source.VertexCount();
+    size_t ni = _source.IndexCount();
 
-    FillArrays(_source, vertices, indices);
+    // @DEBUG_INFO
+    // gzmsg << "nv: " << nv << std::endl;
+    // gzmsg << "ni: " << ni << std::endl;
 
-    // Vertices
-    for (size_t i=0; i<vertices.size(); )
-    {
-      auto&& v0 = vertices[i++];
-      auto&& v1 = vertices[i++];
-      auto&& v2 = vertices[i++];
-      cgal::Point3 p(v0, v1, v2);
-      
-      // @DEBUG_INFO
-      //auto& v = 
-      _target.add_vertex(p);
-      // gzmsg << v << ": " << _target.point(v) << std::endl; 
-    }
+    _source.FillArrays(&vertices, &indices);
 
-    // Faces
-    for (size_t i=0; i<indices.size(); )
-    {
-      // @DEBUG_INFO
-      // gzmsg << "face" << i/3 << std::endl; 
+    _vertices.insert(_vertices.end(), vertices, vertices + 3 * nv);
+    _indices.insert(_indices.end(), indices, indices + ni);
+  }
+  catch(...)
+  {
+    gzerr << "Unknown Error in Mesh::FillArrays" << std::endl;
+  }
+  // Clean up
+  if (vertices)
+    delete[] vertices;
+  if (indices)
+    delete[] indices;
+}
 
-      auto v0 = _target.vertices().begin();
-      auto v1 = _target.vertices().begin(); 
-      auto v2 = _target.vertices().begin();
-      auto i0 = indices[i++];
-      auto i1 = indices[i++];
-      auto i2 = indices[i++];
-      std::advance(v0, i0);
-      std::advance(v1, i1);
-      std::advance(v2, i2);
-      _target.add_face(*v0, *v1, *v2);  
+//////////////////////////////////////////////////
+void MeshTools::MakeSurfaceMesh(const gz::common::Mesh& _source,
+    cgal::Mesh& _target)
+{
+  std::vector<float> vertices;
+  std::vector<int>   indices;
 
-      // @DEBUG_INFO
-      // gzmsg << i0 << ", " << i1 << ", " << i2 << std::endl; 
-      // gzmsg << *v0 << ": " << _target.point(*v0) << std::endl; 
-      // gzmsg << *v1 << ": " << _target.point(*v1) << std::endl; 
-      // gzmsg << *v2 << ": " << _target.point(*v2) << std::endl; 
-    }
+  FillArrays(_source, vertices, indices);
+
+  // Vertices
+  for (size_t i=0; i < vertices.size(); )
+  {
+    auto&& v0 = vertices[i++];
+    auto&& v1 = vertices[i++];
+    auto&& v2 = vertices[i++];
+    cgal::Point3 p(v0, v1, v2);
+
+    // @DEBUG_INFO
+    // auto& v =
+    _target.add_vertex(p);
+    // gzmsg << v << ": " << _target.point(v) << std::endl;
   }
 
-///////////////////////////////////////////////////////////////////////////////
+  // Faces
+  for (size_t i=0; i < indices.size(); )
+  {
+    // @DEBUG_INFO
+    // gzmsg << "face" << i/3 << std::endl;
 
+    auto v0 = _target.vertices().begin();
+    auto v1 = _target.vertices().begin();
+    auto v2 = _target.vertices().begin();
+    auto i0 = indices[i++];
+    auto i1 = indices[i++];
+    auto i2 = indices[i++];
+    std::advance(v0, i0);
+    std::advance(v1, i1);
+    std::advance(v2, i2);
+    _target.add_face(*v0, *v1, *v2);
+
+    // @DEBUG_INFO
+    // gzmsg << i0 << ", " << i1 << ", " << i2 << std::endl;
+    // gzmsg << *v0 << ": " << _target.point(*v0) << std::endl;
+    // gzmsg << *v1 << ": " << _target.point(*v1) << std::endl;
+    // gzmsg << *v2 << ": " << _target.point(*v2) << std::endl;
+  }
 }
-}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/MeshTools_TEST.cc
+++ b/gz-waves/src/MeshTools_TEST.cc
@@ -13,6 +13,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <CGAL/Timer.h>
+
+#include <iostream>
+#include <string>
+
+#include <gz/common.hh>
+#include <gz/common/Util.hh>
+#include <gz/common/MeshManager.hh>
+#include <gz/common/Mesh.hh>
+#include <gz/common/SubMesh.hh>
+
 #include "gz/waves/MeshTools.hh"
 #include "gz/waves/Convert.hh"
 #include "gz/waves/Geometry.hh"
@@ -21,25 +32,21 @@
 #include "gz/waves/WaveParameters.hh"
 #include "gz/waves/CGALTypes.hh"
 
-#include <CGAL/Timer.h>
-
-#include <gz/common.hh>
-#include <gz/common/Util.hh>
-#include <gz/common/MeshManager.hh>
-#include <gz/common/Mesh.hh>
-#include <gz/common/SubMesh.hh>
-
-#include <iostream>
-#include <string>
-
-using namespace gz;
-using namespace waves;
-
 typedef CGAL::Timer Timer;
 
-///////////////////////////////////////////////////////////////////////////////
-// Define tests
+namespace cgal
+{
+using gz::cgal::Mesh;
+using gz::cgal::Triangle;
+using gz::cgal::Vector3;
+}  // namespace cgal
 
+using gz::waves::Geometry;
+using gz::waves::Grid;
+using gz::waves::MeshTools;
+using gz::waves::ToGz;
+
+//////////////////////////////////////////////////
 void TestFillArraysUnitBox()
 {
   std::cout << "TestFillArraysUnitBox..." << std::endl;
@@ -50,7 +57,7 @@ void TestFillArraysUnitBox()
     meshName,
     gz::math::Vector3d(1, 1, 1),
     gz::math::Vector2d(1, 1));
-  
+
   cgal::Mesh mesh;
   std::vector<float> vertices;
   std::vector<int> indices;
@@ -66,10 +73,10 @@ void TestFillArraysUnitBox()
   // for (auto&& i : indices)
   //   std::cout << i << std::endl;
 
-  // Vertices: 6 sides, 4 points per side, 3 coordinates per point  
+  // Vertices: 6 sides, 4 points per side, 3 coordinates per point
   std::cout << "test: " << vertices.size() << std::endl;
   std::cout << "chck: " << 6*4*3 << std::endl;
-  
+
   // Indices: 6 sides, 2 faces per side, 3 vertices per face
   std::cout << "test: " << indices.size() << std::endl;
   std::cout << "chck: " << 6*2*3 << std::endl;
@@ -85,7 +92,7 @@ void TestMakeSurfaceMeshUnitBox()
     meshName,
     gz::math::Vector3d(1, 1, 1),
     gz::math::Vector2d(1, 1));
-  
+
   cgal::Mesh mesh;
   MeshTools::MakeSurfaceMesh(
     *gz::common::MeshManager::Instance()->MeshByName(meshName),
@@ -105,13 +112,15 @@ void TestMakeSurfaceMeshUnitBox()
   // }
 }
 
-#if 0 // DEPRECATED FEATURE
+//////////////////////////////////////////////////
+#if 0  // DEPRECATED FEATURE
 void TestExportWaveMesh()
 {
   std::cout << "TestExportWaveMesh..." << std::endl;
 
   // Wave parameters
-  std::shared_ptr<WaveParameters> waveParams = std::make_shared<WaveParameters>();
+  std::shared_ptr<WaveParameters> waveParams =
+      std::make_shared<WaveParameters>();
   waveParams->SetNumber(1);
   waveParams->SetAmplitude(2.0);
   waveParams->SetPeriod(10.0);
@@ -133,9 +142,9 @@ void TestExportWaveMesh()
   std::shared_ptr<gz::common::Mesh> gzMesh(new gz::common::Mesh());
   gzMesh->SetName(name);
 
-  std::unique_ptr<gz::common::SubMesh> gzSubMesh(new gz::common::SubMesh());  
-  unsigned long iv = 0;
-  for(auto&& face : mesh.faces())
+  std::unique_ptr<gz::common::SubMesh> gzSubMesh(new gz::common::SubMesh());
+  int64_t iv = 0;
+  for (auto&& face : mesh.faces())
   {
     cgal::Triangle tri  = Geometry::MakeTriangle(mesh, face);
     cgal::Vector3 normal = Geometry::Normal(tri);
@@ -160,7 +169,7 @@ void TestExportWaveMesh()
   }
 
   gzMesh->AddSubMesh(*gzSubMesh);
-  
+
   t.stop();
   std::cout << "MakeGzMesh: " << t.time() << " sec" << std::endl;
 
@@ -170,15 +179,15 @@ void TestExportWaveMesh()
     gzMesh.get(),
     "/Users/rhys/Code/ros/asv_ws/tmp/wavefield",
     "dae");
-
 }
 #endif
 
+//////////////////////////////////////////////////
 void TestExportGridMesh()
 {
   std::cout << "TestExportGridMesh..." << std::endl;
 
-  // Wavefield 
+  // Wavefield
   Grid grid({500, 500}, {100, 100});
 
   // Get Mesh
@@ -192,9 +201,9 @@ void TestExportGridMesh()
   std::shared_ptr<gz::common::Mesh> gzMesh(new gz::common::Mesh());
   gzMesh->SetName(name);
 
-  std::unique_ptr<gz::common::SubMesh> gzSubMesh(new gz::common::SubMesh());  
-  unsigned long iv = 0;
-  for(auto&& face : mesh.faces())
+  std::unique_ptr<gz::common::SubMesh> gzSubMesh(new gz::common::SubMesh());
+  int64_t iv = 0;
+  for (auto&& face : mesh.faces())
   {
     cgal::Triangle tri  = Geometry::MakeTriangle(mesh, face);
     cgal::Vector3 normal = Geometry::Normal(tri);
@@ -219,7 +228,7 @@ void TestExportGridMesh()
   }
 
   gzMesh->AddSubMesh(*gzSubMesh);
-  
+
   t.stop();
   std::cout << "MakeGzMesh: " << t.time() << " sec" << std::endl;
 
@@ -229,11 +238,9 @@ void TestExportGridMesh()
     gzMesh.get(),
     std::string("/Users/rhys/Code/ros/asv_ws/tmp/").append(name),
     "dae");
-
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Run tests
+//////////////////////////////////////////////////
 void RunMeshToolsTests()
 {
   TestFillArraysUnitBox();
@@ -241,4 +248,3 @@ void RunMeshToolsTests()
   // TestExportWaveMesh();
   // TestExportGridMesh();
 }
-

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -160,8 +160,8 @@ public:
   /// \param v_idx  is the index for the (nx + 1) x (nx + 1) mesh vertices,
   ///               including skirt
   /// \param w_idx  is the index for the nx x nx simulated vertices
-  void UpdateVertex(size_t v_idx, size_t w_idx);
-  void UpdateVertexAndTangents(size_t v_idx, size_t w_idx);
+  void UpdateVertex(Index v_idx, Index w_idx);
+  void UpdateVertexAndTangents(Index v_idx, Index w_idx);
   void UpdateVertices(double time);
 
   gz::common::Mesh * CreateMesh(const std::string &name, double offset_z,
@@ -265,7 +265,7 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
     tile_size_(params->TileSize()),
     spacing_(params->TileSize() / static_cast<double>(params->CellCount()))
 {
-  size_t nx = params->CellCount();
+  Index nx = params->CellCount();
   double lx = params->TileSize();
 
   auto size = nx * nx;
@@ -376,8 +376,8 @@ void OceanTilePrivate<Vector3>::Create()
   gzmsg << "Spacing:       " << spacing_     << "\n";
 
   // Grid dimensions
-  const size_t nx = nx_;
-  const size_t ny = nx_;
+  const Index nx = nx_;
+  const Index ny = nx_;
   const double lx = tile_size_;
   const double ly = tile_size_;
   const double dx = spacing_;
@@ -393,10 +393,10 @@ void OceanTilePrivate<Vector3>::Create()
 
   gzmsg << "OceanTile: calculating vertices\n";
   // Vertices - (nx+1) vertices in each row / column
-  for (size_t iy=0; iy<=ny; ++iy)
+  for (Index iy=0; iy<=ny; ++iy)
   {
     double py = iy * dy - ly/2.0;
-    for (size_t ix=0; ix<=nx; ++ix)
+    for (Index ix=0; ix<=nx; ++ix)
     {
       // Vertex position
       double px = ix * dx - lx/2.0;
@@ -412,15 +412,15 @@ void OceanTilePrivate<Vector3>::Create()
 
   gzmsg << "OceanTile: calculating indices\n";
   // Indices
-  for (size_t iy=0; iy<ny; ++iy)
+  for (Index iy=0; iy<ny; ++iy)
   {
-    for (size_t ix=0; ix<nx; ++ix)
+    for (Index ix=0; ix<nx; ++ix)
     {
       // Get the vertices in the cell coordinates
-      const size_t idx0 = iy * (nx+1) + ix;
-      const size_t idx1 = iy * (nx+1) + ix + 1;
-      const size_t idx2 = (iy+1) * (nx+1) + ix + 1;
-      const size_t idx3 = (iy+1) * (nx+1) + ix;
+      const Index idx0 = iy * (nx+1) + ix;
+      const Index idx1 = iy * (nx+1) + ix + 1;
+      const Index idx2 = (iy+1) * (nx+1) + ix + 1;
+      const Index idx3 = (iy+1) * (nx+1) + ix;
 
       // Indices
       faces_.push_back(gz::math::Vector3i(idx0, idx1, idx2));
@@ -464,7 +464,7 @@ void OceanTilePrivate<gz::math::Vector3d>::ComputeNormals()
   normals_.assign(vertices_.size(), gz::math::Vector3d::Zero);
 
   // 1. For each face calculate the normal and add to each vertex in the face
-  for (size_t i=0; i<num_faces_; ++i)
+  for (Index i=0; i<num_faces_; ++i)
   {
     // Vertices
     auto v0_idx = faces_[i][0];
@@ -510,7 +510,7 @@ void OceanTilePrivate<Vector3>::ComputeTangentSpace()
   ComputeTBN(vertices_, tex_coords_, faces_, tangents_, bitangents_, normals_);
 
 #if DEBUG
-  for (size_t i=0; i<std::min(static_cast<size_t>(20), vertices_.size()) ; ++i)
+  for (Index i=0; i<std::min(static_cast<Index>(20), vertices_.size()) ; ++i)
   {
     gzmsg << "V["  << i << "]:  "  << vertices_[i]   << "\n";
     gzmsg << "UV[" << i << "]: "   << tex_coords_[i] << "\n"
@@ -626,7 +626,7 @@ void OceanTilePrivate<gz::math::Vector3d>::ComputeTBN(
   } 
 
   // 2. Normalise each vertex's tangent space basis.
-  for (size_t i=0; i<vertices.size(); ++i)
+  for (Index i=0; i<vertices.size(); ++i)
   {
     tangents[i].Normalize();
     bitangents[i].Normalize();
@@ -667,7 +667,7 @@ void OceanTilePrivate<Vector3>::Update(double time)
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<gz::math::Vector3d>::UpdateVertex(
-  size_t v_idx, size_t w_idx)
+  Index v_idx, Index w_idx)
 {
   // 1. Update vertex
   double h  = heights_[w_idx];
@@ -683,7 +683,7 @@ void OceanTilePrivate<gz::math::Vector3d>::UpdateVertex(
 
 //////////////////////////////////////////////////
 template <>
-void OceanTilePrivate<cgal::Point3>::UpdateVertex(size_t v_idx, size_t w_idx)
+void OceanTilePrivate<cgal::Point3>::UpdateVertex(Index v_idx, Index w_idx)
 {
   // 1. Update vertex
   double h  = heights_[w_idx];
@@ -700,7 +700,7 @@ void OceanTilePrivate<cgal::Point3>::UpdateVertex(size_t v_idx, size_t w_idx)
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<gz::math::Vector3d>::UpdateVertexAndTangents(
-    size_t v_idx, size_t w_idx)
+    Index v_idx, Index w_idx)
 {
   // 1. Update vertex
   double h  = heights_[w_idx];
@@ -748,7 +748,7 @@ void OceanTilePrivate<gz::math::Vector3d>::UpdateVertexAndTangents(
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<cgal::Point3>::UpdateVertexAndTangents(
-    size_t v_idx, size_t w_idx)
+    Index v_idx, Index w_idx)
 {
   // 1. Update vertex
   // double h  = heights_[w_idx];
@@ -788,43 +788,43 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double time)
         heights_, sx_, sy_,
         dhdx_, dhdy_, dsxdx_, dsydy_, dsxdy_);
   
-    const size_t nx = nx_;
-    const size_t nx_plus1  = nx + 1;
+    const Index nx = nx_;
+    const Index nx_plus1  = nx + 1;
 
-    for (size_t iy=0; iy<nx; ++iy)
+    for (Index iy=0; iy<nx; ++iy)
     {
-      for (size_t ix=0; ix<nx; ++ix)
+      for (Index ix=0; ix<nx; ++ix)
       {
-        size_t v_idx_cm = iy * nx_plus1 + ix;
-        size_t w_idx_cm = iy * nx + ix;
-        // size_t w_idx_rm = ix * nx + iy;
+        Index v_idx_cm = iy * nx_plus1 + ix;
+        Index w_idx_cm = iy * nx + ix;
+        // Index w_idx_rm = ix * nx + iy;
         UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
       }
     }
 
     // Set skirt values assuming periodic boundary conditions:
-    for (size_t i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
       // Top row (iy = nx) periodic with bottom row (iy = 0)
       {
-        size_t v_idx_cm = nx * nx_plus1 + i;
-        size_t w_idx_cm = i;
-        // size_t w_idx_rm = i * nx;
+        Index v_idx_cm = nx * nx_plus1 + i;
+        Index w_idx_cm = i;
+        // Index w_idx_rm = i * nx;
         UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
       }
       // Right column (ix = nx) periodic with left column (ix = 0)
       {
-        size_t v_idx_cm = i * nx_plus1 + nx;
-        size_t w_idx_cm = i * nx;
-        // size_t w_idx_rm = i;
+        Index v_idx_cm = i * nx_plus1 + nx;
+        Index w_idx_cm = i * nx;
+        // Index w_idx_rm = i;
         UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
       }
     }
     {
       // Top right corner period with bottom right corner.
-      size_t v_idx_cm = nx_plus1 * nx_plus1 - 1;
-      size_t w_idx_cm = 0;
-      // size_t w_idx_rm = 0;
+      Index v_idx_cm = nx_plus1 * nx_plus1 - 1;
+      Index w_idx_cm = 0;
+      // Index w_idx_rm = 0;
       UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
     }  
   }
@@ -833,43 +833,43 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double time)
     wave_sim_->ElevationAt(heights_);
     wave_sim_->DisplacementAt(sx_, sy_);
 
-    const size_t nx = nx_;
-    const size_t nx_plus1  = nx + 1;
+    const Index nx = nx_;
+    const Index nx_plus1  = nx + 1;
 
-    for (size_t iy=0; iy<nx; ++iy)
+    for (Index iy=0; iy<nx; ++iy)
     {
-      for (size_t ix=0; ix<nx; ++ix)
+      for (Index ix=0; ix<nx; ++ix)
       {
-        size_t v_idx_cm = iy * nx_plus1 + ix;
-        size_t w_idx_cm = iy * nx + ix;
-        // size_t w_idx_rm = ix * nx + iy;
+        Index v_idx_cm = iy * nx_plus1 + ix;
+        Index w_idx_cm = iy * nx + ix;
+        // Index w_idx_rm = ix * nx + iy;
         UpdateVertex(v_idx_cm, w_idx_cm);
       }
     }
 
     // Set skirt values assuming periodic boundary conditions:
-    for (size_t i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
       // Top row (iy = nx) periodic with bottom row (iy = 0)
       {
-        size_t v_idx_cm = nx * nx_plus1 + i;
-        size_t w_idx_cm = i;
-        // size_t w_idx_rm = i * nx;
+        Index v_idx_cm = nx * nx_plus1 + i;
+        Index w_idx_cm = i;
+        // Index w_idx_rm = i * nx;
         UpdateVertex(v_idx_cm, w_idx_cm);
       }
       // Right column (ix = nx) periodic with left column (ix = 0)
       {
-        size_t v_idx_cm = i * nx_plus1 + nx;
-        size_t w_idx_cm = i * nx;
-        // size_t w_idx_rm = i;
+        Index v_idx_cm = i * nx_plus1 + nx;
+        Index w_idx_cm = i * nx;
+        // Index w_idx_rm = i;
         UpdateVertex(v_idx_cm, w_idx_cm);
       }
     }
     {
       // Top right corner period with bottom right corner.
-      size_t v_idx_cm = nx_plus1 * nx_plus1 - 1;
-      size_t w_idx_cm = 0;
-      // size_t w_idx_rm = 0;
+      Index v_idx_cm = nx_plus1 * nx_plus1 - 1;
+      Index w_idx_cm = 0;
+      // Index w_idx_rm = 0;
       UpdateVertex(v_idx_cm, w_idx_cm);
     }
   }
@@ -891,7 +891,7 @@ gz::common::Mesh* OceanTilePrivate<Vector3>::CreateMesh(
       new gz::common::SubMeshWithTangents());
 
   // Add position vertices
-  for (size_t i=0; i<vertices_.size(); ++i)
+  for (Index i=0; i<vertices_.size(); ++i)
   {
     submesh->AddVertex(
         vertices_[i][0],
@@ -916,7 +916,7 @@ gz::common::Mesh* OceanTilePrivate<Vector3>::CreateMesh(
   }
 
   // Add indices
-  for (size_t i=0; i<faces_.size(); ++i)
+  for (Index i=0; i<faces_.size(); ++i)
   {
     // Reverse orientation on faces
     if (reverse_orientation)
@@ -961,7 +961,7 @@ void OceanTilePrivate<gz::math::Vector3d>::UpdateMesh(
   }
 
   // Update positions, normals, texture coords etc.
-  for (size_t i=0; i<vertices_.size(); ++i)
+  for (Index i=0; i<vertices_.size(); ++i)
   {
     submesh->SetVertex(i, vertices_[i]);
     submesh->SetNormal(i, normals_[i]);

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -15,24 +15,26 @@
 
 #include "gz/waves/OceanTile.hh"
 
-#include "gz/common/SubMeshWithTangents.hh"
-#include "gz/waves/Geometry.hh"
-#include "gz/waves/WaveSimulation.hh"
-#include "gz/waves/LinearRandomFFTWaveSimulation.hh"
-#include "gz/waves/LinearRandomWaveSimulation.hh"
-#include "gz/waves/LinearRegularWaveSimulation.hh"
-#include "gz/waves/TrochoidIrregularWaveSimulation.hh"
-#include "gz/waves/WaveParameters.hh"
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include <Eigen/Dense>
 
 #include <gz/common.hh>
 #include <gz/common/Mesh.hh>
 #include <gz/common/SubMesh.hh>
 
-#include <Eigen/Dense>
+#include "gz/common/SubMeshWithTangents.hh"
+#include "gz/waves/Geometry.hh"
+#include "gz/waves/LinearRandomFFTWaveSimulation.hh"
+#include "gz/waves/LinearRandomWaveSimulation.hh"
+#include "gz/waves/LinearRegularWaveSimulation.hh"
+#include "gz/waves/TrochoidIrregularWaveSimulation.hh"
+#include "gz/waves/Types.hh"
+#include "gz/waves/WaveParameters.hh"
+#include "gz/waves/WaveSimulation.hh"
 
-#include <cmath>
-#include <iostream>
-#include <vector>
 
 using Eigen::ArrayXXd;
 using Eigen::ArrayXd;
@@ -55,6 +57,7 @@ namespace vector
   cgal::Point3 Zero<cgal::Point3> = cgal::Point3(0.0, 0.0, 0.0);
 }
 
+//////////////////////////////////////////////////
 template <typename Vector3>
 class OceanTilePrivate
 {
@@ -63,42 +66,42 @@ public:
   
   ~OceanTilePrivate();
 
-  OceanTilePrivate(unsigned int _N, double _L, bool _hasVisuals=true);
+  OceanTilePrivate(Index nx, double lx, bool has_visuals=true);
 
-  OceanTilePrivate(WaveParametersPtr _params, bool _hasVisuals=true);
+  OceanTilePrivate(WaveParametersPtr params, bool has_visuals=true);
 
-  void SetWindVelocity(double _ux, double _uy);
+  void SetWindVelocity(double ux, double uy);
 
-  bool                        mHasVisuals;
-  size_t                      mResolution;      /// \brief FFT size (N = 2^n)
-  size_t                      mRowLength;       /// \brief Number of vertices per row (N+1)
-  size_t                      mNumVertices;     /// \brief Total number of vertices (N+1)^2
-  size_t                      mNumFaces;        /// \brief Total number of faces 2 * N^2
-  double                      mTileSize;        /// \brief Tile size in world units
-  double                      mSpacing;         /// \brief Space between vertices
+  bool                        has_visuals_;
+  Index                       nx_;              /// \brief FFT size (nx is power of 2)
+  Index                       row_length_;      /// \brief Number of vertices per row (nx+1)
+  Index                       num_vertices_;    /// \brief Total number of vertices (nx+1)^2
+  Index                       num_faces_;       /// \brief Total number of faces 2 * nx^2
+  double                      tile_size_;       /// \brief Tile size in world units
+  double                      spacing_;         /// \brief Space between vertices
 
-  std::vector<Vector3>        mVertices0;
-  std::vector<Vector3>        mVertices;
-  std::vector<gz::math::Vector3i> mFaces;
+  std::vector<Vector3>        vertices0_;
+  std::vector<Vector3>        vertices_;
+  std::vector<gz::math::Vector3i> faces_;
 
-  std::vector<Vector3>        mTangents;
-  std::vector<gz::math::Vector2d> mTexCoords;
-  std::vector<Vector3>        mBitangents;
-  std::vector<Vector3>        mNormals;
+  std::vector<Vector3>        tangents_;
+  std::vector<gz::math::Vector2d> tex_coords_;
+  std::vector<Vector3>        bitangents_;
+  std::vector<Vector3>        normals_;
 
-  std::string                 mAboveOceanMeshName = "AboveOceanTileMesh";
-  std::string                 mBelowOceanMeshName = "BelowOceanTileMesh";
+  std::string                 above_ocean_mesh_name_ = "AboveOceanTileMesh";
+  std::string                 below_ocean_mesh_name_ = "BelowOceanTileMesh";
 
-  std::unique_ptr<IWaveSimulation> mWaveSim;
+  std::unique_ptr<IWaveSimulation> wave_sim_;
 
-  Eigen::ArrayXd             mHeights;
-  Eigen::ArrayXd             mDhdx;
-  Eigen::ArrayXd             mDhdy;
-  Eigen::ArrayXd             mDisplacementsX;
-  Eigen::ArrayXd             mDisplacementsY;
-  Eigen::ArrayXd             mDxdx;
-  Eigen::ArrayXd             mDydy;
-  Eigen::ArrayXd             mDxdy;
+  Eigen::ArrayXd             heights_;  // height
+  Eigen::ArrayXd             dhdx_;     // height deriv
+  Eigen::ArrayXd             dhdy_;     // height deriv
+  Eigen::ArrayXd             sx_;       // x displacement
+  Eigen::ArrayXd             sy_;       // y displacement
+  Eigen::ArrayXd             dsxdx_;
+  Eigen::ArrayXd             dsydy_;
+  Eigen::ArrayXd             dsxdy_;
 
   void Create();
 
@@ -114,7 +117,7 @@ public:
   // (u, v) = (1, 1) at the bottom right 
   // The tangent space basis calculation is adjusted to 
   // conform with this convention.
-  gz::common::Mesh * CreateMesh();
+  gz::common::Mesh* CreateMesh();
 
   void ComputeNormals();
 
@@ -132,39 +135,39 @@ public:
   // Lesson 8: Tangent Space: http://jerome.jouvie.free.fr/opengl-tutorials/Lesson8.php
   //
   static void ComputeTBN(
-      const Vector3& _p0, 
-      const Vector3& _p1, 
-      const Vector3& _p2, 
-      const gz::math::Vector2d& _uv0, 
-      const gz::math::Vector2d& _uv1, 
-      const gz::math::Vector2d& _uv2, 
-      Vector3& _tangent, 
-      Vector3& _bitangent, 
-      Vector3& _normal);
+      const Vector3 &p0,
+      const Vector3 &p1,
+      const Vector3 &p2,
+      const gz::math::Vector2d &uv0,
+      const gz::math::Vector2d &uv1,
+      const gz::math::Vector2d &uv2,
+      Vector3 &tangent,
+      Vector3 &bitangent,
+      Vector3 &normal);
 
   static void ComputeTBN(
-      const std::vector<Vector3>& _vertices,
-      const std::vector<gz::math::Vector2d>& _texCoords,
-      const std::vector<gz::math::Vector3i>& _faces, 
-      std::vector<Vector3>& _tangents,
-      std::vector<Vector3>& _bitangents,
-      std::vector<Vector3>& _normals);
+      const std::vector<Vector3> &vertices,
+      const std::vector<gz::math::Vector2d> &tex_coords,
+      const std::vector<gz::math::Vector3i> &faces,
+      std::vector<Vector3> &tangents,
+      std::vector<Vector3> &bitangents,
+      std::vector<Vector3> &normals);
 
-  void Update(double _time);
+  void Update(double time);
 
   /// \brief Update a vertex and it's tangent space.
   ///
-  /// \param idx0 is the index for the (N + 1) x (N + 1) mesh vertices,
-  ///             including skirt
-  /// \param idx1 is the index for the N x N simulated vertices
+  /// \param v_idx  is the index for the (nx + 1) x (nx + 1) mesh vertices,
+  ///               including skirt
+  /// \param w_idx  is the index for the nx x nx simulated vertices
   void UpdateVertex(size_t v_idx, size_t w_idx);
   void UpdateVertexAndTangents(size_t v_idx, size_t w_idx);
-  void UpdateVertices(double _time);
+  void UpdateVertices(double time);
 
-  gz::common::Mesh * CreateMesh(const std::string &_name, double _offsetZ,
-      bool _reverseOrientation);
+  gz::common::Mesh * CreateMesh(const std::string &name, double offset_z,
+      bool reverse_orientation);
 
-  void UpdateMesh(double _time, gz::common::Mesh *_mesh);
+  void UpdateMesh(double time, gz::common::Mesh *mesh);
 
 };
 
@@ -177,33 +180,33 @@ OceanTilePrivate<Vector3>::~OceanTilePrivate()
 //////////////////////////////////////////////////
 template <typename Vector3>
 OceanTilePrivate<Vector3>::OceanTilePrivate(
-    unsigned int _N,
-    double _L,
-    bool _hasVisuals) :
-    mHasVisuals(_hasVisuals),
-    mResolution(_N),
-    mRowLength(_N + 1),
-    mNumVertices((_N + 1) * (_N + 1)),
-    mNumFaces(2 * _N * _N),
-    mTileSize(_L),
-    mSpacing(_L / static_cast<double>(_N))
+    Index nx,
+    double lx,
+    bool has_visuals) :
+    has_visuals_(has_visuals),
+    nx_(nx),
+    row_length_(nx + 1),
+    num_vertices_((nx + 1) * (nx + 1)),
+    num_faces_(2 * nx * nx),
+    tile_size_(lx),
+    spacing_(lx / static_cast<double>(nx))
 {
-  auto size = _N * _N;
-  mHeights = Eigen::ArrayXd::Zero(size);
-  mDhdx = Eigen::ArrayXd::Zero(size);
-  mDhdy = Eigen::ArrayXd::Zero(size);
-  mDisplacementsX = Eigen::ArrayXd::Zero(size);
-  mDisplacementsY = Eigen::ArrayXd::Zero(size);
-  mDxdx = Eigen::ArrayXd::Zero(size);
-  mDydy = Eigen::ArrayXd::Zero(size);
-  mDxdy = Eigen::ArrayXd::Zero(size);
+  auto size = nx * nx;
+  heights_ = Eigen::ArrayXd::Zero(size);
+  dhdx_ = Eigen::ArrayXd::Zero(size);
+  dhdy_ = Eigen::ArrayXd::Zero(size);
+  sx_ = Eigen::ArrayXd::Zero(size);
+  sy_ = Eigen::ArrayXd::Zero(size);
+  dsxdx_ = Eigen::ArrayXd::Zero(size);
+  dsydy_ = Eigen::ArrayXd::Zero(size);
+  dsxdy_ = Eigen::ArrayXd::Zero(size);
 
   // Different types of wave simulator are supported...
   // 0 - LinearRegularWaveSimulation
   // 1 - TrochoidIrregularWaveSimulation
   // 2 - LinearRandomFFTWaveSimulation
 
-  const int wave_sim_type = 2;
+  Index wave_sim_type = 2;
   switch (wave_sim_type)
   {
     case 0:
@@ -213,35 +216,35 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
       double dir_y = 0.0;
       double amplitude = 3.0;
       double period = 10.0;
-      std::unique_ptr<LinearRegularWaveSimulation> waveSim(
-          new LinearRegularWaveSimulation(_L, _L, _N, _N));
-      waveSim->SetDirection(dir_x, dir_y);
-      waveSim->SetAmplitude(amplitude);
-      waveSim->SetPeriod(period);
-      mWaveSim = std::move(waveSim);
+      std::unique_ptr<LinearRegularWaveSimulation> wave_sim(
+          new LinearRegularWaveSimulation(lx, lx, nx, nx));
+      wave_sim->SetDirection(dir_x, dir_y);
+      wave_sim->SetAmplitude(amplitude);
+      wave_sim->SetPeriod(period);
+      wave_sim_ = std::move(wave_sim);
       break;
     }
     case 1:
     {
       // Trochoid
-      std::shared_ptr<WaveParameters> waveParams(new WaveParameters());
-      waveParams->SetNumber(3);
-      waveParams->SetAngle(0.6);
-      waveParams->SetScale(1.2);
-      waveParams->SetSteepness(1.0);
-      waveParams->SetAmplitude(3.0);
-      waveParams->SetPeriod(7.0);
-      waveParams->SetDirection(gz::math::Vector2d(1.0, 0.0));
-      mWaveSim.reset(new TrochoidIrregularWaveSimulation(_N, _L, waveParams));
+      std::shared_ptr<WaveParameters> wave_params(new WaveParameters());
+      wave_params->SetNumber(3);
+      wave_params->SetAngle(0.6);
+      wave_params->SetScale(1.2);
+      wave_params->SetSteepness(1.0);
+      wave_params->SetAmplitude(3.0);
+      wave_params->SetPeriod(7.0);
+      wave_params->SetDirection(gz::math::Vector2d(1.0, 0.0));
+      wave_sim_.reset(new TrochoidIrregularWaveSimulation(nx, lx, wave_params));
       break;
     }
     case 2:
     {
       // FFT2
-      std::unique_ptr<LinearRandomFFTWaveSimulation> waveSim(
-          new LinearRandomFFTWaveSimulation(_L, _L, _N, _N));
-      waveSim->SetLambda(1.0);   // larger lambda => steeper waves.
-      mWaveSim = std::move(waveSim);
+      std::unique_ptr<LinearRandomFFTWaveSimulation> wave_sim(
+          new LinearRandomFFTWaveSimulation(lx, lx, nx, nx));
+      wave_sim->SetLambda(1.0);   // larger lambda => steeper waves.
+      wave_sim_ = std::move(wave_sim);
       break;
     }
     default:
@@ -252,28 +255,28 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
 //////////////////////////////////////////////////
 template <typename Vector3>
 OceanTilePrivate<Vector3>::OceanTilePrivate(
-    WaveParametersPtr _params,
-    bool _hasVisuals) :
-    mHasVisuals(_hasVisuals),
-    mResolution(_params->CellCount()),
-    mRowLength(_params->CellCount() + 1),
-    mNumVertices((_params->CellCount() + 1) * (_params->CellCount() + 1)),
-    mNumFaces(2 * _params->CellCount() * _params->CellCount()),
-    mTileSize(_params->TileSize()),
-    mSpacing(_params->TileSize() / static_cast<double>(_params->CellCount()))
+    WaveParametersPtr params,
+    bool has_visuals) :
+    has_visuals_(has_visuals),
+    nx_(params->CellCount()),
+    row_length_(params->CellCount() + 1),
+    num_vertices_((params->CellCount() + 1) * (params->CellCount() + 1)),
+    num_faces_(2 * params->CellCount() * params->CellCount()),
+    tile_size_(params->TileSize()),
+    spacing_(params->TileSize() / static_cast<double>(params->CellCount()))
 {
-  size_t _N = _params->CellCount();
-  double _L = _params->TileSize();
+  size_t nx = params->CellCount();
+  double lx = params->TileSize();
 
-  auto size = _N * _N;
-  mHeights = Eigen::ArrayXd::Zero(size);
-  mDhdx = Eigen::ArrayXd::Zero(size);
-  mDhdy = Eigen::ArrayXd::Zero(size);
-  mDisplacementsX = Eigen::ArrayXd::Zero(size);
-  mDisplacementsY = Eigen::ArrayXd::Zero(size);
-  mDxdx = Eigen::ArrayXd::Zero(size);
-  mDydy = Eigen::ArrayXd::Zero(size);
-  mDxdy = Eigen::ArrayXd::Zero(size);
+  auto size = nx * nx;
+  heights_ = Eigen::ArrayXd::Zero(size);
+  dhdx_ = Eigen::ArrayXd::Zero(size);
+  dhdy_ = Eigen::ArrayXd::Zero(size);
+  sx_ = Eigen::ArrayXd::Zero(size);
+  sy_ = Eigen::ArrayXd::Zero(size);
+  dsxdx_ = Eigen::ArrayXd::Zero(size);
+  dsydy_ = Eigen::ArrayXd::Zero(size);
+  dsxdy_ = Eigen::ArrayXd::Zero(size);
 
   // Different types of wave simulator are supported...
   // 0 - LinearRegularWaveSimulation
@@ -281,29 +284,29 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
   // 2 - LinearRandomFFTWaveSimulation
   // 3 - LinearRandomWaveSimulation
 
-  int wave_sim_type = 0;
-  if (_params->Algorithm() == "sinusoid" ||
-      _params->Algorithm() == "linear_regular")
+  Index wave_sim_type = 0;
+  if (params->Algorithm() == "sinusoid" ||
+      params->Algorithm() == "linear_regular")
   {
     wave_sim_type = 0;
   }
-  else if (_params->Algorithm() == "trochoid")
+  else if (params->Algorithm() == "trochoid")
   {
     wave_sim_type = 1;
   }
-  else if (_params->Algorithm() == "fft" ||
-      _params->Algorithm() == "linear_random_fft")
+  else if (params->Algorithm() == "fft" ||
+      params->Algorithm() == "linear_random_fft")
   {
     wave_sim_type = 2;
   }
-  else if (_params->Algorithm() == "linear_random")
+  else if (params->Algorithm() == "linear_random")
   {
     wave_sim_type = 3;
   }
   else
   {
     gzerr << "Invalid wave algorithm type: "
-        << _params->Algorithm() << "\n";
+        << params->Algorithm() << "\n";
   }
 
   switch (wave_sim_type)
@@ -311,41 +314,41 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
     case 0:
     {
       // Linear Regular (Monochromatic)
-      double dir_x = _params->Direction().X();
-      double dir_y = _params->Direction().Y();
-      double amplitude = _params->Amplitude();
-      double period = _params->Period();
-      std::unique_ptr<LinearRegularWaveSimulation> waveSim(
-          new LinearRegularWaveSimulation(_L, _L, _N, _N));
-      waveSim->SetDirection(dir_x, dir_y);
-      waveSim->SetAmplitude(amplitude);
-      waveSim->SetPeriod(period);
-      mWaveSim = std::move(waveSim);
+      double dir_x = params->Direction().X();
+      double dir_y = params->Direction().Y();
+      double amplitude = params->Amplitude();
+      double period = params->Period();
+      std::unique_ptr<LinearRegularWaveSimulation> wave_sim(
+          new LinearRegularWaveSimulation(lx, lx, nx, nx));
+      wave_sim->SetDirection(dir_x, dir_y);
+      wave_sim->SetAmplitude(amplitude);
+      wave_sim->SetPeriod(period);
+      wave_sim_ = std::move(wave_sim);
       break;
     }
     case 1:
     {
       // Trochoid
-      mWaveSim.reset(new TrochoidIrregularWaveSimulation(_N, _L, _params));
+      wave_sim_.reset(new TrochoidIrregularWaveSimulation(nx, lx, params));
       break;
     }
     case 2:
     {
       // Linear Random FFT (ECKV / Cos2s)
-      std::unique_ptr<LinearRandomFFTWaveSimulation> waveSim(
-          new LinearRandomFFTWaveSimulation(_L, _L, _N, _N));
+      std::unique_ptr<LinearRandomFFTWaveSimulation> wave_sim(
+          new LinearRandomFFTWaveSimulation(lx, lx, nx, nx));
       
       // larger lambda => steeper waves.
-      waveSim->SetLambda(_params->Steepness());
-      mWaveSim = std::move(waveSim);
+      wave_sim->SetLambda(params->Steepness());
+      wave_sim_ = std::move(wave_sim);
       break;
     }
     case 3:
     {
       // Linear Random (Pierson-Moskowitz)
-      std::unique_ptr<LinearRandomWaveSimulation> waveSim(
-          new LinearRandomWaveSimulation(_L, _L, _N, _N));
-      mWaveSim = std::move(waveSim);
+      std::unique_ptr<LinearRandomWaveSimulation> wave_sim(
+          new LinearRandomWaveSimulation(lx, lx, nx, nx));
+      wave_sim_ = std::move(wave_sim);
       break;
     }
     default:
@@ -355,9 +358,9 @@ OceanTilePrivate<Vector3>::OceanTilePrivate(
 
 //////////////////////////////////////////////////
 template <typename Vector3>
-void OceanTilePrivate<Vector3>::SetWindVelocity(double _ux, double _uy)
+void OceanTilePrivate<Vector3>::SetWindVelocity(double ux, double uy)
 {
-  mWaveSim->SetWindVelocity(_ux, _uy);
+  wave_sim_->SetWindVelocity(ux, uy);
 }
 
 //////////////////////////////////////////////////
@@ -365,45 +368,45 @@ template <typename Vector3>
 void OceanTilePrivate<Vector3>::Create()
 {
   gzmsg << "OceanTile: create tile\n";
-  gzmsg << "Resolution:    " << mResolution  << "\n";
-  gzmsg << "RowLength:     " << mRowLength   << "\n";
-  gzmsg << "NumVertices:   " << mNumVertices << "\n";
-  gzmsg << "NumFaces:      " << mNumFaces    << "\n";
-  gzmsg << "TileSize:      " << mTileSize    << "\n";
-  gzmsg << "Spacing:       " << mSpacing     << "\n";
+  gzmsg << "Resolution:    " << nx_  << "\n";
+  gzmsg << "RowLength:     " << row_length_   << "\n";
+  gzmsg << "NumVertices:   " << num_vertices_ << "\n";
+  gzmsg << "NumFaces:      " << num_faces_    << "\n";
+  gzmsg << "TileSize:      " << tile_size_    << "\n";
+  gzmsg << "Spacing:       " << spacing_     << "\n";
 
   // Grid dimensions
-  const size_t nx = this->mResolution;
-  const size_t ny = this->mResolution;
-  const double Lx = this->mTileSize;
-  const double Ly = this->mTileSize;
-  const double lx = this->mSpacing;
-  const double ly = this->mSpacing;
+  const size_t nx = nx_;
+  const size_t ny = nx_;
+  const double lx = tile_size_;
+  const double ly = tile_size_;
+  const double dx = spacing_;
+  const double dy = spacing_;
   // Here we are actually mapping (u, v) to each quad in the tile
   // (not the entire tile). 
-  // const double xTex = 1.0 * lx;
-  // const double yTex = 1.0 * ly;
+  // const double x_tex = 1.0 * lx;
+  // const double y_tex = 1.0 * ly;
   /// \todo add param to tune bump map scaling
-  double texScale = 0.1;
-  const double xTex = texScale * Lx / nx;
-  const double yTex = texScale * Ly / ny;
+  double tex_scale = 0.1;
+  const double x_tex = tex_scale * lx / nx;
+  const double y_tex = tex_scale * ly / ny;
 
   gzmsg << "OceanTile: calculating vertices\n";
-  // Vertices - (N+1) vertices in each row / column
+  // Vertices - (nx+1) vertices in each row / column
   for (size_t iy=0; iy<=ny; ++iy)
   {
-    double py = iy * ly - Ly/2.0;
+    double py = iy * dy - ly/2.0;
     for (size_t ix=0; ix<=nx; ++ix)
     {
       // Vertex position
-      double px = ix * lx - Lx/2.0;
+      double px = ix * dx - lx/2.0;
 
       Vector3 vertex(px, py, 0);
-      mVertices0.push_back(vertex);
-      mVertices.push_back(vertex);
+      vertices0_.push_back(vertex);
+      vertices_.push_back(vertex);
       // Texture coordinates (u, v): top left: (0, 0), bottom right: (1, 1)
-      gz::math::Vector2d texCoord(ix * xTex, 1.0 - (iy * yTex));
-      mTexCoords.push_back(texCoord);
+      gz::math::Vector2d tex_coord(ix * x_tex, 1.0 - (iy * y_tex));
+      tex_coords_.push_back(tex_coord);
     }
   }
 
@@ -420,25 +423,25 @@ void OceanTilePrivate<Vector3>::Create()
       const size_t idx3 = (iy+1) * (nx+1) + ix;
 
       // Indices
-      mFaces.push_back(gz::math::Vector3i(idx0, idx1, idx2));
-      mFaces.push_back(gz::math::Vector3i(idx0, idx2, idx3));
+      faces_.push_back(gz::math::Vector3i(idx0, idx1, idx2));
+      faces_.push_back(gz::math::Vector3i(idx0, idx2, idx3));
     }
   }
 
   gzmsg << "OceanTile: assigning texture coords\n";
   // Texture Coordinates
-  mTangents.assign(mVertices.size(), vector::Zero<Vector3>);
-  mBitangents.assign(mVertices.size(), vector::Zero<Vector3>);
-  mNormals.assign(mVertices.size(), vector::Zero<Vector3>);
+  tangents_.assign(vertices_.size(), vector::Zero<Vector3>);
+  bitangents_.assign(vertices_.size(), vector::Zero<Vector3>);
+  normals_.assign(vertices_.size(), vector::Zero<Vector3>);
 
-  if (mHasVisuals) 
+  if (has_visuals_) 
   {
     /// \note: uncomment to calculate normals and tangents by finited difference
     // ComputeNormals();
     // ComputeTangentSpace();
 #if 0
-    CreateMesh(this->mAboveOceanMeshName, 0.0, false);
-    CreateMesh(this->mBelowOceanMeshName, -0.05, true);
+    CreateMesh(above_ocean_mesh_name_, 0.0, false);
+    CreateMesh(below_ocean_mesh_name_, -0.05, true);
 #endif
   }
 }
@@ -447,8 +450,8 @@ void OceanTilePrivate<Vector3>::Create()
 template <typename Vector3>
 gz::common::Mesh * OceanTilePrivate<Vector3>::CreateMesh()
 {
-  this->Create();
-  return CreateMesh(this->mAboveOceanMeshName, 0.0, false);
+  Create();
+  return CreateMesh(above_ocean_mesh_name_, 0.0, false);
 }
 
 //////////////////////////////////////////////////
@@ -458,30 +461,30 @@ void OceanTilePrivate<gz::math::Vector3d>::ComputeNormals()
   // gzmsg << "OceanTile: compute normals\n";
 
   // 0. Reset normals.
-  mNormals.assign(mVertices.size(), gz::math::Vector3d::Zero);
+  normals_.assign(vertices_.size(), gz::math::Vector3d::Zero);
 
   // 1. For each face calculate the normal and add to each vertex in the face
-  for (size_t i=0; i<mNumFaces; ++i)
+  for (size_t i=0; i<num_faces_; ++i)
   {
     // Vertices
-    auto v0Idx = mFaces[i][0];
-    auto v1Idx = mFaces[i][1];
-    auto v2Idx = mFaces[i][2];
-    auto&& v0 = mVertices[v0Idx];
-    auto&& v1 = mVertices[v1Idx];
-    auto&& v2 = mVertices[v2Idx];
+    auto v0_idx = faces_[i][0];
+    auto v1_idx = faces_[i][1];
+    auto v2_idx = faces_[i][2];
+    auto&& v0 = vertices_[v0_idx];
+    auto&& v1 = vertices_[v1_idx];
+    auto&& v2 = vertices_[v2_idx];
 
     // Normal
     gz::math::Vector3d normal(gz::math::Vector3d::Normal(v0, v1, v2));
 
     // Add to vertices
-    mNormals[v0Idx] += normal;
-    mNormals[v1Idx] += normal;
-    mNormals[v2Idx] += normal;
+    normals_[v0_idx] += normal;
+    normals_[v1_idx] += normal;
+    normals_[v2_idx] += normal;
   }
 
   // 2. Normalise each vertex normal.
-  for (auto&& normal : mNormals)
+  for (auto&& normal : normals_)
   {
       normal.Normalize();
   }
@@ -504,16 +507,16 @@ void OceanTilePrivate<Vector3>::ComputeTangentSpace()
 {
   // gzmsg << "OceanTile: compute tangent space\n";
 
-  ComputeTBN(mVertices, mTexCoords, mFaces, mTangents, mBitangents, mNormals);
+  ComputeTBN(vertices_, tex_coords_, faces_, tangents_, bitangents_, normals_);
 
 #if DEBUG
-  for (size_t i=0; i<std::min(static_cast<size_t>(20), mVertices.size()) ; ++i)
+  for (size_t i=0; i<std::min(static_cast<size_t>(20), vertices_.size()) ; ++i)
   {
-    gzmsg << "V["  << i << "]:  "  << mVertices[i]   << "\n";
-    gzmsg << "UV[" << i << "]: "   << mTexCoords[i]  << "\n"
-    gzmsg << "T["  << i << "]:  "  << mTangents[i]   << "\n";
-    gzmsg << "B["  << i << "]:  "  << mBitangents[i] << "\n";
-    gzmsg << "N["  << i << "]:  "  << mNormals[i]    << "\n";
+    gzmsg << "V["  << i << "]:  "  << vertices_[i]   << "\n";
+    gzmsg << "UV[" << i << "]: "   << tex_coords_[i] << "\n"
+    gzmsg << "T["  << i << "]:  "  << tangents_[i]   << "\n";
+    gzmsg << "B["  << i << "]:  "  << bitangents_[i] << "\n";
+    gzmsg << "N["  << i << "]:  "  << normals_[i]    << "\n";
   }
 #endif
 
@@ -523,52 +526,52 @@ void OceanTilePrivate<Vector3>::ComputeTangentSpace()
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<gz::math::Vector3d>::ComputeTBN(
-    const gz::math::Vector3d& _p0, 
-    const gz::math::Vector3d& _p1, 
-    const gz::math::Vector3d& _p2, 
-    const gz::math::Vector2d& _uv0, 
-    const gz::math::Vector2d& _uv1, 
-    const gz::math::Vector2d& _uv2, 
-    gz::math::Vector3d& _tangent, 
-    gz::math::Vector3d& _bitangent, 
-    gz::math::Vector3d& _normal)
+    const gz::math::Vector3d &p0, 
+    const gz::math::Vector3d &p1, 
+    const gz::math::Vector3d &p2, 
+    const gz::math::Vector2d &uv0, 
+    const gz::math::Vector2d &uv1, 
+    const gz::math::Vector2d &uv2, 
+    gz::math::Vector3d &tangent, 
+    gz::math::Vector3d &bitangent, 
+    gz::math::Vector3d &normal)
 {
   // Correction to the TBN calculation when the v texture coordinate
   // is 0 at the top of a texture and 1 at the bottom. 
   double vsgn = -1.0;
-  auto edge1 = _p1 - _p0;
-  auto edge2 = _p2 - _p0;
-  auto duv1 = _uv1 - _uv0;
-  auto duv2 = _uv2 - _uv0;
+  auto edge1 = p1 - p0;
+  auto edge2 = p2 - p0;
+  auto duv1 = uv1 - uv0;
+  auto duv2 = uv2 - uv0;
 
   double f = 1.0f / (duv1.X() * duv2.Y() - duv2.X() * duv1.Y()) * vsgn;
 
-  _tangent.X() = f * (duv2.Y() * edge1.X() - duv1.Y() * edge2.X()) * vsgn;
-  _tangent.Y() = f * (duv2.Y() * edge1.Y() - duv1.Y() * edge2.Y()) * vsgn;
-  _tangent.Z() = f * (duv2.Y() * edge1.Z() - duv1.Y() * edge2.Z()) * vsgn;
-  _tangent.Normalize();
+  tangent.X() = f * (duv2.Y() * edge1.X() - duv1.Y() * edge2.X()) * vsgn;
+  tangent.Y() = f * (duv2.Y() * edge1.Y() - duv1.Y() * edge2.Y()) * vsgn;
+  tangent.Z() = f * (duv2.Y() * edge1.Z() - duv1.Y() * edge2.Z()) * vsgn;
+  tangent.Normalize();
 
-  _bitangent.X() = f * (-duv2.X() * edge1.X() + duv1.X() * edge2.X());
-  _bitangent.Y() = f * (-duv2.X() * edge1.Y() + duv1.X() * edge2.Y());
-  _bitangent.Z() = f * (-duv2.X() * edge1.Z() + duv1.X() * edge2.Z());
-  _bitangent.Normalize();  
+  bitangent.X() = f * (-duv2.X() * edge1.X() + duv1.X() * edge2.X());
+  bitangent.Y() = f * (-duv2.X() * edge1.Y() + duv1.X() * edge2.Y());
+  bitangent.Z() = f * (-duv2.X() * edge1.Z() + duv1.X() * edge2.Z());
+  bitangent.Normalize();  
 
-  _normal = _tangent.Cross(_bitangent);
-  _normal.Normalize();  
+  normal = tangent.Cross(bitangent);
+  normal.Normalize();  
 }
 
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<cgal::Point3>::ComputeTBN(
-    const cgal::Point3& /*_p0*/, 
-    const cgal::Point3& /*_p1*/, 
-    const cgal::Point3& /*_p2*/, 
-    const gz::math::Vector2d& /*_uv0*/, 
-    const gz::math::Vector2d& /*_uv1*/, 
-    const gz::math::Vector2d& /*_uv2*/, 
-    cgal::Point3& /*_tangent*/, 
-    cgal::Point3& /*_bitangent*/, 
-    cgal::Point3& /*_normal*/)
+    const cgal::Point3 & /*p0*/, 
+    const cgal::Point3 & /*p1*/, 
+    const cgal::Point3 & /*p2*/, 
+    const gz::math::Vector2d &/*uv0*/, 
+    const gz::math::Vector2d &/*uv1*/, 
+    const gz::math::Vector2d &/*uv2*/, 
+    cgal::Point3 &/*tangent*/, 
+    cgal::Point3 &/*bitangent*/, 
+    cgal::Point3 &/*normal*/)
 {
   // Not used
   gzerr << "No implementation"
@@ -578,20 +581,20 @@ void OceanTilePrivate<cgal::Point3>::ComputeTBN(
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<gz::math::Vector3d>::ComputeTBN(
-    const std::vector<gz::math::Vector3d>& _vertices,
-    const std::vector<gz::math::Vector2d>& _texCoords,
-    const std::vector<gz::math::Vector3i>& _faces, 
-    std::vector<gz::math::Vector3d>& _tangents,
-    std::vector<gz::math::Vector3d>& _bitangents,
-    std::vector<gz::math::Vector3d>& _normals)
+    const std::vector<gz::math::Vector3d> &vertices,
+    const std::vector<gz::math::Vector2d> &tex_coords,
+    const std::vector<gz::math::Vector3i> &faces, 
+    std::vector<gz::math::Vector3d> &tangents,
+    std::vector<gz::math::Vector3d> &bitangents,
+    std::vector<gz::math::Vector3d> &normals)
 {
   // 0. Resize and zero outputs.
-  _tangents.assign(_vertices.size(), gz::math::Vector3d::Zero);
-  _bitangents.assign(_vertices.size(), gz::math::Vector3d::Zero);
-  _normals.assign(_vertices.size(), gz::math::Vector3d::Zero);
+  tangents.assign(vertices.size(), gz::math::Vector3d::Zero);
+  bitangents.assign(vertices.size(), gz::math::Vector3d::Zero);
+  normals.assign(vertices.size(), gz::math::Vector3d::Zero);
 
   // 1. For each face calculate TBN and add to each vertex in the face.
-  for (auto&& face : _faces)
+  for (auto&& face : faces)
   {
     // Face vertex indices.
     auto idx0 = face[0];
@@ -599,47 +602,47 @@ void OceanTilePrivate<gz::math::Vector3d>::ComputeTBN(
     auto idx2 = face[2];
 
     // Face vertex points.
-    auto&& p0 = _vertices[idx0];
-    auto&& p1 = _vertices[idx1];
-    auto&& p2 = _vertices[idx2];
+    auto&& p0 = vertices[idx0];
+    auto&& p1 = vertices[idx1];
+    auto&& p2 = vertices[idx2];
 
     // Face vertex texture coordinates.
-    auto&& uv0 = _texCoords[idx0];
-    auto&& uv1 = _texCoords[idx1];
-    auto&& uv2 = _texCoords[idx2];
+    auto&& uv0 = tex_coords[idx0];
+    auto&& uv1 = tex_coords[idx1];
+    auto&& uv2 = tex_coords[idx2];
 
     // Compute tangent space.
-    gz::math::Vector3d T, B, N;
-    ComputeTBN(p0, p1, p2, uv0, uv1, uv2, T, B, N);
+    gz::math::Vector3d tangent, bitangent, normal;
+    ComputeTBN(p0, p1, p2, uv0, uv1, uv2, tangent, bitangent, normal);
 
     // Assign to vertices.
-    for (int i=0; i<3; ++i)
+    for (Index i=0; i<3; ++i)
     {
       auto idx = face[i];
-      _tangents[idx]   += T;
-      _bitangents[idx] += B;
-      _normals[idx]    += N;
+      tangents[idx]   += tangent;
+      bitangents[idx] += bitangent;
+      normals[idx]    += normal;
     }
   } 
 
   // 2. Normalise each vertex's tangent space basis.
-  for (size_t i=0; i<_vertices.size(); ++i)
+  for (size_t i=0; i<vertices.size(); ++i)
   {
-    _tangents[i].Normalize();
-    _bitangents[i].Normalize();
-    _normals[i].Normalize();
+    tangents[i].Normalize();
+    bitangents[i].Normalize();
+    normals[i].Normalize();
   }
 }
 
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<cgal::Point3>::ComputeTBN(
-    const std::vector<cgal::Point3>& /*_vertices*/,
-    const std::vector<gz::math::Vector2d>& /*_texCoords*/,
-    const std::vector<gz::math::Vector3i>& /*_faces*/, 
-    std::vector<cgal::Point3>& /*_tangents*/,
-    std::vector<cgal::Point3>& /*_bitangents*/,
-    std::vector<cgal::Point3>& /*_normals*/)
+    const std::vector<cgal::Point3> &/*vertices*/,
+    const std::vector<gz::math::Vector2d> &/*tex_coords*/,
+    const std::vector<gz::math::Vector3i> &/*faces*/, 
+    std::vector<cgal::Point3> &/*tangents*/,
+    std::vector<cgal::Point3> &/*bitangents*/,
+    std::vector<cgal::Point3> &/*normals*/)
 {
   // Not used
   gzerr << "No implementation " 
@@ -648,11 +651,11 @@ void OceanTilePrivate<cgal::Point3>::ComputeTBN(
 
 //////////////////////////////////////////////////
 template <typename Vector3>
-void OceanTilePrivate<Vector3>::Update(double _time)
+void OceanTilePrivate<Vector3>::Update(double time)
 {
-  UpdateVertices(_time);
+  UpdateVertices(time);
 
-  if (mHasVisuals)
+  if (has_visuals_)
   {
     /// \note: Uncomment to calculate the tangent space using finite differences
     // ComputeTangentSpace();
@@ -667,12 +670,12 @@ void OceanTilePrivate<gz::math::Vector3d>::UpdateVertex(
   size_t v_idx, size_t w_idx)
 {
   // 1. Update vertex
-  double h  = mHeights[w_idx];
-  double sx = mDisplacementsX[w_idx];
-  double sy = mDisplacementsY[w_idx];
+  double h  = heights_[w_idx];
+  double sx = sx_[w_idx];
+  double sy = sy_[w_idx];
 
-  auto&& v0 = mVertices0[v_idx];
-  auto&& v  = mVertices[v_idx];
+  auto&& v0 = vertices0_[v_idx];
+  auto&& v  = vertices_[v_idx];
   v.X() = v0.X() + sy;
   v.Y() = v0.Y() + sx;
   v.Z() = v0.Z() + h;
@@ -683,12 +686,12 @@ template <>
 void OceanTilePrivate<cgal::Point3>::UpdateVertex(size_t v_idx, size_t w_idx)
 {
   // 1. Update vertex
-  double h  = mHeights[w_idx];
-  double sx = mDisplacementsX[w_idx];
-  double sy = mDisplacementsY[w_idx];
+  double h  = heights_[w_idx];
+  double sx = sx_[w_idx];
+  double sy = sy_[w_idx];
 
-  auto&& v0 = mVertices0[v_idx];
-  mVertices[v_idx] = cgal::Point3(
+  auto&& v0 = vertices0_[v_idx];
+  vertices_[v_idx] = cgal::Point3(
     v0.x() + sy,
     v0.y() + sx,
     v0.z() + h);
@@ -700,35 +703,35 @@ void OceanTilePrivate<gz::math::Vector3d>::UpdateVertexAndTangents(
     size_t v_idx, size_t w_idx)
 {
   // 1. Update vertex
-  double h  = mHeights[w_idx];
-  double sx = mDisplacementsX[w_idx];
-  double sy = mDisplacementsY[w_idx];
+  double h  = heights_[w_idx];
+  double sx = sx_[w_idx];
+  double sy = sy_[w_idx];
 
-  auto&& v0 = mVertices0[v_idx];
-  auto&& v  = mVertices[v_idx];
+  auto&& v0 = vertices0_[v_idx];
+  auto&& v  = vertices_[v_idx];
   v.X() = v0.X() + sy;
   v.Y() = v0.Y() + sx;
   v.Z() = v0.Z() + h;
 
   // 2. Update tangent and bitangent vectors (not normalised).
   // @TODO Check sign for displacement terms
-  double dhdx  = mDhdx[w_idx]; 
-  double dhdy  = mDhdy[w_idx]; 
-  double dsxdx = mDxdx[w_idx]; 
-  double dsydy = mDydy[w_idx]; 
-  double dsxdy = mDxdy[w_idx]; 
+  double dhdx  = dhdx_[w_idx]; 
+  double dhdy  = dhdy_[w_idx]; 
+  double dsxdx = dsxdx_[w_idx]; 
+  double dsydy = dsydy_[w_idx]; 
+  double dsxdy = dsxdy_[w_idx]; 
 
-  auto&& t = mTangents[v_idx];
+  auto&& t = tangents_[v_idx];
   t.X() = dsydy + 1.0;
   t.Y() = dsxdy;
   t.Z() = dhdy;
 
-  auto&& b = mBitangents[v_idx];
+  auto&& b = bitangents_[v_idx];
   b.X() = dsxdy;
   b.Y() = dsxdx + 1.0;
   b.Z() = dhdx;
 
-  auto&& n = mNormals[v_idx];
+  auto&& n = normals_[v_idx];
   auto normal =  t.Cross(b);
   n.X() = normal.X();
   n.Y() = normal.Y();
@@ -748,26 +751,26 @@ void OceanTilePrivate<cgal::Point3>::UpdateVertexAndTangents(
     size_t v_idx, size_t w_idx)
 {
   // 1. Update vertex
-  // double h  = mHeights[w_idx];
-  // double sx = mDisplacementsX[w_idx];
-  // double sy = mDisplacementsY[w_idx];
+  // double h  = heights_[w_idx];
+  // double sx = sx_[w_idx];
+  // double sy = sy_[w_idx];
 
-  // auto&& v0 = mVertices0[v_idx];
+  // auto&& v0 = vertices0_[v_idx];
 
   // 2. Update tangent and bitangent vectors (not normalised).
   // @TODO Check sign for displacement terms
-  double dhdx  = mDhdx[w_idx]; 
-  double dhdy  = mDhdy[w_idx]; 
-  double dsxdx = mDxdx[w_idx]; 
-  double dsydy = mDydy[w_idx]; 
-  double dsxdy = mDxdy[w_idx]; 
+  double dhdx  = dhdx_[w_idx]; 
+  double dhdy  = dhdy_[w_idx]; 
+  double dsxdx = dsxdx_[w_idx]; 
+  double dsydy = dsydy_[w_idx]; 
+  double dsxdy = dsxdy_[w_idx]; 
 
-  mTangents[v_idx] = cgal::Point3(
+  tangents_[v_idx] = cgal::Point3(
     dsydy + 1.0,
     dsxdy,
     dhdy);
   
-  mBitangents[v_idx] = cgal::Point3(
+  bitangents_[v_idx] = cgal::Point3(
     dsxdy,
     dsxdx + 1.0,
     dhdx);
@@ -775,51 +778,51 @@ void OceanTilePrivate<cgal::Point3>::UpdateVertexAndTangents(
 
 //////////////////////////////////////////////////
 template <typename Vector3>
-void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
+void OceanTilePrivate<Vector3>::UpdateVertices(double time)
 {
-  mWaveSim->SetTime(_time);
+  wave_sim_->SetTime(time);
 
-  if (mHasVisuals)
+  if (has_visuals_)
   {
-    mWaveSim->DisplacementAndDerivAt(
-        mHeights, mDisplacementsX, mDisplacementsY,
-        mDhdx, mDhdy, mDxdx, mDydy, mDxdy);
+    wave_sim_->DisplacementAndDerivAt(
+        heights_, sx_, sy_,
+        dhdx_, dhdy_, dsxdx_, dsydy_, dsxdy_);
   
-    const size_t N = mResolution;
-    const size_t NPlus1  = N + 1;
+    const size_t nx = nx_;
+    const size_t nx_plus1  = nx + 1;
 
-    for (size_t iy=0; iy<N; ++iy)
+    for (size_t iy=0; iy<nx; ++iy)
     {
-      for (size_t ix=0; ix<N; ++ix)
+      for (size_t ix=0; ix<nx; ++ix)
       {
-        size_t v_idx_cm = iy * NPlus1 + ix;
-        size_t w_idx_cm = iy * N + ix;
-        // size_t w_idx_rm = ix * N + iy;
+        size_t v_idx_cm = iy * nx_plus1 + ix;
+        size_t w_idx_cm = iy * nx + ix;
+        // size_t w_idx_rm = ix * nx + iy;
         UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
       }
     }
 
     // Set skirt values assuming periodic boundary conditions:
-    for (size_t i=0; i<N; ++i)
+    for (size_t i=0; i<nx; ++i)
     {
-      // Top row (iy = N) periodic with bottom row (iy = 0)
+      // Top row (iy = nx) periodic with bottom row (iy = 0)
       {
-        size_t v_idx_cm = N * NPlus1 + i;
+        size_t v_idx_cm = nx * nx_plus1 + i;
         size_t w_idx_cm = i;
-        // size_t w_idx_rm = i * N;
+        // size_t w_idx_rm = i * nx;
         UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
       }
-      // Right column (ix = N) periodic with left column (ix = 0)
+      // Right column (ix = nx) periodic with left column (ix = 0)
       {
-        size_t v_idx_cm = i * NPlus1 + N;
-        size_t w_idx_cm = i * N;
+        size_t v_idx_cm = i * nx_plus1 + nx;
+        size_t w_idx_cm = i * nx;
         // size_t w_idx_rm = i;
         UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
       }
     }
     {
       // Top right corner period with bottom right corner.
-      size_t v_idx_cm = NPlus1 * NPlus1 - 1;
+      size_t v_idx_cm = nx_plus1 * nx_plus1 - 1;
       size_t w_idx_cm = 0;
       // size_t w_idx_rm = 0;
       UpdateVertexAndTangents(v_idx_cm, w_idx_cm);
@@ -827,44 +830,44 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
   }
   else
   {
-    mWaveSim->ElevationAt(mHeights);
-    mWaveSim->DisplacementAt(mDisplacementsX, mDisplacementsY);
+    wave_sim_->ElevationAt(heights_);
+    wave_sim_->DisplacementAt(sx_, sy_);
 
-    const size_t N = mResolution;
-    const size_t NPlus1  = N + 1;
+    const size_t nx = nx_;
+    const size_t nx_plus1  = nx + 1;
 
-    for (size_t iy=0; iy<N; ++iy)
+    for (size_t iy=0; iy<nx; ++iy)
     {
-      for (size_t ix=0; ix<N; ++ix)
+      for (size_t ix=0; ix<nx; ++ix)
       {
-        size_t v_idx_cm = iy * NPlus1 + ix;
-        size_t w_idx_cm = iy * N + ix;
-        // size_t w_idx_rm = ix * N + iy;
+        size_t v_idx_cm = iy * nx_plus1 + ix;
+        size_t w_idx_cm = iy * nx + ix;
+        // size_t w_idx_rm = ix * nx + iy;
         UpdateVertex(v_idx_cm, w_idx_cm);
       }
     }
 
     // Set skirt values assuming periodic boundary conditions:
-    for (size_t i=0; i<N; ++i)
+    for (size_t i=0; i<nx; ++i)
     {
-      // Top row (iy = N) periodic with bottom row (iy = 0)
+      // Top row (iy = nx) periodic with bottom row (iy = 0)
       {
-        size_t v_idx_cm = N * NPlus1 + i;
+        size_t v_idx_cm = nx * nx_plus1 + i;
         size_t w_idx_cm = i;
-        // size_t w_idx_rm = i * N;
+        // size_t w_idx_rm = i * nx;
         UpdateVertex(v_idx_cm, w_idx_cm);
       }
-      // Right column (ix = N) periodic with left column (ix = 0)
+      // Right column (ix = nx) periodic with left column (ix = 0)
       {
-        size_t v_idx_cm = i * NPlus1 + N;
-        size_t w_idx_cm = i * N;
+        size_t v_idx_cm = i * nx_plus1 + nx;
+        size_t w_idx_cm = i * nx;
         // size_t w_idx_rm = i;
         UpdateVertex(v_idx_cm, w_idx_cm);
       }
     }
     {
       // Top right corner period with bottom right corner.
-      size_t v_idx_cm = NPlus1 * NPlus1 - 1;
+      size_t v_idx_cm = nx_plus1 * nx_plus1 - 1;
       size_t w_idx_cm = 0;
       // size_t w_idx_rm = 0;
       UpdateVertex(v_idx_cm, w_idx_cm);
@@ -874,59 +877,59 @@ void OceanTilePrivate<Vector3>::UpdateVertices(double _time)
 
 //////////////////////////////////////////////////
 template <typename Vector3>
-gz::common::Mesh * OceanTilePrivate<Vector3>::CreateMesh(
-    const std::string &_name, double _offsetZ,
-    bool _reverseOrientation)
+gz::common::Mesh* OceanTilePrivate<Vector3>::CreateMesh(
+    const std::string &name, double offset_z,
+    bool reverse_orientation)
 {
   // Logging
   gzmsg << "OceanTile: creating mesh\n";
   std::unique_ptr<gz::common::Mesh> mesh = std::make_unique<gz::common::Mesh>();
-  mesh->SetName(_name);
+  mesh->SetName(name);
 
   gzmsg << "OceanTile: create submesh\n";
   std::unique_ptr<gz::common::SubMeshWithTangents> submesh(
       new gz::common::SubMeshWithTangents());
 
   // Add position vertices
-  for (size_t i=0; i<mVertices.size(); ++i)
+  for (size_t i=0; i<vertices_.size(); ++i)
   {
     submesh->AddVertex(
-        mVertices[i][0],
-        mVertices[i][1],
-        mVertices[i][2] + _offsetZ);
+        vertices_[i][0],
+        vertices_[i][1],
+        vertices_[i][2] + offset_z);
 
     submesh->AddNormal(
-        mNormals[i][0],
-        mNormals[i][1],
-        mNormals[i][2]);
+        normals_[i][0],
+        normals_[i][1],
+        normals_[i][2]);
 
     /// using an extension that supports tangents
     submesh->AddTangent(
-        mTangents[i][0],
-        mTangents[i][1],
-        mTangents[i][2]);
+        tangents_[i][0],
+        tangents_[i][1],
+        tangents_[i][2]);
 
     // uv0
     submesh->AddTexCoord(
-        mTexCoords[i][0],
-        mTexCoords[i][1]);
+        tex_coords_[i][0],
+        tex_coords_[i][1]);
   }
 
   // Add indices
-  for (size_t i=0; i<mFaces.size(); ++i)
+  for (size_t i=0; i<faces_.size(); ++i)
   {
     // Reverse orientation on faces
-    if (_reverseOrientation)
+    if (reverse_orientation)
     {
-      submesh->AddIndex(mFaces[i][0]);
-      submesh->AddIndex(mFaces[i][2]);
-      submesh->AddIndex(mFaces[i][1]);
+      submesh->AddIndex(faces_[i][0]);
+      submesh->AddIndex(faces_[i][2]);
+      submesh->AddIndex(faces_[i][1]);
     }
     else
     {
-      submesh->AddIndex(mFaces[i][0]);
-      submesh->AddIndex(mFaces[i][1]);
-      submesh->AddIndex(mFaces[i][2]);
+      submesh->AddIndex(faces_[i][0]);
+      submesh->AddIndex(faces_[i][1]);
+      submesh->AddIndex(faces_[i][2]);
     }
   }
  
@@ -940,37 +943,37 @@ gz::common::Mesh * OceanTilePrivate<Vector3>::CreateMesh(
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<gz::math::Vector3d>::UpdateMesh(
-    double _time, gz::common::Mesh *_mesh)
+    double time, gz::common::Mesh *mesh)
 {
-  this->Update(_time);
+  Update(time);
 
   // \todo: add checks
   // \todo: handle more than one submesh
 
   // Get the submesh
-  auto baseSubMesh = _mesh->SubMeshByIndex(0).lock();
-  auto subMesh = std::dynamic_pointer_cast<
-      gz::common::SubMeshWithTangents>(baseSubMesh);
-  if (!subMesh)
+  auto base_submesh = mesh->SubMeshByIndex(0).lock();
+  auto submesh = std::dynamic_pointer_cast<
+      gz::common::SubMeshWithTangents>(base_submesh);
+  if (!submesh)
   {
     ignwarn << "OceanTile: submesh does not support tangents\n";
     return;
   }
 
   // Update positions, normals, texture coords etc.
-  for (size_t i=0; i<mVertices.size(); ++i)
+  for (size_t i=0; i<vertices_.size(); ++i)
   {
-    subMesh->SetVertex(i, mVertices[i]);
-    subMesh->SetNormal(i, mNormals[i]);
-    subMesh->SetTangent(i, mTangents[i]);
-    subMesh->SetTexCoord(i, mTexCoords[i]);
+    submesh->SetVertex(i, vertices_[i]);
+    submesh->SetNormal(i, normals_[i]);
+    submesh->SetTangent(i, tangents_[i]);
+    submesh->SetTexCoord(i, tex_coords_[i]);
   }
 }
 
 //////////////////////////////////////////////////
 template <>
 void OceanTilePrivate<cgal::Point3>::UpdateMesh(
-    double /*_time*/, gz::common::Mesh */*_mesh*/)
+    double /*time*/, gz::common::Mesh */*mesh*/)
 {
   /// \note This template specialisation is supplied for compilation on
   ///       macOS M1 (arm64). It should never be called. 
@@ -988,110 +991,115 @@ OceanTileT<gz::math::Vector3d>::~OceanTileT()
 //////////////////////////////////////////////////
 template <>
 OceanTileT<gz::math::Vector3d>::OceanTileT(
-    unsigned int _N, double _L, bool _hasVisuals) :
-    dataPtr(std::make_unique<OceanTilePrivate<gz::math::Vector3d>>(
-        _N, _L, _hasVisuals))
+    Index nx, double lx, bool has_visuals) :
+    impl_(std::make_unique<OceanTilePrivate<gz::math::Vector3d>>(
+        nx, lx, has_visuals))
 {
 }
 
 //////////////////////////////////////////////////
 template <>
 OceanTileT<gz::math::Vector3d>::OceanTileT(
-    WaveParametersPtr _params, bool _hasVisuals) :
-    dataPtr(std::make_unique<OceanTilePrivate<gz::math::Vector3d>>(
-        _params, _hasVisuals))
+    WaveParametersPtr params, bool has_visuals) :
+    impl_(std::make_unique<OceanTilePrivate<gz::math::Vector3d>>(
+        params, has_visuals))
 {
 }
 
 //////////////////////////////////////////////////
 template <>
-void OceanTileT<gz::math::Vector3d>::SetWindVelocity(double _ux, double _uy)
+void OceanTileT<gz::math::Vector3d>::SetWindVelocity(double ux, double uy)
 {
-  this->dataPtr->SetWindVelocity(_ux, _uy);
+  impl_->SetWindVelocity(ux, uy);
 }
 
 //////////////////////////////////////////////////
 template <>
 double OceanTileT<gz::math::Vector3d>::TileSize() const
 {
-  return this->dataPtr->mTileSize;
+  return impl_->tile_size_;
 }
 
 //////////////////////////////////////////////////
 template <>
-unsigned int OceanTileT<gz::math::Vector3d>::Resolution() const
+Index OceanTileT<gz::math::Vector3d>::Resolution() const
 {
-  return this->dataPtr->mResolution;
+  return impl_->nx_;
 }
 
 //////////////////////////////////////////////////
 template <>
 void OceanTileT<gz::math::Vector3d>::Create()
 {
-  return this->dataPtr->Create();
+  return impl_->Create();
 }
 
 //////////////////////////////////////////////////
 template <>
 gz::common::Mesh* OceanTileT<gz::math::Vector3d>::CreateMesh()
 {
-  return this->dataPtr->CreateMesh();
+  return impl_->CreateMesh();
 }
 
 //////////////////////////////////////////////////
 template <>
-void OceanTileT<gz::math::Vector3d>::Update(double _time)
+void OceanTileT<gz::math::Vector3d>::Update(double time)
 {
-  this->dataPtr->Update(_time);
+  impl_->Update(time);
 }
 
 //////////////////////////////////////////////////
 template <>
-void OceanTileT<gz::math::Vector3d>::UpdateMesh(double _time, gz::common::Mesh *_mesh)
+void OceanTileT<gz::math::Vector3d>::UpdateMesh(
+    double time, gz::common::Mesh *mesh)
 {
-  this->dataPtr->UpdateMesh(_time, _mesh);
+  impl_->UpdateMesh(time, mesh);
 }
 
 //////////////////////////////////////////////////
 template <>
-unsigned int OceanTileT<gz::math::Vector3d>::VertexCount() const
+Index OceanTileT<gz::math::Vector3d>::VertexCount() const
 {
-  return this->dataPtr->mVertices.size();
+  return impl_->vertices_.size();
 }
 
 //////////////////////////////////////////////////
 template <>
-gz::math::Vector3d OceanTileT<gz::math::Vector3d>::Vertex(unsigned int _index) const
+gz::math::Vector3d OceanTileT<gz::math::Vector3d>::Vertex(
+    Index index) const
 {
-  return this->dataPtr->mVertices[_index];
+  return impl_->vertices_[index];
 }
 
 //////////////////////////////////////////////////
 template <>
-gz::math::Vector2d OceanTileT<gz::math::Vector3d>::UV0(unsigned int _index) const
+gz::math::Vector2d OceanTileT<gz::math::Vector3d>::UV0(
+    Index index) const
 {
-  return this->dataPtr->mTexCoords[_index];
+  return impl_->tex_coords_[index];
 }
 
 //////////////////////////////////////////////////
 template <>
-unsigned int OceanTileT<gz::math::Vector3d>::FaceCount() const
+Index OceanTileT<gz::math::Vector3d>::FaceCount() const
 {
-  return this->dataPtr->mFaces.size();
+  return impl_->faces_.size();
 }
 
 //////////////////////////////////////////////////
 template <>
-gz::math::Vector3i OceanTileT<gz::math::Vector3d>::Face(unsigned int _index) const
+gz::math::Vector3i OceanTileT<gz::math::Vector3d>::Face(
+    Index index) const
 {
-  return this->dataPtr->mFaces[_index];
+  return impl_->faces_[index];
 }
 
 //////////////////////////////////////////////////
 template <>
-const std::vector<gz::math::Vector3d>& OceanTileT<gz::math::Vector3d>::Vertices() const
+const std::vector<gz::math::Vector3d>&
+OceanTileT<gz::math::Vector3d>::Vertices() const
 {
-  return this->dataPtr->mVertices;
+  return impl_->vertices_;
 }
 
 //////////////////////////////////////////////////
@@ -1105,110 +1113,110 @@ OceanTileT<cgal::Point3>::~OceanTileT()
 //////////////////////////////////////////////////
 template <>
 OceanTileT<cgal::Point3>::OceanTileT(
-    unsigned int _N, double _L, bool _hasVisuals) :
-    dataPtr(std::make_unique<OceanTilePrivate<cgal::Point3>>(
-        _N, _L, _hasVisuals))
+    Index nx, double lx, bool has_visuals) :
+    impl_(std::make_unique<OceanTilePrivate<cgal::Point3>>(
+        nx, lx, has_visuals))
 {
 }
 
 //////////////////////////////////////////////////
 template <>
 OceanTileT<cgal::Point3>::OceanTileT(
-    WaveParametersPtr _params, bool _hasVisuals) :
-    dataPtr(std::make_unique<OceanTilePrivate<cgal::Point3>>(
-        _params, _hasVisuals))
+    WaveParametersPtr params, bool has_visuals) :
+    impl_(std::make_unique<OceanTilePrivate<cgal::Point3>>(
+        params, has_visuals))
 {
 }
 
 //////////////////////////////////////////////////
 template <>
-void OceanTileT<cgal::Point3>::SetWindVelocity(double _ux, double _uy)
+void OceanTileT<cgal::Point3>::SetWindVelocity(double ux, double uy)
 {
-  this->dataPtr->SetWindVelocity(_ux, _uy);
+  impl_->SetWindVelocity(ux, uy);
 }
 
 //////////////////////////////////////////////////
 template <>
 double OceanTileT<cgal::Point3>::TileSize() const
 {
-  return this->dataPtr->mTileSize;
+  return impl_->tile_size_;
 }
 
 //////////////////////////////////////////////////
 template <>
-unsigned int OceanTileT<cgal::Point3>::Resolution() const
+Index OceanTileT<cgal::Point3>::Resolution() const
 {
-  return this->dataPtr->mResolution;
+  return impl_->nx_;
 }
 
 //////////////////////////////////////////////////
 template <>
 void OceanTileT<cgal::Point3>::Create()
 {
-  return this->dataPtr->Create();
+  return impl_->Create();
 }
 
 //////////////////////////////////////////////////
 template <>
 gz::common::Mesh* OceanTileT<cgal::Point3>::CreateMesh()
 {
-  return this->dataPtr->CreateMesh();
+  return impl_->CreateMesh();
 }
 
 //////////////////////////////////////////////////
 template <>
-void OceanTileT<cgal::Point3>::Update(double _time)
+void OceanTileT<cgal::Point3>::Update(double time)
 {
-  this->dataPtr->Update(_time);
+  impl_->Update(time);
 }
 
 //////////////////////////////////////////////////
 template <>
-void OceanTileT<cgal::Point3>::UpdateMesh(double _time, gz::common::Mesh *_mesh)
+void OceanTileT<cgal::Point3>::UpdateMesh(double time, gz::common::Mesh *mesh)
 {
-  this->dataPtr->UpdateMesh(_time, _mesh);
+  impl_->UpdateMesh(time, mesh);
 }
 
 //////////////////////////////////////////////////
 template <>
-unsigned int OceanTileT<cgal::Point3>::VertexCount() const
+Index OceanTileT<cgal::Point3>::VertexCount() const
 {
-  return this->dataPtr->mVertices.size();
+  return impl_->vertices_.size();
 }
 
 //////////////////////////////////////////////////
 template <>
-cgal::Point3 OceanTileT<cgal::Point3>::Vertex(unsigned int _index) const
+cgal::Point3 OceanTileT<cgal::Point3>::Vertex(Index index) const
 {
-  return this->dataPtr->mVertices[_index];
+  return impl_->vertices_[index];
 }
 
 //////////////////////////////////////////////////
 template <>
-gz::math::Vector2d OceanTileT<cgal::Point3>::UV0(unsigned int _index) const
+gz::math::Vector2d OceanTileT<cgal::Point3>::UV0(Index index) const
 {
-  return this->dataPtr->mTexCoords[_index];
+  return impl_->tex_coords_[index];
 }
 
 //////////////////////////////////////////////////
 template <>
-unsigned int OceanTileT<cgal::Point3>::FaceCount() const
+Index OceanTileT<cgal::Point3>::FaceCount() const
 {
-  return this->dataPtr->mFaces.size();
+  return impl_->faces_.size();
 }
 
 //////////////////////////////////////////////////
 template <>
-gz::math::Vector3i OceanTileT<cgal::Point3>::Face(unsigned int _index) const
+gz::math::Vector3i OceanTileT<cgal::Point3>::Face(Index index) const
 {
-  return this->dataPtr->mFaces[_index];
+  return impl_->faces_[index];
 }
 
 //////////////////////////////////////////////////
 template <>
 const std::vector<cgal::Point3>& OceanTileT<cgal::Point3>::Vertices() const
 {
-  return this->dataPtr->mVertices;
+  return impl_->vertices_;
 }
 }
 }

--- a/gz-waves/src/PhysicalConstants.cc
+++ b/gz-waves/src/PhysicalConstants.cc
@@ -20,30 +20,30 @@ namespace gz
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////    
+//////////////////////////////////////////////////
 // PhysicalConstants
 
-  double PhysicalConstants::Gravity()
-  {
-    // return -9.8;
-    return -9.81;
-  }
-
-  double PhysicalConstants::G()
-  {
-    return 6.67408E-11;
-  }
-
-  double PhysicalConstants::WaterDensity()
-  {
-    // return 998.6;
-    return 1025.0;
-  }
-
-  double PhysicalConstants::WaterKinematicViscosity()
-  {
-    return 1.0533E-6;
-  }
-
+double PhysicalConstants::Gravity()
+{
+  // return -9.8;
+  return -9.81;
 }
+
+double PhysicalConstants::G()
+{
+  return 6.67408E-11;
 }
+
+double PhysicalConstants::WaterDensity()
+{
+  // return 998.6;
+  return 1025.0;
+}
+
+double PhysicalConstants::WaterKinematicViscosity()
+{
+  return 1.0533E-6;
+}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/Physics.cc
+++ b/gz-waves/src/Physics.cc
@@ -14,23 +14,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/Physics.hh"
-#include "gz/waves/Algorithm.hh"
-#include "gz/waves/Convert.hh"
-#include "gz/waves/Geometry.hh"
-#include "gz/waves/PhysicalConstants.hh"
-#include "gz/waves/Utilities.hh"
-#include "gz/waves/Wavefield.hh"
-#include "gz/waves/WavefieldSampler.hh"
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Timer.h>
-
-#include <gz/math/Pose3.hh>
-#include <gz/math/Vector3.hh>
-#include <gz/common.hh>
-
-#include <sdf/sdf.hh>
 
 #include <array>
 #include <cmath>
@@ -39,1176 +26,1280 @@
 #include <limits>
 #include <string>
 
+#include <gz/math/Pose3.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/common.hh>
+
+#include <sdf/sdf.hh>
+
+#include "gz/waves/Algorithm.hh"
+#include "gz/waves/Convert.hh"
+#include "gz/waves/Geometry.hh"
+#include "gz/waves/PhysicalConstants.hh"
+#include "gz/waves/Utilities.hh"
+#include "gz/waves/Wavefield.hh"
+#include "gz/waves/WavefieldSampler.hh"
+
 namespace gz
 {
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////    
+//////////////////////////////////////////////////
 // Utilities
-  void DebugPrint(const cgal::Triangle& triangle)
-  {
-    gzmsg << "Vertex[0]:   " << triangle[0] << std::endl;
-    gzmsg << "Vertex[1]:   " << triangle[1] << std::endl;
-    gzmsg << "Vertex[2]:   " << triangle[2] << std::endl;
-    gzmsg << "Normal:      " << Geometry::Normal(triangle) << std::endl;
-  }
+void DebugPrint(const cgal::Triangle& triangle)
+{
+  gzmsg << "Vertex[0]:   " << triangle[0] << "\n";
+  gzmsg << "Vertex[1]:   " << triangle[1] << "\n";
+  gzmsg << "Vertex[2]:   " << triangle[2] << "\n";
+  gzmsg << "Normal:      " << Geometry::Normal(triangle) << "\n";
+}
 
-///////////////////////////////////////////////////////////////////////////////    
+//////////////////////////////////////////////////
 // Physics
 
-  cgal::Point3 Physics::CenterOfForce(
-    double _fA, double _fB,
-    const cgal::Point3& _A,
-    const cgal::Point3& _B
-  )
+cgal::Point3 Physics::CenterOfForce(
+  double _fA, double _fB,
+  const cgal::Point3& _A,
+  const cgal::Point3& _B
+)
+{
+  /// \todo provide robust floating point checks
+  double div = _fA + _fB;
+  if (div != 0)
   {
-    /// \todo provide robust floating point checks
-    double div = _fA + _fB;
-    if (div != 0)
-    {
-      double t = _fA / div;
-      return _B + (_A - _B) * t;  
-    }
-    else
-    {
-      return _B;
-    }
+    double t = _fA / div;
+    return _B + (_A - _B) * t;
+  } else {
+    return _B;
   }
+}
 
-  double Physics::DeepWaterDispersionToOmega(double _wavenumber)
+//////////////////////////////////////////////////
+double Physics::DeepWaterDispersionToOmega(double _wavenumber)
+{
+  const double g = std::fabs(PhysicalConstants::Gravity());
+  return std::sqrt(g * _wavenumber);
+}
+
+//////////////////////////////////////////////////
+double Physics::DeepWaterDispersionToWavenumber(double _omega)
+{
+  const double g = std::fabs(PhysicalConstants::Gravity());
+  return _omega * _omega / g;
+}
+
+//////////////////////////////////////////////////
+double Physics::ViscousDragCoefficient(double Rn)
+{
+  // Set a lower limit on Rn to 1.0E+3 since the 1957 ITTC formula
+  // has a pole at Rn = 1.0E+2. For a 10m boat in salt water this
+  // corresponds to a velocity ~ 1.0E-5
+  double r = std::max(1.0E3, Rn);
+  double d = std::log10(r) - 2.0;
+  double d2 = d*d;
+  double CF = 0.075 / d2;
+  return CF;
+}
+
+//////////////////////////////////////////////////
+cgal::Point3 Physics::CenterOfPressureApexUp(
+  double _z0,
+  const cgal::Point3& _H,
+  const cgal::Point3& _M,
+  const cgal::Point3& _B
+)
+{
+  cgal::Vector3 alt = _B - _H;
+  double h = _H.z() - _M.z();
+  double tc = 2.0/3.0;
+  double div = 6.0 * _z0 + 4.0 * h;
+  if (div != 0)
   {
-    const double g = std::fabs(PhysicalConstants::Gravity());
-    return std::sqrt(g * _wavenumber);
+    tc = (4.0 * _z0 + 3.0 * h) / div;
   }
+  return _H + alt * tc;
+}
 
-  double Physics::DeepWaterDispersionToWavenumber(double _omega)
+//////////////////////////////////////////////////
+cgal::Point3 Physics::CenterOfPressureApexDn(
+  double _z0,
+  const cgal::Point3& _L,
+  const cgal::Point3& _M,
+  const cgal::Point3& _B
+)
+{
+  cgal::Vector3 alt = _L - _B;
+  double h = _M.z() - _L.z();
+  double tc = 1.0/3.0;
+  double div = 6.0 * _z0 + 2.0 * h;
+  if (div != 0)
   {
-    const double g = std::fabs(PhysicalConstants::Gravity());
-    return _omega * _omega / g; 
+    tc = (2.0 * _z0 + h) / div;
   }
+  return _B + alt * tc;
+}
 
-  double Physics::ViscousDragCoefficient(double Rn)
+//////////////////////////////////////////////////
+void Physics::BuoyancyForceAtCenterOfPressure(
+  double _depthC,
+  const cgal::Point3& _C,
+  const cgal::Point3& _H,
+  const cgal::Point3& _M,
+  const cgal::Point3& _L,
+  const cgal::Vector3& _normal,
+  cgal::Point3& _center,
+  cgal::Vector3& _force
+)
+{
+  double fluidDensity = PhysicalConstants::WaterDensity();  // kg m^-3
+  double gravity = PhysicalConstants::Gravity();            // m s^-1
+
+  // Split the triangle into upper and lower triangles bisected by a
+  // line normal to the z-axis
+  cgal::Point3 D = Geometry::HorizontalIntercept(_H, _M, _L);
+  cgal::Point3 B = Geometry::MidPoint(_M, D);
+
+  // Initialise to the base midpoint (correct force calcuation for
+  // triangles with a horizontal base)
+  double fU = 0, fL = 0;
+  cgal::Point3 CpU = B;
+  cgal::Point3 CpL = B;
+
+  // Upper triangle H > M
+  if (_H.z() >= _M.z())
   {
-    // Set a lower limit on Rn to 1.0E+3 since the 1957 ITTC formula
-    // has a pole at Rn = 1.0E+2. For a 10m boat in salt water this 
-    // corresponds to a velocity ~ 1.0E-5 
-    double r = std::max(1.0E3, Rn);
-    double d = std::log10(r) - 2.0;
-    double d2 = d*d;
-    double CF = 0.075 / d2;
-    return CF;
-  }
+    // Center of pressure
+    double z0 = _depthC - (_H.z() - _C.z());
+    CpU = CenterOfPressureApexUp(z0, _H, _M, B);
 
-  cgal::Point3 Physics::CenterOfPressureApexUp(
-    double _z0,
-    const cgal::Point3& _H,
-    const cgal::Point3& _M,
-    const cgal::Point3& _B
-  )
-  {
-    cgal::Vector3 alt = _B - _H;
-    double h = _H.z() - _M.z();
-    double tc = 2.0/3.0;    
-    double div = 6.0 * _z0 + 4.0 * h;
-    if (div != 0)
-    {
-      tc = (4.0 * _z0 + 3.0 * h) / div;
-    }
-    return _H + alt * tc;
-  }
-
-  cgal::Point3 Physics::CenterOfPressureApexDn(
-    double _z0,
-    const cgal::Point3& _L,
-    const cgal::Point3& _M,
-    const cgal::Point3& _B
-  )
-  {
-    cgal::Vector3 alt = _L - _B;
-    double h = _M.z() - _L.z();
-    double tc = 1.0/3.0;
-    double div = 6.0 * _z0 + 2.0 * h;
-    if (div != 0)
-    {
-      tc = (2.0 * _z0 + h) / div;  
-    }
-    return _B + alt * tc;
-  }
-
-  void Physics::BuoyancyForceAtCenterOfPressure(
-    double _depthC,
-    const cgal::Point3& _C,
-    const cgal::Point3& _H,
-    const cgal::Point3& _M,
-    const cgal::Point3& _L,
-    const cgal::Vector3& _normal,
-    cgal::Point3& _center, 
-    cgal::Vector3& _force
-  )
-  {
-    double fluidDensity = PhysicalConstants::WaterDensity(); // kg m^-3 
-    double gravity = PhysicalConstants::Gravity();           // m s^-1
-    
-    // Split the triangle into upper and lower triangles bisected by a line normal to the z-axis
-    cgal::Point3 D = Geometry::HorizontalIntercept(_H, _M, _L);
-    cgal::Point3 B = Geometry::MidPoint(_M, D);
-
-    // Initialise to the base midpoint (correct force calcuation for triangles with a horizontal base)    
-    double fU=0, fL=0;
-    cgal::Point3 CpU = B;   
-    cgal::Point3 CpL = B;
-
-    // Upper triangle H > M
-    if (_H.z() >= _M.z())
-    {
-      // Center of pressure
-      double z0 = _depthC - (_H.z() - _C.z());
-      CpU = CenterOfPressureApexUp(z0, _H, _M, B);
-      
-      // Force at centroid
-      cgal::Point3 CU = Geometry::TriangleCentroid(_H, _M, D);
-      double hCU = _depthC + (_C.z() - CU.z());
-      double area = Geometry::TriangleArea(_H, _M, D);
-      fU = fluidDensity * gravity * area * hCU;    
-
-      // @DEBUG_INFO
-      // gzmsg << "_depthC: " << _depthC << std::endl; 
-      // gzmsg << "_C:      " << _C << std::endl; 
-      // gzmsg << "_H:      " << _H << std::endl; 
-      // gzmsg << "_M:      " << _M << std::endl; 
-      // gzmsg << "_L:      " << _L << std::endl; 
-      // gzmsg << "_normal: " << _normal << std::endl; 
-      // gzmsg << "D:       " << D << std::endl; 
-      // gzmsg << "B:       " << B << std::endl; 
-      // gzmsg << "z0:      " << z0 << std::endl; 
-      // gzmsg << "CpU:     " << CpU << std::endl; 
-      // gzmsg << "CU:      " << CU << std::endl; 
-      // gzmsg << "hCU:     " << hCU << std::endl; 
-      // gzmsg << "area:    " << area << std::endl; 
-      // gzmsg << "fU:      " << fU << std::endl; 
-    }
-
-    // Lower triangle L < M
-    if (_M.z() > _L.z())
-    { 
-      // Center of preseesure
-      double z0 = _depthC + (_C.z() - _M.z());
-      CpL = CenterOfPressureApexDn(z0, _L, _M, B);
-      
-      // Force at centroid
-      cgal::Point3 CL = Geometry::TriangleCentroid(_L, _M, D);
-      double hCL = _depthC + (_C.z() - CL.z());
-      double area = Geometry::TriangleArea(_L, _M, D);
-      fL = fluidDensity * gravity * area * hCL;
-
-      // @DEBUG_INFO
-      // gzmsg << "_depthC: " << _depthC << std::endl; 
-      // gzmsg << "_C:      " << _C << std::endl; 
-      // gzmsg << "_H:      " << _H << std::endl; 
-      // gzmsg << "_M:      " << _M << std::endl; 
-      // gzmsg << "_L:      " << _L << std::endl; 
-      // gzmsg << "_normal: " << _normal << std::endl; 
-      // gzmsg << "D:       " << D << std::endl; 
-      // gzmsg << "B:       " << B << std::endl; 
-      // gzmsg << "z0:      " << z0 << std::endl; 
-      // gzmsg << "CpL:     " << CpL << std::endl; 
-      // gzmsg << "CL:      " << CL << std::endl; 
-      // gzmsg << "hCL:     " << hCL << std::endl; 
-      // gzmsg << "area:    " << area << std::endl;
-      // gzmsg << "fL:      " << fL << std::endl; 
-    }
-        
-    // Calculate the force and centre of application
-    _force = _normal * (fU + fL);
-    _center = CenterOfForce(fU, fL, CpU, CpL);
+    // Force at centroid
+    cgal::Point3 CU = Geometry::TriangleCentroid(_H, _M, D);
+    double hCU = _depthC + (_C.z() - CU.z());
+    double area = Geometry::TriangleArea(_H, _M, D);
+    fU = fluidDensity * gravity * area * hCU;
 
     // @DEBUG_INFO
-    // gzmsg << "_depthC: " << _depthC << std::endl;
-    // gzmsg << "_C:      " << _C << std::endl;
-    // gzmsg << "_H:      " << _H << std::endl;
-    // gzmsg << "_M:      " << _M << std::endl;
-    // gzmsg << "_L:      " << _L << std::endl;
-    // gzmsg << "_normal: " << _normal << std::endl;
-    // gzmsg << "_force:  " << _force << std::endl;
-    // gzmsg << "_center: " << _center << std::endl;
+    // gzmsg << "_depthC: " << _depthC << "\n";
+    // gzmsg << "_C:      " << _C << "\n";
+    // gzmsg << "_H:      " << _H << "\n";
+    // gzmsg << "_M:      " << _M << "\n";
+    // gzmsg << "_L:      " << _L << "\n";
+    // gzmsg << "_normal: " << _normal << "\n";
+    // gzmsg << "D:       " << D << "\n";
+    // gzmsg << "B:       " << B << "\n";
+    // gzmsg << "z0:      " << z0 << "\n";
+    // gzmsg << "CpU:     " << CpU << "\n";
+    // gzmsg << "CU:      " << CU << "\n";
+    // gzmsg << "hCU:     " << hCU << "\n";
+    // gzmsg << "area:    " << area << "\n";
+    // gzmsg << "fU:      " << fU << "\n";
   }
 
-  void Physics::BuoyancyForceAtCentroid(
-    const WavefieldSampler& _wavefieldSampler,
-    const cgal::Triangle& _triangle,
-    cgal::Point3& _center,
-    cgal::Vector3& _force
-  )
+  // Lower triangle L < M
+  if (_M.z() > _L.z())
   {
-    // Physical constants
-    double density = PhysicalConstants::WaterDensity();   // kg m^-3 
-    double gravity = PhysicalConstants::Gravity();        // m s^-1
-    
-    // Calculate the triangles centroid
-    _center = Geometry::TriangleCentroid(_triangle);
+    // Center of preseesure
+    double z0 = _depthC + (_C.z() - _M.z());
+    CpL = CenterOfPressureApexDn(z0, _L, _M, B);
 
-    // Calculate the depth
-    double h = _wavefieldSampler.ComputeDepth(_center);
-
-    // Calculate the force
-    cgal::Vector3 normal = Geometry::Normal(_triangle);
-    double area = Geometry::TriangleArea(_triangle);
-    _force = normal * (density * gravity * area * h);
-  }
-
-  void Physics::BuoyancyForceAtCenterOfPressure(
-    const WavefieldSampler& _wavefieldSampler,
-    const cgal::Triangle& _triangle,
-    cgal::Point3& _center,
-    cgal::Vector3& _force
-  )
-  {
-    // Sort triangle vertices by height.
-    std::array<cgal::Point3, 3> v {
-      _triangle[0],
-      _triangle[1],
-      _triangle[2]
-    };
-    std::array<double, 3> vz { v[0].z(), v[1].z(), v[2].z() };
-    auto index = algorithm::sort_indexes(vz); 
-    
-    cgal::Point3 H = v[index[0]];
-    cgal::Point3 M = v[index[1]];
-    cgal::Point3 L = v[index[2]];
+    // Force at centroid
+    cgal::Point3 CL = Geometry::TriangleCentroid(_L, _M, D);
+    double hCL = _depthC + (_C.z() - CL.z());
+    double area = Geometry::TriangleArea(_L, _M, D);
+    fL = fluidDensity * gravity * area * hCL;
 
     // @DEBUG_INFO
-    // DebugPrint(_triangle);
-    // gzmsg << "vz:          "; for (auto z: vz)    { gzmsg << z << " "; }; gzmsg << std::endl;
-    // gzmsg << "index:       "; for (auto i: index) { gzmsg << i << " "; }; gzmsg << std::endl;
-    // gzmsg << "H:           " << H << std::endl;
-    // gzmsg << "M:           " << M << std::endl;
-    // gzmsg << "L:           " << L << std::endl;
-
-    // Calculate the depth at the centroid
-    cgal::Point3 C = Geometry::TriangleCentroid(_triangle);
-
-    // Calculate the depth    
-    double depthC = _wavefieldSampler.ComputeDepth(C);
-
-    cgal::Vector3 normal = Geometry::Normal(_triangle);
-
-    // Calculate buoyancy
-    BuoyancyForceAtCenterOfPressure(depthC, C, H, M, L, normal, _center, _force);
+    // gzmsg << "_depthC: " << _depthC << "\n";
+    // gzmsg << "_C:      " << _C << "\n";
+    // gzmsg << "_H:      " << _H << "\n";
+    // gzmsg << "_M:      " << _M << "\n";
+    // gzmsg << "_L:      " << _L << "\n";
+    // gzmsg << "_normal: " << _normal << "\n";
+    // gzmsg << "D:       " << D << "\n";
+    // gzmsg << "B:       " << B << "\n";
+    // gzmsg << "z0:      " << z0 << "\n";
+    // gzmsg << "CpL:     " << CpL << "\n";
+    // gzmsg << "CL:      " << CL << "\n";
+    // gzmsg << "hCL:     " << hCL << "\n";
+    // gzmsg << "area:    " << area << "\n";
+    // gzmsg << "fL:      " << fL << "\n";
   }
 
-  std::array<double, 3> Physics::ComputeHeightMap(
-    const WavefieldSampler& _wavefieldSampler,
-    const cgal::Triangle& _triangle
-  )
-  {
-    // Heightmap for the triangle vertices
-    cgal::Direction3 direction(0, 0, -1);
-    std::array<double, 3> heightMap;
+  // Calculate the force and centre of application
+  _force = _normal * (fU + fL);
+  _center = CenterOfForce(fU, fL, CpU, CpL);
 
-    // Calculate the height above the surface (-depth)
-    for (Index i=0; i<3; ++i)
+  // @DEBUG_INFO
+  // gzmsg << "_depthC: " << _depthC << "\n";
+  // gzmsg << "_C:      " << _C << "\n";
+  // gzmsg << "_H:      " << _H << "\n";
+  // gzmsg << "_M:      " << _M << "\n";
+  // gzmsg << "_L:      " << _L << "\n";
+  // gzmsg << "_normal: " << _normal << "\n";
+  // gzmsg << "_force:  " << _force << "\n";
+  // gzmsg << "_center: " << _center << "\n";
+}
+
+//////////////////////////////////////////////////
+void Physics::BuoyancyForceAtCentroid(
+  const WavefieldSampler& _wavefieldSampler,
+  const cgal::Triangle& _triangle,
+  cgal::Point3& _center,
+  cgal::Vector3& _force
+)
+{
+  // Physical constants
+  double density = PhysicalConstants::WaterDensity();   // kg m^-3
+  double gravity = PhysicalConstants::Gravity();        // m s^-1
+
+  // Calculate the triangles centroid
+  _center = Geometry::TriangleCentroid(_triangle);
+
+  // Calculate the depth
+  double h = _wavefieldSampler.ComputeDepth(_center);
+
+  // Calculate the force
+  cgal::Vector3 normal = Geometry::Normal(_triangle);
+  double area = Geometry::TriangleArea(_triangle);
+  _force = normal * (density * gravity * area * h);
+}
+
+//////////////////////////////////////////////////
+void Physics::BuoyancyForceAtCenterOfPressure(
+  const WavefieldSampler& _wavefieldSampler,
+  const cgal::Triangle& _triangle,
+  cgal::Point3& _center,
+  cgal::Vector3& _force
+)
+{
+  // Sort triangle vertices by height.
+  std::array<cgal::Point3, 3> v {
+    _triangle[0],
+    _triangle[1],
+    _triangle[2]
+  };
+  std::array<double, 3> vz { v[0].z(), v[1].z(), v[2].z() };
+  auto index = algorithm::sort_indexes(vz);
+
+  cgal::Point3 H = v[index[0]];
+  cgal::Point3 M = v[index[1]];
+  cgal::Point3 L = v[index[2]];
+
+  // @DEBUG_INFO
+  // DebugPrint(_triangle);
+  // gzmsg << "vz:          "; for (auto z: vz)    { gzmsg << z << " "; };
+  // gzmsg << "\n";
+  // gzmsg << "index:       "; for (auto i: index) { gzmsg << i << " "; };
+  // gzmsg << "\n";
+  // gzmsg << "H:           " << H << "\n";
+  // gzmsg << "M:           " << M << "\n";
+  // gzmsg << "L:           " << L << "\n";
+
+  // Calculate the depth at the centroid
+  cgal::Point3 C = Geometry::TriangleCentroid(_triangle);
+
+  // Calculate the depth
+  double depthC = _wavefieldSampler.ComputeDepth(C);
+
+  cgal::Vector3 normal = Geometry::Normal(_triangle);
+
+  // Calculate buoyancy
+  BuoyancyForceAtCenterOfPressure(depthC, C, H, M, L, normal, _center, _force);
+}
+
+//////////////////////////////////////////////////
+std::array<double, 3> Physics::ComputeHeightMap(
+  const WavefieldSampler& _wavefieldSampler,
+  const cgal::Triangle& _triangle
+)
+{
+  // Heightmap for the triangle vertices
+  cgal::Direction3 direction(0, 0, -1);
+  std::array<double, 3> heightMap;
+
+  // Calculate the height above the surface (-depth)
+  for (Index i=0; i < 3; ++i)
+  {
+    cgal::Point3 vertex = _triangle[i];
+    heightMap[i] = -_wavefieldSampler.ComputeDepth(vertex);
+  }
+  return heightMap;
+}
+
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+class HydrodynamicsParametersPrivate
+{
+ public:
+  HydrodynamicsParametersPrivate() :
+    dampingOn(true),
+    cDampL1(1.0E-6),
+    cDampL2(1.0E-6),
+    cDampR1(1.0E-6),
+    cDampR2(1.0E-6),
+    viscousDragOn(true),
+    pressureDragOn(true),
+    cPDrag1(1.0E+2),
+    cPDrag2(1.0E+2),
+    fPDrag(0.4),
+    cSDrag1(1.0E+2),
+    cSDrag2(1.0E+2),
+    fSDrag(0.4),
+    vRDrag(1.0)
+  {}
+
+  // Linear and rotational damping
+  bool dampingOn;
+
+  // Linear drag coefficients
+  double cDampL1;
+  double cDampL2;
+
+  // Rotation drag coefficients
+  double cDampR1;
+  double cDampR2;
+
+  /// Viscous drag
+  bool viscousDragOn;
+
+  /// Pressure drag
+  bool pressureDragOn;
+
+  /// Positive pressure (lift)
+  double cPDrag1;
+  double cPDrag2;
+  double fPDrag;
+  /// Negative pressure (suction)
+  double cSDrag1;
+  double cSDrag2;
+  double fSDrag;
+
+  // Reference speed for the pressure drag calculation
+  double vRDrag;
+};
+
+//////////////////////////////////////////////////
+HydrodynamicsParameters::~HydrodynamicsParameters()
+{
+}
+
+//////////////////////////////////////////////////
+HydrodynamicsParameters::HydrodynamicsParameters() :
+  data(new HydrodynamicsParametersPrivate())
+{
+}
+
+//////////////////////////////////////////////////
+bool HydrodynamicsParameters::DampingOn() const
+{
+  return this->data->dampingOn;
+}
+
+//////////////////////////////////////////////////
+bool HydrodynamicsParameters::ViscousDragOn() const
+{
+  return this->data->viscousDragOn;
+}
+
+//////////////////////////////////////////////////
+bool HydrodynamicsParameters::PressureDragOn() const
+{
+  return this->data->pressureDragOn;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::CDampL1() const
+{
+  return this->data->cDampL1;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::CDampL2() const
+{
+  return this->data->cDampL2;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::CDampR1() const
+{
+  return this->data->cDampR1;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::CDampR2() const
+{
+  return this->data->cDampR2;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::CPDrag1() const
+{
+  return this->data->cPDrag1;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::CPDrag2() const
+{
+  return this->data->cPDrag2;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::FPDrag() const
+{
+  return this->data->fPDrag;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::CSDrag1() const
+{
+  return this->data->cSDrag1;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::CSDrag2() const
+{
+  return this->data->cSDrag2;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::FSDrag() const
+{
+  return this->data->fSDrag;
+}
+
+//////////////////////////////////////////////////
+double HydrodynamicsParameters::VRDrag() const
+{
+  return this->data->vRDrag;
+}
+
+//////////////////////////////////////////////////
+void HydrodynamicsParameters::SetFromMsg(const gz::msgs::Param_V& _msg)
+{
+  this->data->dampingOn      = Utilities::MsgParamBool(
+      _msg,  "damping_on",       this->data->dampingOn);
+  this->data->viscousDragOn  = Utilities::MsgParamBool(
+      _msg,  "viscous_drag_on",  this->data->viscousDragOn);
+  this->data->pressureDragOn = Utilities::MsgParamBool(
+      _msg,  "pressure_drag_on", this->data->pressureDragOn);
+
+  this->data->cDampL1 = Utilities::MsgParamDouble(
+      _msg, "cDampL1",  this->data->cDampL1);
+  this->data->cDampL2 = Utilities::MsgParamDouble(
+      _msg, "cDampL2",  this->data->cDampL2);
+  this->data->cDampR1 = Utilities::MsgParamDouble(
+      _msg, "cDampR1",  this->data->cDampR1);
+  this->data->cDampR2 = Utilities::MsgParamDouble(
+      _msg, "cDampR2",  this->data->cDampR2);
+  this->data->cPDrag1 = Utilities::MsgParamDouble(
+      _msg, "cPDrag1",  this->data->cPDrag1);
+  this->data->cPDrag2 = Utilities::MsgParamDouble(
+      _msg, "cPDrag2",  this->data->cPDrag2);
+  this->data->fPDrag  = Utilities::MsgParamDouble(
+      _msg, "fPDrag",   this->data->fPDrag);
+  this->data->cSDrag1 = Utilities::MsgParamDouble(
+      _msg, "cSDrag1",  this->data->cSDrag1);
+  this->data->cSDrag2 = Utilities::MsgParamDouble(
+      _msg, "cSDrag2",  this->data->cSDrag2);
+  this->data->fSDrag  = Utilities::MsgParamDouble(
+      _msg, "fSDrag",   this->data->fSDrag);
+  this->data->vRDrag  = Utilities::MsgParamDouble(
+      _msg, "vRDrag",   this->data->vRDrag);
+}
+
+//////////////////////////////////////////////////
+void HydrodynamicsParameters::SetFromSDF(sdf::Element& _sdf)
+{
+  this->data->dampingOn      = Utilities::SdfParamBool(
+      _sdf,  "damping_on",       this->data->dampingOn);
+  this->data->viscousDragOn  = Utilities::SdfParamBool(
+      _sdf,  "viscous_drag_on",  this->data->viscousDragOn);
+  this->data->pressureDragOn = Utilities::SdfParamBool(
+      _sdf,  "pressure_drag_on", this->data->pressureDragOn);
+
+  this->data->cDampL1 = Utilities::SdfParamDouble(
+      _sdf, "cDampL1",  this->data->cDampL1);
+  this->data->cDampL2 = Utilities::SdfParamDouble(
+      _sdf, "cDampL2",  this->data->cDampL2);
+  this->data->cDampR1 = Utilities::SdfParamDouble(
+      _sdf, "cDampR1",  this->data->cDampR1);
+  this->data->cDampR2 = Utilities::SdfParamDouble(
+      _sdf, "cDampR2",  this->data->cDampR2);
+  this->data->cPDrag1 = Utilities::SdfParamDouble(
+      _sdf, "cPDrag1",  this->data->cPDrag1);
+  this->data->cPDrag2 = Utilities::SdfParamDouble(
+      _sdf, "cPDrag2",  this->data->cPDrag2);
+  this->data->fPDrag  = Utilities::SdfParamDouble(
+      _sdf, "fPDrag",   this->data->fPDrag);
+  this->data->cSDrag1 = Utilities::SdfParamDouble(
+      _sdf, "cSDrag1",  this->data->cSDrag1);
+  this->data->cSDrag2 = Utilities::SdfParamDouble(
+      _sdf, "cSDrag2",  this->data->cSDrag2);
+  this->data->fSDrag  = Utilities::SdfParamDouble(
+      _sdf, "fSDrag",   this->data->fSDrag);
+  this->data->vRDrag  = Utilities::SdfParamDouble(
+      _sdf, "vRDrag",   this->data->vRDrag);
+}
+
+//////////////////////////////////////////////////
+void HydrodynamicsParameters::DebugPrint() const
+{
+  gzmsg << "damping_on:       " << this->data->dampingOn << "\n";
+  gzmsg << "viscous_drag_on:  " << this->data->viscousDragOn << "\n";
+  gzmsg << "pressure_drag_on: " << this->data->pressureDragOn << "\n";
+  gzmsg << "cDampL1:          " << this->data->cDampL1 << "\n";
+  gzmsg << "cDampL2:          " << this->data->cDampL2 << "\n";
+  gzmsg << "cDampR1:          " << this->data->cDampR1 << "\n";
+  gzmsg << "cDampR2:          " << this->data->cDampR2 << "\n";
+  gzmsg << "cPDrag1:          " << this->data->cPDrag1 << "\n";
+  gzmsg << "cPDrag2:          " << this->data->cPDrag2 << "\n";
+  gzmsg << "fPDrag:           " << this->data->fPDrag << "\n";
+  gzmsg << "cSDrag1:          " << this->data->cSDrag1 << "\n";
+  gzmsg << "cSDrag2:          " << this->data->cSDrag2 << "\n";
+  gzmsg << "fSDrag:           " << this->data->fSDrag << "\n";
+  gzmsg << "vRDrag:           " << this->data->vRDrag << "\n";
+}
+
+//////////////////////////////////////////////////
+
+class TriangleProperties
+{
+ public:
+  TriangleProperties() :
+    index(0),
+    normal(CGAL::NULL_VECTOR),
+    area(std::numeric_limits<double>::signaling_NaN()),
+    subArea(std::numeric_limits<double>::signaling_NaN()),
+    vh(CGAL::ORIGIN),
+    vm(CGAL::ORIGIN),
+    vl(CGAL::ORIGIN),
+    hh(std::numeric_limits<double>::signaling_NaN()),
+    hm(std::numeric_limits<double>::signaling_NaN()),
+    hl(std::numeric_limits<double>::signaling_NaN())
+  {
+  }
+
+  Index index;                        // index to the original triangle
+  cgal::Vector3 normal;               // triangle normal
+  double area;                        // area
+  double subArea;                     // submerged area
+  std::array<double, 3> heightMap;    // heightmap[3] - unsorted
+  cgal::Point3 vh;                    // high vertex
+  cgal::Point3 vm;                    // mid vertex
+  cgal::Point3 vl;                    // low vertex
+  double hh;                          // high vertex height
+  double hm;                          // mid vertex height
+  double hl;                          // low vertex height
+};
+
+//////////////////////////////////////////////////
+void DebugPrint(const TriangleProperties& props)
+{
+  gzmsg << "index:        " << props.index << "\n";
+  gzmsg << "normal:       " << props.normal << "\n";
+  gzmsg << "area:         " << props.area << "\n";
+  gzmsg << "subArea:      " << props.subArea << "\n";
+  gzmsg << "vh:           " << props.vh << "\n";
+  gzmsg << "vm:           " << props.vm << "\n";
+  gzmsg << "vl:           " << props.vl << "\n";
+  gzmsg << "hh:           " << props.hh << "\n";
+  gzmsg << "hm:           " << props.hm << "\n";
+  gzmsg << "hl:           " << props.hl << "\n";
+}
+
+//////////////////////////////////////////////////
+class SubmergedTriangleProperties
+{
+ public:
+  SubmergedTriangleProperties() :
+    index(0),
+    normal(CGAL::NULL_VECTOR),
+    centroid(CGAL::ORIGIN),
+    xr(CGAL::NULL_VECTOR),
+    area(std::numeric_limits<double>::signaling_NaN()),
+    vp(CGAL::NULL_VECTOR),
+    up(CGAL::NULL_VECTOR),
+    cosTheta(std::numeric_limits<double>::signaling_NaN()),
+    vn(CGAL::NULL_VECTOR),
+    vt(CGAL::NULL_VECTOR),
+    ut(CGAL::NULL_VECTOR),
+    uf(CGAL::NULL_VECTOR),
+    vf(CGAL::NULL_VECTOR)
+  {
+  }
+
+  Index index;            // index to the original triangle
+  cgal::Vector3 normal;   // triangle normal
+  cgal::Point3 centroid;  // triangle centroid = r
+  cgal::Vector3 xr;       // xr = centroid - CoM = (r - x)
+  double area;            // area
+  cgal::Vector3 vp;       // point velocity vp = v + omega x r,
+                                  // where r = centroid - CoM
+  cgal::Vector3 up;       // normalized point velocity.
+  double cosTheta;        // cos[theta] = up . normal
+  cgal::Vector3 vn;       // point velocity normal to surface
+                                  // vn = (vp . normal) normal
+  cgal::Vector3 vt;       // point velocity tangential to surface
+                                  // vt = vp - vn
+  cgal::Vector3 ut;       // normalized tangential point velocity.
+  cgal::Vector3 uf;       // direction of tangential flow.
+                                  // uf = - vt / ||vt|| = - ut
+  cgal::Vector3 vf;       // tangential flow vf = ||vp|| uf
+};
+
+//////////////////////////////////////////////////
+void DebugPrint(const SubmergedTriangleProperties& props)
+{
+  gzmsg << "index:        " << props.index << "\n";
+  gzmsg << "normal:       " << props.normal << "\n";
+  gzmsg << "centroid:     " << props.centroid << "\n";
+  gzmsg << "xr:           " << props.xr << "\n";
+  gzmsg << "area:         " << props.area << "\n";
+  gzmsg << "vp:           " << props.vp << "\n";
+  gzmsg << "up:           " << props.up << "\n";
+  gzmsg << "cosTheta:     " << props.cosTheta << "\n";
+  gzmsg << "vn:           " << props.vn << "\n";
+  gzmsg << "vt:           " << props.vt << "\n";
+  gzmsg << "ut:           " << props.ut << "\n";
+  gzmsg << "uf:           " << props.uf << "\n";
+  gzmsg << "vf:           " << props.vf << "\n";
+}
+
+//////////////////////////////////////////////////
+
+class HydrodynamicsPrivate
+{
+ public:
+  /// \brief The hydrodynamics parameters.
+  std::shared_ptr<const HydrodynamicsParameters> params;
+
+  /// \brief The mesh of the rigid body described by this model link.
+  std::shared_ptr<const cgal::Mesh> linkMesh;
+
+  /// \brief The wavefield sampler for this rigid body (linkMesh).
+  std::shared_ptr<const WavefieldSampler>  wavefieldSampler;
+
+  /// \brief Pose of the centre of mass.
+  gz::math::Pose3d pose;
+
+  /// \brief Position of the centre of mass (CGAL types).
+  cgal::Point3 position;
+
+  // \brief Linear velocity of the centre of mass.
+  cgal::Vector3 linVelocity;
+
+  /// \brief Angular velocity of the centre of mass.
+  cgal::Vector3 angVelocity;
+
+  /// \brief The calculated waterline length.
+  double waterlineLength;
+
+  /// \brief The depth at each vertex point.
+  cgal::Mesh::Property_map<cgal::Mesh::Vertex_index, double> depths;
+  std::vector<cgal::Triangle> submergedTriangles;
+  std::vector<TriangleProperties> triangleProperties;
+  std::vector<SubmergedTriangleProperties> submergedTriangleProperties;
+  std::vector<cgal::Line> waterline;
+
+  double area;
+
+  double submergedArea;
+
+  // Keep buoyance force and center of pressure for debugging...
+  std::vector<cgal::Vector3> fBuoyancy;
+  std::vector<cgal::Point3>  cBuoyancy;
+
+  /// \brief The computed force
+  cgal::Vector3 force;
+
+  /// \brief The computed torque
+  cgal::Vector3 torque;
+};
+
+//////////////////////////////////////////////////
+
+Hydrodynamics::Hydrodynamics(
+  std::shared_ptr<const HydrodynamicsParameters> _params,
+  std::shared_ptr<const cgal::Mesh> _linkMesh,
+  std::shared_ptr<const WavefieldSampler> _wavefieldSampler
+) : data(new HydrodynamicsPrivate())
+{
+  this->data->params = _params;
+  this->data->linkMesh = _linkMesh;
+  this->data->wavefieldSampler = _wavefieldSampler;
+  this->data->position = CGAL::ORIGIN;
+  this->data->linVelocity = CGAL::NULL_VECTOR;
+  this->data->angVelocity = CGAL::NULL_VECTOR;
+  this->data->waterlineLength = 0.0;
+}
+
+//////////////////////////////////////////////////
+void Hydrodynamics::Update(
+  std::shared_ptr<const WavefieldSampler> _wavefieldSampler,
+  const gz::math::Pose3d& _pose,
+  const cgal::Vector3& _linVelocity,
+  const cgal::Vector3& _angVelocity
+)
+{
+  // Set rigid body props.
+  this->data->wavefieldSampler = _wavefieldSampler;
+  this->data->pose = _pose;
+  this->data->position = ToPoint3(_pose.Pos());
+  this->data->linVelocity = _linVelocity;
+  this->data->angVelocity = _angVelocity;
+
+  // Reset
+  this->data->force = CGAL::NULL_VECTOR;
+  this->data->torque = CGAL::NULL_VECTOR;
+
+  // Update physics
+  this->UpdateSubmergedTriangles();
+  this->ComputeAreas();
+  this->ComputeWaterlineLength();
+  this->ComputePointVelocities();
+  this->ComputeBuoyancyForce();
+
+  if (this->data->params->ViscousDragOn())
+    this->ComputeViscousDragForce();
+
+  if (this->data->params->PressureDragOn())
+    this->ComputePressureDragForce();
+
+  if (this->data->params->DampingOn())
+    this->ComputeDampingForce();
+}
+
+//////////////////////////////////////////////////
+const cgal::Vector3& Hydrodynamics::Force() const
+{
+  return this->data->force;
+}
+
+//////////////////////////////////////////////////
+const cgal::Vector3& Hydrodynamics::Torque() const
+{
+  return this->data->torque;
+}
+
+//////////////////////////////////////////////////
+const std::vector<cgal::Line>& Hydrodynamics::GetWaterline() const
+{
+  return this->data->waterline;
+}
+
+//////////////////////////////////////////////////
+const std::vector<cgal::Triangle>& Hydrodynamics::GetSubmergedTriangles() const
+{
+  return this->data->submergedTriangles;
+}
+
+//////////////////////////////////////////////////
+void Hydrodynamics::UpdateSubmergedTriangles()
+{
+  this->data->submergedTriangles.clear();
+  this->data->triangleProperties.clear();
+  this->data->submergedTriangleProperties.clear();
+  this->data->waterline.clear();
+
+  auto& linkMesh = *this->data->linkMesh;
+  auto& wavefieldSampler = *this->data->wavefieldSampler;
+
+  // @TODO_FRAGILE - prefer not to const_cast... assign prop map at creation.
+  // Compute depths
+  auto& ncLinkMesh = const_cast<cgal::Mesh&>(*this->data->linkMesh);
+  auto pair = ncLinkMesh.add_property_map<
+      cgal::Mesh::Vertex_index, double>("v:depth", 0);
+  this->data->depths = pair.first;
+  for (auto&& v : linkMesh.vertices())
+  {
+    this->data->depths[v] = wavefieldSampler.ComputeDepth(linkMesh.point(v));
+  }
+
+  // Get a list of the meshes exterior triangles
+  for (auto&& face : linkMesh.faces())
+  {
+    cgal::Triangle triangle = Geometry::MakeTriangle(linkMesh, face);
+
+    TriangleProperties triProps;
+    // triProps.index = i;
+    triProps.normal = Geometry::Normal(triangle);
+    triProps.area = Geometry::TriangleArea(triangle);
+
+    // @TODO_OPTIMISE - compute depth once for each vertex then assign
+    // height to each triangle
+    // triProps.heightMap =
+    //      Physics::ComputeHeightMap(wavefieldSampler, triangle);
+
+    // Note sign change for height.
+    const auto& rng = CGAL::vertices_around_face(
+        linkMesh.halfedge(face), linkMesh);
+    for (
+      auto&& it = std::make_pair(std::begin(rng), 0);
+      it.first != std::end(rng);
+      ++it.first, ++it.second)
     {
-      cgal::Point3 vertex = _triangle[i];
-      heightMap[i] = -_wavefieldSampler.ComputeDepth(vertex);
+      triProps.heightMap[it.second] = -this->data->depths[*it.first];
     }
-    return heightMap;
-  }    
 
-///////////////////////////////////////////////////////////////////////////////
-// HydrodynamicsParameters
+    this->data->triangleProperties.push_back(triProps);
 
-  class HydrodynamicsParametersPrivate
+    // Populate the submerged sub-triangles
+    this->PopulateSubmergedTriangle(triangle, triProps);
+
+    // @DEBUG_INFO
+    // DebugPrint(triangle);
+    // DebugPrint(triProps);
+  }
+
+  // @DEBUG_INFO
+  // gzmsg << "TriCount: " << this->data->triangleProperties.size() << "\n";
+  // for (auto triProps : this->data->triangleProperties)
+  // {
+  //   DebugPrint(triProps);
+  // }
+  // gzmsg << "SubTriCount: " << this->data->submergedTriangles.size() << "\n";
+  // for (auto subTriProps : this->data->submergedTriangleProperties)
+  // {
+  //   DebugPrint(subTriProps);
+  // }
+}
+
+//////////////////////////////////////////////////
+void Hydrodynamics::PopulateSubmergedTriangle(
+  const cgal::Triangle& _triangle,
+  TriangleProperties& _triProps)
+{
+  // Calculations
+  const Index H = 0, M = 1, L = 2;
+  std::array<Index, 3> idx = algorithm::sort_indexes(_triProps.heightMap);
+
+  _triProps.hh = _triProps.heightMap[idx[H]];
+  _triProps.hm = _triProps.heightMap[idx[M]];
+  _triProps.hl = _triProps.heightMap[idx[L]];
+
+  _triProps.vh = _triangle[idx[H]];
+  _triProps.vm = _triangle[idx[M]];
+  _triProps.vl = _triangle[idx[L]];
+
+  if (_triProps.hh > 0)
   {
-    public: HydrodynamicsParametersPrivate() :
-      dampingOn(true),
-      cDampL1(1.0E-6),
-      cDampL2(1.0E-6),
-      cDampR1(1.0E-6),
-      cDampR2(1.0E-6),
-      viscousDragOn(true),
-      pressureDragOn(true),
-      cPDrag1(1.0E+2),
-      cPDrag2(1.0E+2),
-      fPDrag(0.4),
-      cSDrag1(1.0E+2),
-      cSDrag2(1.0E+2),
-      fSDrag(0.4),
-      vRDrag(1.0)
-    {}
+    if (_triProps.hm > 0)
+    {
+      if (_triProps.hl > 0)
+      {
+        // no-op
+      } else {
+        this->SplitPartiallySubmergedTriangle1(_triProps);
+      }
+    } else {
+      this->SplitPartiallySubmergedTriangle2(_triProps);
+    }
+  } else {
+    this->AddFullySubmergedTriangle(_triProps);
+  }
+}
 
-    // Linear and rotational damping
-    public: bool dampingOn;
+//////////////////////////////////////////////////
+void Hydrodynamics::SplitPartiallySubmergedTriangle1(
+    TriangleProperties& _triProps)
+{
+  cgal::Vector3& n = _triProps.normal;
+  cgal::Point3& vh = _triProps.vh;
+  cgal::Point3& vm = _triProps.vm;
+  cgal::Point3& vl = _triProps.vl;
+  double hh = _triProps.hh;
+  double hm = _triProps.hm;
+  double hl = _triProps.hl;
+
+  double tm = -hl/(hm - hl);
+  double th = -hl/(hh - hl);
+
+  cgal::Point3 vmi = vl + (vm - vl) * tm;
+  cgal::Point3 vhi = vl + (vh - vl) * th;
+
+  // @DEBUG_INFO
+  // gzmsg << "index:         " << _triProps.index << "\n";
+  // gzmsg << "vmi:           " << vmi << "\n";
+  // gzmsg << "vhi:           " << vhi << "\n";
+
+  // Create the new submerged triangle
+  cgal::Triangle tri0(vl, vmi, vhi);
+  if (CGAL::scalar_product(n, Geometry::Normal(tri0)) < 0.0)
+  {
+    // Change orientation
+    tri0 = cgal::Triangle(vl, vhi, vmi);
+  }
+  this->data->submergedTriangles.push_back(tri0);
+
+  // Properties of the submerged tri0
+  SubmergedTriangleProperties subTriProps0;
+  subTriProps0.index = _triProps.index;
+  subTriProps0.normal = Geometry::Normal(tri0);
+  subTriProps0.centroid = Geometry::TriangleCentroid(tri0);
+  subTriProps0.area = Geometry::TriangleArea(tri0);
+  this->data->submergedTriangleProperties.push_back(subTriProps0);
+
+  // Fraction of original triangle submerged.
+  _triProps.subArea = subTriProps0.area;
+
+  // Create a new line (for the water line)
+  cgal::Line line(vmi, vhi);
+  this->data->waterline.push_back(line);
+}
+
+//////////////////////////////////////////////////
+void Hydrodynamics::SplitPartiallySubmergedTriangle2(
+    TriangleProperties& _triProps)
+{
+  cgal::Vector3& n = _triProps.normal;
+  cgal::Point3& vh = _triProps.vh;
+  cgal::Point3& vm = _triProps.vm;
+  cgal::Point3& vl = _triProps.vl;
+  double hh = _triProps.hh;
+  double hm = _triProps.hm;
+  double hl = _triProps.hl;
+
+  double tm = -hm/(hh - hm);
+  double tl = -hl/(hh - hl);
+
+  cgal::Point3 vmi =  vm + (vh - vm) * tm;
+  cgal::Point3 vli =  vl + (vh - vl) * tl;
+
+  // Create the new submerged triangles
+  cgal::Triangle tri0(vm, vmi, vl);
+  cgal::Triangle tri1(vmi, vli, vl);
+
+  if (CGAL::scalar_product(n, Geometry::Normal(tri0)) < 0.0)
+  {
+    tri0 = cgal::Triangle(vmi, vm, vl);
+  }
+  if (CGAL::scalar_product(n, Geometry::Normal(tri1)) < 0.0)
+  {
+    tri1 = cgal::Triangle(vli, vmi, vl);
+  }
+
+  this->data->submergedTriangles.push_back(tri0);
+  this->data->submergedTriangles.push_back(tri1);
+
+  // Properties of the submerged tri0
+  SubmergedTriangleProperties subTriProps0;
+  subTriProps0.index = _triProps.index;
+  subTriProps0.normal = Geometry::Normal(tri0);
+  subTriProps0.centroid = Geometry::TriangleCentroid(tri0);
+  subTriProps0.area = Geometry::TriangleArea(tri0);
+  this->data->submergedTriangleProperties.push_back(subTriProps0);
+
+  // Properties of the submerged tri1
+  SubmergedTriangleProperties subTriProps1;
+  subTriProps1.index = _triProps.index;
+  subTriProps1.normal = Geometry::Normal(tri1);
+  subTriProps1.centroid = Geometry::TriangleCentroid(tri1);
+  subTriProps1.area = Geometry::TriangleArea(tri1);
+  this->data->submergedTriangleProperties.push_back(subTriProps1);
+
+  // Fraction of original triangle submerged.
+  _triProps.subArea = subTriProps0.area + subTriProps1.area;
+
+  // Create a new line (for the water line)
+  cgal::Line line(vmi, vli);
+  this->data->waterline.push_back(line);
+}
+
+//////////////////////////////////////////////////
+void Hydrodynamics::AddFullySubmergedTriangle(
+    TriangleProperties& _triProps)
+{
+  // Add the full triangle
+  cgal::Vector3& n = _triProps.normal;
+  cgal::Point3& vh = _triProps.vh;
+  cgal::Point3& vm = _triProps.vm;
+  cgal::Point3& vl = _triProps.vl;
+
+  // Create the new submerged triangle
+  cgal::Triangle tri(vh, vm, vl);
+  if (CGAL::scalar_product(n, Geometry::Normal(tri)) < 0.0)
+  {
+    tri = cgal::Triangle(vm, vh, vl);
+  }
+  this->data->submergedTriangles.push_back(tri);
+
+  // Properties of the submerged triangle
+  SubmergedTriangleProperties subTriProps;
+  subTriProps.index = _triProps.index;
+  subTriProps.normal = _triProps.normal;
+  subTriProps.centroid = Geometry::TriangleCentroid(tri);
+  subTriProps.area = _triProps.area;
+  this->data->submergedTriangleProperties.push_back(subTriProps);
+
+  // Fraction of original triangle submerged.
+  _triProps.subArea = subTriProps.area;
+}
+
+//////////////////////////////////////////////////
+void Hydrodynamics::ComputeAreas()
+{
+  double area = 0.0;
+  for (auto&& props : this->data->triangleProperties)
+  {
+    area += props.area;
+  }
+  this->data->area = area;
+
+  double subArea = 0.0;
+  for (auto&& props : this->data->submergedTriangleProperties)
+  {
+    subArea += props.area;
+  }
+  this->data->submergedArea = subArea;
+}
+
+//////////////////////////////////////////////////
+void Hydrodynamics::ComputeWaterlineLength()
+{
+  // Calculate the direction of the x-axis
+  cgal::Vector3 xaxis = ToVector3(this->data->pose.Rot().RotateVector(
+    gz::math::Vector3d(1, 0, 0)));
+
+  // Project the waterline onto the x-axis
+  double length = 0.0;
+  for (auto&& line : this->data->waterline)
+  {
+    length += std::abs(CGAL::scalar_product(line.to_vector(), xaxis));
+  }
+  length *= 0.5;
+  this->data->waterlineLength = length;
+  // @DEBUG_INFO
+  // gzmsg << "waterline length: " << length << "\n";
+}
+
+//////////////////////////////////////////////////
+// Compute the point velocity at a triangles centroid
+void Hydrodynamics::ComputePointVelocities()
+{
+  auto& position = this->data->position;
+  auto& v = this->data->linVelocity;
+  auto& omega = this->data->angVelocity;
+
+  for (auto&& subTriProps : this->data->submergedTriangleProperties)
+  {
+    // relative position of the centroid wrt CoM
+    subTriProps.xr = subTriProps.centroid - position;
+
+    // vp = v + omega x xr
+    subTriProps.vp = v + CGAL::cross_product(omega, subTriProps.xr);
+
+    // up = vp / ||vp||
+    subTriProps.up = Geometry::Normalize(subTriProps.vp);
+
+    // cos(theta) = up . n
+    subTriProps.cosTheta = CGAL::scalar_product(
+        subTriProps.up, subTriProps.normal);
+
+    // vn = (up . n) n
+    subTriProps.vn = subTriProps.normal * subTriProps.cosTheta;
+
+    // vt = vp - vn
+    subTriProps.vt = subTriProps.vp - subTriProps.vn;
+
+    // un = vn / ||vn||
+    // subTriProps.un = Geometry::Normalize(subTriProps.vn);
+
+    // ut = vt / ||vt||
+    subTriProps.ut = Geometry::Normalize(subTriProps.vt);
+
+    // uf = - vt / ||vt|| = - ut
+    subTriProps.uf = - subTriProps.ut;
+
+    // vf = ||vp|| uf
+    subTriProps.vf =
+        subTriProps.uf * std::sqrt(subTriProps.vp.squared_length());
+  }
+}
+
+//////////////////////////////////////////////////
+// Compute the Reynolds number
+double Hydrodynamics::ComputeReynoldsNumber() const
+{
+  // fluid speed
+  auto& v = this->data->linVelocity;
+  double u = std::sqrt(v.squared_length());
+
+  // characteristic length
+  double L = this->data->waterlineLength;
+
+  // Reynolds number
+  double kv = PhysicalConstants::WaterKinematicViscosity();
+  double Rn = u * L / kv;
+
+  return Rn;
+}
+
+//////////////////////////////////////////////////
+void Hydrodynamics::ComputeBuoyancyForce()
+{
+  cgal::Vector3 sumForce  = CGAL::NULL_VECTOR;
+  cgal::Vector3 sumTorque = CGAL::NULL_VECTOR;
+
+  this->data->fBuoyancy.clear();
+  this->data->cBuoyancy.clear();
+
+  // Calculate the buoyancy force for the submerged triangles
+  auto& position  =  this->data->position;
+  auto& wavefieldSampler = *this->data->wavefieldSampler;
+  for (auto&& subTri : this->data->submergedTriangles)
+  {
+    // Force and center of pressure.
+    cgal::Point3 center = CGAL::ORIGIN;
+    cgal::Vector3 force = CGAL::NULL_VECTOR;
+    Physics::BuoyancyForceAtCenterOfPressure(
+      wavefieldSampler, subTri, center, force);
+    this->data->fBuoyancy.push_back(force);
+    this->data->cBuoyancy.push_back(center);
+
+    // Torque
+    cgal::Vector3 xr = center - position;
+    cgal::Vector3 torque = CGAL::cross_product(xr, force);
+    sumForce += force;
+    sumTorque += torque;
+  }
+
+  this->data->force  += sumForce;
+  this->data->torque += sumTorque;
+}
+
+//////////////////////////////////////////////////
+void Hydrodynamics::ComputeDampingForce()
+{
+  auto& params = *this->data->params;
 
     // Linear drag coefficients
-    public: double cDampL1;
-    public: double cDampL2;
+  double cDampL1 = params.CDampL1();
+  double cDampR1 = params.CDampR1();
 
-    // Rotation drag coefficients
-    public: double cDampR1;
-    public: double cDampR2;
+  // Quadratic drag coefficients
+  double cDampL2 = params.CDampL2();
+  double cDampR2 = params.CDampR2();
 
-    /// Viscous drag
-    public: bool viscousDragOn;
+  double area = this->data->area;
+  double subArea = this->data->submergedArea;
+  double rs = subArea / area;
 
-    /// Pressure drag
-    public: bool pressureDragOn;
+  // Force
+  auto& v = this->data->linVelocity;
+  double linSpeed = std::sqrt(v.squared_length());
+  double cL = - rs * (cDampL1 + cDampL2 * linSpeed);
+  cgal::Vector3 force = v * cL;
 
-    /// Positive pressure (lift)
-    public: double cPDrag1;
-    public: double cPDrag2;
-    public: double fPDrag;
-    /// Negative pressure (suction)
-    public: double cSDrag1;
-    public: double cSDrag2;
-    public: double fSDrag;
-    
-    // Reference speed for the pressure drag calculation
-    public: double vRDrag;
+  auto& omega = this->data->angVelocity;
+  double angSpeed = std::sqrt(omega.squared_length());
+  double cR = - rs * (cDampR1 + cDampR2 * angSpeed);
+  cgal::Vector3 torque = omega * cR;
 
-  };
+  this->data->force  += force;
+  this->data->torque += torque;
 
-  HydrodynamicsParameters::~HydrodynamicsParameters()
+  // @DEBUG_INF0
+  // gzmsg << "area:       " << area << "\n";
+  // gzmsg << "subArea:    " << subArea << "\n";
+  // gzmsg << "v:          " << v << "\n";
+  // gzmsg << "omega:      " << omega << "\n";
+  // gzmsg << "linSpeed:   " << linSpeed << "\n";
+  // gzmsg << "angSpeed:   " << angSpeed << "\n";
+  // gzmsg << "cR:         " << cR << "\n";
+  // gzmsg << "cL:         " << cL << "\n";
+  // gzmsg << "force:      " << force << "\n";
+  // gzmsg << "torque:     " << torque << "\n";
+}
+
+//////////////////////////////////////////////////
+// Viscous drag force - applied at triangle centroid.
+void Hydrodynamics::ComputeViscousDragForce()
+{
+  double rho = PhysicalConstants::WaterDensity();
+  double Rn = this->ComputeReynoldsNumber();
+  double cF = Physics::ViscousDragCoefficient(Rn);
+
+  cgal::Vector3 sumForce  = CGAL::NULL_VECTOR;
+  cgal::Vector3 sumTorque = CGAL::NULL_VECTOR;
+  for (auto&& subTriProps : this->data->submergedTriangleProperties)
   {
-  }
-
-  HydrodynamicsParameters::HydrodynamicsParameters() :
-    data(new HydrodynamicsParametersPrivate())
-  {
-  }
-
-  bool HydrodynamicsParameters::DampingOn() const
-  {
-    return this->data->dampingOn;
-  }
-
-  bool HydrodynamicsParameters::ViscousDragOn() const
-  {
-    return this->data->viscousDragOn;
-  }
-
-  bool HydrodynamicsParameters::PressureDragOn() const
-  {
-    return this->data->pressureDragOn;
-  }
-
-  double HydrodynamicsParameters::CDampL1() const
-  {
-    return this->data->cDampL1;
-  }
-
-  double HydrodynamicsParameters::CDampL2() const
-  {
-    return this->data->cDampL2;
-  }
-
-  double HydrodynamicsParameters::CDampR1() const
-  {
-    return this->data->cDampR1;
-  }
-
-  double HydrodynamicsParameters::CDampR2() const
-  {
-    return this->data->cDampR2;
-  }
-
-  double HydrodynamicsParameters::CPDrag1() const
-  {
-    return this->data->cPDrag1;
-  }
-
-  double HydrodynamicsParameters::CPDrag2() const
-  {
-    return this->data->cPDrag2;
-  }
-
-  double HydrodynamicsParameters::FPDrag() const
-  {
-    return this->data->fPDrag;
-  }
-
-  double HydrodynamicsParameters::CSDrag1() const
-  {
-    return this->data->cSDrag1;
-  }
-
-  double HydrodynamicsParameters::CSDrag2() const
-  {
-    return this->data->cSDrag2;
-  }
-
-  double HydrodynamicsParameters::FSDrag() const
-  {
-    return this->data->fSDrag;
-  }
-  
-  double HydrodynamicsParameters::VRDrag() const
-  {
-    return this->data->vRDrag;
-  }
-
-  void HydrodynamicsParameters::SetFromMsg(const gz::msgs::Param_V& _msg)
-  {
-    this->data->dampingOn      = Utilities::MsgParamBool(_msg,  "damping_on",       this->data->dampingOn);
-    this->data->viscousDragOn  = Utilities::MsgParamBool(_msg,  "viscous_drag_on",  this->data->viscousDragOn);
-    this->data->pressureDragOn = Utilities::MsgParamBool(_msg,  "pressure_drag_on", this->data->pressureDragOn);
-
-    this->data->cDampL1 = Utilities::MsgParamDouble(_msg, "cDampL1",  this->data->cDampL1);
-    this->data->cDampL2 = Utilities::MsgParamDouble(_msg, "cDampL2",  this->data->cDampL2);
-    this->data->cDampR1 = Utilities::MsgParamDouble(_msg, "cDampR1",  this->data->cDampR1);
-    this->data->cDampR2 = Utilities::MsgParamDouble(_msg, "cDampR2",  this->data->cDampR2);
-    this->data->cPDrag1 = Utilities::MsgParamDouble(_msg, "cPDrag1",  this->data->cPDrag1);
-    this->data->cPDrag2 = Utilities::MsgParamDouble(_msg, "cPDrag2",  this->data->cPDrag2);
-    this->data->fPDrag  = Utilities::MsgParamDouble(_msg, "fPDrag",   this->data->fPDrag);
-    this->data->cSDrag1 = Utilities::MsgParamDouble(_msg, "cSDrag1",  this->data->cSDrag1);
-    this->data->cSDrag2 = Utilities::MsgParamDouble(_msg, "cSDrag2",  this->data->cSDrag2);
-    this->data->fSDrag  = Utilities::MsgParamDouble(_msg, "fSDrag",   this->data->fSDrag);
-    this->data->vRDrag  = Utilities::MsgParamDouble(_msg, "vRDrag",   this->data->vRDrag);
-  }
-
-  void HydrodynamicsParameters::SetFromSDF(sdf::Element& _sdf)
-  {
-    this->data->dampingOn      = Utilities::SdfParamBool(_sdf,  "damping_on",       this->data->dampingOn);
-    this->data->viscousDragOn  = Utilities::SdfParamBool(_sdf,  "viscous_drag_on",  this->data->viscousDragOn);
-    this->data->pressureDragOn = Utilities::SdfParamBool(_sdf,  "pressure_drag_on", this->data->pressureDragOn);
-
-    this->data->cDampL1 = Utilities::SdfParamDouble(_sdf, "cDampL1",  this->data->cDampL1);
-    this->data->cDampL2 = Utilities::SdfParamDouble(_sdf, "cDampL2",  this->data->cDampL2);
-    this->data->cDampR1 = Utilities::SdfParamDouble(_sdf, "cDampR1",  this->data->cDampR1);
-    this->data->cDampR2 = Utilities::SdfParamDouble(_sdf, "cDampR2",  this->data->cDampR2);
-    this->data->cPDrag1 = Utilities::SdfParamDouble(_sdf, "cPDrag1",  this->data->cPDrag1);
-    this->data->cPDrag2 = Utilities::SdfParamDouble(_sdf, "cPDrag2",  this->data->cPDrag2);
-    this->data->fPDrag  = Utilities::SdfParamDouble(_sdf, "fPDrag",   this->data->fPDrag);
-    this->data->cSDrag1 = Utilities::SdfParamDouble(_sdf, "cSDrag1",  this->data->cSDrag1);
-    this->data->cSDrag2 = Utilities::SdfParamDouble(_sdf, "cSDrag2",  this->data->cSDrag2);
-    this->data->fSDrag  = Utilities::SdfParamDouble(_sdf, "fSDrag",   this->data->fSDrag);
-    this->data->vRDrag  = Utilities::SdfParamDouble(_sdf, "vRDrag",   this->data->vRDrag);
-  }
-
-  void HydrodynamicsParameters::DebugPrint() const
-  {
-    gzmsg << "damping_on:       " << this->data->dampingOn << std::endl;
-    gzmsg << "viscous_drag_on:  " << this->data->viscousDragOn << std::endl;
-    gzmsg << "pressure_drag_on: " << this->data->pressureDragOn << std::endl;
-    gzmsg << "cDampL1:          " << this->data->cDampL1 << std::endl;
-    gzmsg << "cDampL2:          " << this->data->cDampL2 << std::endl;
-    gzmsg << "cDampR1:          " << this->data->cDampR1 << std::endl;
-    gzmsg << "cDampR2:          " << this->data->cDampR2 << std::endl;
-    gzmsg << "cPDrag1:          " << this->data->cPDrag1 << std::endl;
-    gzmsg << "cPDrag2:          " << this->data->cPDrag2 << std::endl;
-    gzmsg << "fPDrag:           " << this->data->fPDrag << std::endl;
-    gzmsg << "cSDrag1:          " << this->data->cSDrag1 << std::endl;
-    gzmsg << "cSDrag2:          " << this->data->cSDrag2 << std::endl;
-    gzmsg << "fSDrag:           " << this->data->fSDrag << std::endl;
-    gzmsg << "vRDrag:           " << this->data->vRDrag << std::endl;
-  }
-
-///////////////////////////////////////////////////////////////////////////////    
-// TriangleProperties / SubmergedTriangleProperties
-
-  class TriangleProperties
-  {
-    public: TriangleProperties() :
-      index(0),
-      normal(CGAL::NULL_VECTOR),
-      area(std::numeric_limits<double>::signaling_NaN()),
-      subArea(std::numeric_limits<double>::signaling_NaN()),
-      vh(CGAL::ORIGIN),
-      vm(CGAL::ORIGIN),
-      vl(CGAL::ORIGIN),
-      hh(std::numeric_limits<double>::signaling_NaN()),
-      hm(std::numeric_limits<double>::signaling_NaN()),
-      hl(std::numeric_limits<double>::signaling_NaN())
-    {
-    }
-
-    public: Index index;                       // index to the original triangle  
-    public: cgal::Vector3 normal;                     // triangle normal
-    public: double area;                        // area
-    public: double subArea;                     // submerged area
-    public: std::array<double, 3> heightMap;    // heightmap[3] - unsorted      
-    public: cgal::Point3 vh;                          // high vertex
-    public: cgal::Point3 vm;                          // mid vertex
-    public: cgal::Point3 vl;                          // low vertex
-    public: double hh;                          // high vertex height
-    public: double hm;                          // mid vertex height
-    public: double hl;                          // low vertex height
-  };
-
-  void DebugPrint(const TriangleProperties& props)
-  {
-    gzmsg << "index:        " << props.index << std::endl;
-    gzmsg << "normal:       " << props.normal << std::endl;
-    gzmsg << "area:         " << props.area << std::endl;
-    gzmsg << "subArea:      " << props.subArea << std::endl;
-    gzmsg << "vh:           " << props.vh << std::endl;
-    gzmsg << "vm:           " << props.vm << std::endl;
-    gzmsg << "vl:           " << props.vl << std::endl;
-    gzmsg << "hh:           " << props.hh << std::endl;
-    gzmsg << "hm:           " << props.hm << std::endl;
-    gzmsg << "hl:           " << props.hl << std::endl;
-  }
-
-  class SubmergedTriangleProperties
-  {
-    public: SubmergedTriangleProperties() :
-      index(0),
-      normal(CGAL::NULL_VECTOR),
-      centroid(CGAL::ORIGIN),
-      xr(CGAL::NULL_VECTOR),
-      area(std::numeric_limits<double>::signaling_NaN()),
-      vp(CGAL::NULL_VECTOR),
-      up(CGAL::NULL_VECTOR),
-      cosTheta(std::numeric_limits<double>::signaling_NaN()),
-      vn(CGAL::NULL_VECTOR),
-      vt(CGAL::NULL_VECTOR),
-      ut(CGAL::NULL_VECTOR),
-      uf(CGAL::NULL_VECTOR),
-      vf(CGAL::NULL_VECTOR)
-    {          
-    }
-
-    public: Index index;            // index to the original triangle  
-    public: cgal::Vector3 normal;   // triangle normal
-    public: cgal::Point3 centroid;  // triangle centroid = r
-    public: cgal::Vector3 xr;       // xr = centroid - CoM = (r - x)
-    public: double area;            // area
-    public: cgal::Vector3 vp;       // point velocity vp = v + omega x r, where r = centroid - CoM
-    public: cgal::Vector3 up;       // normalized point velocity. 
-    public: double cosTheta;        // cos[theta] = up . normal  
-    public: cgal::Vector3 vn;       // point velocity normal to surface vn = (vp . normal) normal
-    public: cgal::Vector3 vt;       // point velocity tangential to surface vt = vp - vn
-    public: cgal::Vector3 ut;       // normalized tangential point velocity. 
-    public: cgal::Vector3 uf;       // direction of tangential flow. uf = - vt / ||vt|| = - ut 
-    public: cgal::Vector3 vf;       // tangential flow vf = ||vp|| uf
-  };
-
-  void DebugPrint(const SubmergedTriangleProperties& props)
-  {
-    gzmsg << "index:        " << props.index << std::endl;
-    gzmsg << "normal:       " << props.normal << std::endl;
-    gzmsg << "centroid:     " << props.centroid << std::endl;
-    gzmsg << "xr:           " << props.xr << std::endl;
-    gzmsg << "area:         " << props.area << std::endl;
-    gzmsg << "vp:           " << props.vp << std::endl;
-    gzmsg << "up:           " << props.up << std::endl;
-    gzmsg << "cosTheta:     " << props.cosTheta << std::endl;
-    gzmsg << "vn:           " << props.vn << std::endl;
-    gzmsg << "vt:           " << props.vt << std::endl;
-    gzmsg << "ut:           " << props.ut << std::endl;
-    gzmsg << "uf:           " << props.uf << std::endl;
-    gzmsg << "vf:           " << props.vf << std::endl;
-  }
-
-///////////////////////////////////////////////////////////////////////////////    
-// HydrodynamicsPrivate
-
-  class HydrodynamicsPrivate
-  {
-    /// \brief The hydrodynamics parameters. 
-    public: std::shared_ptr<const HydrodynamicsParameters> params;
-
-    /// \brief The mesh of the rigid body described by this model link.
-    public: std::shared_ptr<const cgal::Mesh> linkMesh;
-
-    /// \brief The wavefield sampler for this rigid body (linkMesh).
-    public: std::shared_ptr<const WavefieldSampler>  wavefieldSampler;
-
-    /// \brief Pose of the centre of mass.
-    public: gz::math::Pose3d pose;
-
-    /// \brief Position of the centre of mass (CGAL types).
-    public: cgal::Point3 position;
-
-    // \brief Linear velocity of the centre of mass.
-    public: cgal::Vector3 linVelocity;
-
-    /// \brief Angular velocity of the centre of mass.
-    public: cgal::Vector3 angVelocity;
-
-    /// \brief The calculated waterline length.
-    public: double waterlineLength;
-
-    /// \brief The depth at each vertex point.
-    public: cgal::Mesh::Property_map<cgal::Mesh::Vertex_index, double> depths;
-    public: std::vector<cgal::Triangle> submergedTriangles;
-    public: std::vector<TriangleProperties> triangleProperties;
-    public: std::vector<SubmergedTriangleProperties> submergedTriangleProperties;
-    public: std::vector<cgal::Line> waterline;
-
-    public: double area;
-
-    public: double submergedArea;
-
-    // Keep buoyance force and center of pressure for debugging...
-    public: std::vector<cgal::Vector3> fBuoyancy;
-    public: std::vector<cgal::Point3>  cBuoyancy;
-  
-    /// \brief The computed force
-    public: cgal::Vector3 force;
-
-    /// \brief The computed torque
-    public: cgal::Vector3 torque;
-  };
-
-///////////////////////////////////////////////////////////////////////////////    
-// Hydrodynamics
-
-  Hydrodynamics::Hydrodynamics(
-    std::shared_ptr<const HydrodynamicsParameters> _params,
-    std::shared_ptr<const cgal::Mesh> _linkMesh,
-    std::shared_ptr<const WavefieldSampler> _wavefieldSampler
-  ) : data(new HydrodynamicsPrivate())
-  {
-    this->data->params = _params;
-    this->data->linkMesh = _linkMesh;
-    this->data->wavefieldSampler = _wavefieldSampler;
-    this->data->position = CGAL::ORIGIN;
-    this->data->linVelocity = CGAL::NULL_VECTOR;
-    this->data->angVelocity = CGAL::NULL_VECTOR;
-    this->data->waterlineLength = 0.0;
-  }
-
-  void Hydrodynamics::Update(
-    std::shared_ptr<const WavefieldSampler> _wavefieldSampler,
-    const gz::math::Pose3d& _pose,
-    const cgal::Vector3& _linVelocity,
-    const cgal::Vector3& _angVelocity
-  )
-  {
-    // Set rigid body props.
-    this->data->wavefieldSampler = _wavefieldSampler;
-    this->data->pose = _pose;
-    this->data->position = ToPoint3(_pose.Pos());
-    this->data->linVelocity = _linVelocity;
-    this->data->angVelocity = _angVelocity;
-
-    // Reset
-    this->data->force = CGAL::NULL_VECTOR;
-    this->data->torque = CGAL::NULL_VECTOR;
-
-    // Update physics
-    this->UpdateSubmergedTriangles();
-    this->ComputeAreas();
-    this->ComputeWaterlineLength();
-    this->ComputePointVelocities();
-    this->ComputeBuoyancyForce();
-
-    if (this->data->params->ViscousDragOn())
-      this->ComputeViscousDragForce();
-    
-    if (this->data->params->PressureDragOn())
-      this->ComputePressureDragForce();
-    
-    if (this->data->params->DampingOn())
-      this->ComputeDampingForce();
-  }
-
-  const cgal::Vector3& Hydrodynamics::Force() const
-  {
-    return this->data->force;
-  }
-
-  const cgal::Vector3& Hydrodynamics::Torque() const
-  {
-    return this->data->torque;
-  }
-
-  const std::vector<cgal::Line>& Hydrodynamics::GetWaterline() const
-  {
-    return this->data->waterline;
-  }
-
-  const std::vector<cgal::Triangle>& Hydrodynamics::GetSubmergedTriangles() const
-  {
-    return this->data->submergedTriangles;
-  }
-
-  void Hydrodynamics::UpdateSubmergedTriangles()
-  {
-    this->data->submergedTriangles.clear();
-    this->data->triangleProperties.clear();
-    this->data->submergedTriangleProperties.clear();
-    this->data->waterline.clear();
-    
-    auto& linkMesh = *this->data->linkMesh;
-    auto& wavefieldSampler = *this->data->wavefieldSampler;
-
-    // @TODO_FRAGILE - prefer not to const_cast... assign prop map at creation.
-    // Compute depths
-    auto& ncLinkMesh = const_cast<cgal::Mesh&>(*this->data->linkMesh);
-    auto pair = ncLinkMesh.add_property_map<cgal::Mesh::Vertex_index, double>("v:depth", 0);
-    this->data->depths = pair.first;
-    for (auto&& v : linkMesh.vertices())
-    {
-      this->data->depths[v] = wavefieldSampler.ComputeDepth(linkMesh.point(v));
-    }
-
-    // Get a list of the meshes exterior triangles
-    for (auto&& face : linkMesh.faces())
-    {
-      cgal::Triangle triangle = Geometry::MakeTriangle(linkMesh, face);
-
-      TriangleProperties triProps;
-      // triProps.index = i;
-      triProps.normal = Geometry::Normal(triangle);
-      triProps.area = Geometry::TriangleArea(triangle);
-
-      // @TODO_OPTIMISE - compute depth once for each vertex then assign height to each triangle
-      // triProps.heightMap =  Physics::ComputeHeightMap(wavefieldSampler, triangle);
-     
-      // Note sign change for height.
-      const auto& rng = CGAL::vertices_around_face(linkMesh.halfedge(face), linkMesh);
-      for (
-        auto&& it = std::make_pair(std::begin(rng), 0); 
-        it.first != std::end(rng);
-        ++it.first, ++it.second)
-      {
-        triProps.heightMap[it.second] = -this->data->depths[*it.first];
-      }
-
-      this->data->triangleProperties.push_back(triProps);
-
-      // Populate the submerged sub-triangles
-      this->PopulateSubmergedTriangle(triangle, triProps);
-
-      // @DEBUG_INFO
-      // DebugPrint(triangle);
-      // DebugPrint(triProps);
-    }
-
-    // @DEBUG_INFO
-    // gzmsg << "TriCount: " << this->data->triangleProperties.size() << std::endl;
-    // for (auto triProps : this->data->triangleProperties)
-    // {
-    //   DebugPrint(triProps);
-    // }
-    // gzmsg << "SubTriCount: " << this->data->submergedTriangles.size() << std::endl;
-    // for (auto subTriProps : this->data->submergedTriangleProperties)
-    // {
-    //   DebugPrint(subTriProps);
-    // }
-  }
-
-  void Hydrodynamics::PopulateSubmergedTriangle(
-    const cgal::Triangle& _triangle,
-    TriangleProperties& _triProps)
-  {
-    // Calculations
-    const Index H=0, M=1, L=2;
-    std::array<Index, 3> idx = algorithm::sort_indexes(_triProps.heightMap);
-  
-    _triProps.hh = _triProps.heightMap[idx[H]];
-    _triProps.hm = _triProps.heightMap[idx[M]];
-    _triProps.hl = _triProps.heightMap[idx[L]];
-  
-    _triProps.vh = _triangle[idx[H]];
-    _triProps.vm = _triangle[idx[M]];
-    _triProps.vl = _triangle[idx[L]];
-      
-    if (_triProps.hh > 0)
-    {
-      if (_triProps.hm > 0)
-      {
-        if (_triProps.hl > 0)
-          ; // no-op
-        else
-          this->SplitPartiallySubmergedTriangle1(_triProps);        
-      } 
-      else
-        this->SplitPartiallySubmergedTriangle2(_triProps);        
-    }
-    else
-      this->AddFullySubmergedTriangle(_triProps);      
-  }
-
-  void Hydrodynamics::SplitPartiallySubmergedTriangle1(TriangleProperties& _triProps)
-  {
-    cgal::Vector3& n = _triProps.normal;
-    cgal::Point3& vh = _triProps.vh;
-    cgal::Point3& vm = _triProps.vm;
-    cgal::Point3& vl = _triProps.vl;
-    double hh = _triProps.hh;
-    double hm = _triProps.hm;
-    double hl = _triProps.hl;
-    
-    double tm = -hl/(hm - hl);
-    double th = -hl/(hh - hl);
-    
-    cgal::Point3 vmi = vl + (vm - vl) * tm;
-    cgal::Point3 vhi = vl + (vh - vl) * th; 
-
-    // @DEBUG_INFO
-    // gzmsg << "index:         " << _triProps.index << std::endl;
-    // gzmsg << "vmi:           " << vmi << std::endl;
-    // gzmsg << "vhi:           " << vhi << std::endl;
-            
-    // Create the new submerged triangle
-    cgal::Triangle tri0(vl, vmi, vhi);
-    if (CGAL::scalar_product(n, Geometry::Normal(tri0)) < 0.0)
-    {
-      // Change orientation
-      tri0 = cgal::Triangle(vl, vhi, vmi);
-    }
-    this->data->submergedTriangles.push_back(tri0);
-
-    // Properties of the submerged tri0
-    SubmergedTriangleProperties subTriProps0;
-    subTriProps0.index = _triProps.index;
-    subTriProps0.normal = Geometry::Normal(tri0);
-    subTriProps0.centroid = Geometry::TriangleCentroid(tri0);    
-    subTriProps0.area = Geometry::TriangleArea(tri0);
-    this->data->submergedTriangleProperties.push_back(subTriProps0);
-
-    // Fraction of original triangle submerged.
-    _triProps.subArea = subTriProps0.area;
-
-    // Create a new line (for the water line)
-    cgal::Line line(vmi, vhi);
-    this->data->waterline.push_back(line);
-  }
-
-  void Hydrodynamics::SplitPartiallySubmergedTriangle2(TriangleProperties& _triProps)
-  {
-    cgal::Vector3& n = _triProps.normal;
-    cgal::Point3& vh = _triProps.vh;
-    cgal::Point3& vm = _triProps.vm;
-    cgal::Point3& vl = _triProps.vl;
-    double hh = _triProps.hh;
-    double hm = _triProps.hm;
-    double hl = _triProps.hl;
-
-    double tm = -hm/(hh - hm);
-    double tl = -hl/(hh - hl);
-    
-    cgal::Point3 vmi =  vm + (vh - vm) * tm;
-    cgal::Point3 vli =  vl + (vh - vl) * tl;
-          
-    // Create the new submerged triangles
-    cgal::Triangle tri0(vm, vmi, vl);
-    cgal::Triangle tri1(vmi, vli, vl);
-
-    if (CGAL::scalar_product(n, Geometry::Normal(tri0)) < 0.0)
-    {
-      tri0 = cgal::Triangle(vmi, vm, vl);
-    }
-    if (CGAL::scalar_product(n, Geometry::Normal(tri1)) < 0.0)
-    {
-      tri1 = cgal::Triangle(vli, vmi, vl);
-    }
-    
-    this->data->submergedTriangles.push_back(tri0);
-    this->data->submergedTriangles.push_back(tri1);
-
-    // Properties of the submerged tri0
-    SubmergedTriangleProperties subTriProps0;
-    subTriProps0.index = _triProps.index;
-    subTriProps0.normal = Geometry::Normal(tri0);
-    subTriProps0.centroid = Geometry::TriangleCentroid(tri0);
-    subTriProps0.area = Geometry::TriangleArea(tri0);
-    this->data->submergedTriangleProperties.push_back(subTriProps0);
-
-    // Properties of the submerged tri1
-    SubmergedTriangleProperties subTriProps1;
-    subTriProps1.index = _triProps.index;
-    subTriProps1.normal = Geometry::Normal(tri1);
-    subTriProps1.centroid = Geometry::TriangleCentroid(tri1);
-    subTriProps1.area = Geometry::TriangleArea(tri1);
-    this->data->submergedTriangleProperties.push_back(subTriProps1);
-
-    // Fraction of original triangle submerged.
-    _triProps.subArea = subTriProps0.area + subTriProps1.area;
-
-    // Create a new line (for the water line)
-    cgal::Line line(vmi, vli);
-    this->data->waterline.push_back(line);
-  }
-
-  void Hydrodynamics::AddFullySubmergedTriangle(TriangleProperties& _triProps)
-  {
-    // Add the full triangle
-    cgal::Vector3& n = _triProps.normal;
-    cgal::Point3& vh = _triProps.vh;
-    cgal::Point3& vm = _triProps.vm;
-    cgal::Point3& vl = _triProps.vl;
-    
-    // Create the new submerged triangle
-    cgal::Triangle tri(vh, vm, vl);
-    if (CGAL::scalar_product(n, Geometry::Normal(tri)) < 0.0)
-    {
-      tri = cgal::Triangle(vm, vh, vl);
-    }
-    this->data->submergedTriangles.push_back(tri);
-
-    // Properties of the submerged triangle
-    SubmergedTriangleProperties subTriProps;
-    subTriProps.index = _triProps.index;
-    subTriProps.normal = _triProps.normal;
-    subTriProps.centroid = Geometry::TriangleCentroid(tri);    
-    subTriProps.area = _triProps.area;
-    this->data->submergedTriangleProperties.push_back(subTriProps);
-
-    // Fraction of original triangle submerged.
-    _triProps.subArea = subTriProps.area;
-  }
-
-  void Hydrodynamics::ComputeAreas()
-  {
-    double area=0.0;
-    for (auto&& props : this->data->triangleProperties)
-    {
-      area += props.area;
-    }
-    this->data->area = area;
-
-    double subArea=0.0;
-    for (auto&& props : this->data->submergedTriangleProperties)
-    {
-      subArea += props.area;
-    }
-    this->data->submergedArea = subArea;
-  }
-
-  void Hydrodynamics::ComputeWaterlineLength()
-  {
-    // Calculate the direction of the x-axis
-    cgal::Vector3 xaxis = ToVector3(this->data->pose.Rot().RotateVector(
-      gz::math::Vector3d(1, 0, 0)));
-
-    // Project the waterline onto the x-axis
-    double length = 0.0;
-    for (auto&& line : this->data->waterline)
-    {
-      length += std::abs(CGAL::scalar_product(line.to_vector(), xaxis));
-    }
-    length *= 0.5;
-    this->data->waterlineLength = length;
-    // @DEBUG_INFO
-    // gzmsg << "waterline length: " << length << std::endl;
-  }
-
-  // Compute the point velocity at a triangles centroid
-  void Hydrodynamics::ComputePointVelocities()
-  {
-    auto& position = this->data->position;
-    auto& v = this->data->linVelocity;
-    auto& omega = this->data->angVelocity;
-
-    for (auto&& subTriProps : this->data->submergedTriangleProperties)
-    {
-      // relative position of the centroid wrt CoM
-      subTriProps.xr = subTriProps.centroid - position;
-      
-      // vp = v + omega x xr
-      subTriProps.vp = v + CGAL::cross_product(omega, subTriProps.xr);
-
-      // up = vp / ||vp||
-      subTriProps.up = Geometry::Normalize(subTriProps.vp);
-      
-      // cos(theta) = up . n
-      subTriProps.cosTheta = CGAL::scalar_product(subTriProps.up, subTriProps.normal);
-
-      // vn = (up . n) n
-      subTriProps.vn = subTriProps.normal * subTriProps.cosTheta;
-      
-      // vt = vp - vn
-      subTriProps.vt = subTriProps.vp - subTriProps.vn;
-
-      // un = vn / ||vn||
-      // subTriProps.un = Geometry::Normalize(subTriProps.vn);
-
-      // ut = vt / ||vt||
-      subTriProps.ut = Geometry::Normalize(subTriProps.vt);
-
-      // uf = - vt / ||vt|| = - ut
-      subTriProps.uf = - subTriProps.ut;
-
-      // vf = ||vp|| uf
-      subTriProps.vf = subTriProps.uf * std::sqrt(subTriProps.vp.squared_length());
-    }
-  }
-
-  // Compute the Reynolds number
-  double Hydrodynamics::ComputeReynoldsNumber() const 
-  {
-    // fluid speed
-    auto& v = this->data->linVelocity;
-    double u = std::sqrt(v.squared_length());
-
-    // characteristic length
-    double L = this->data->waterlineLength;
-
-    // Reynolds number
-    double kv = PhysicalConstants::WaterKinematicViscosity();
-    double Rn = u * L / kv;
-
-    return Rn;
-  }
-
-  void Hydrodynamics::ComputeBuoyancyForce()
-  {
-    cgal::Vector3 sumForce  = CGAL::NULL_VECTOR;
-    cgal::Vector3 sumTorque = CGAL::NULL_VECTOR;
-
-    this->data->fBuoyancy.clear();
-    this->data->cBuoyancy.clear();
-
-    // Calculate the buoyancy force for the submerged triangles
-    auto& position  =  this->data->position;
-    auto& wavefieldSampler = *this->data->wavefieldSampler;
-    for (auto&& subTri : this->data->submergedTriangles)
-    {
-      // Force and center of pressure.
-      cgal::Point3 center = CGAL::ORIGIN;
-      cgal::Vector3 force = CGAL::NULL_VECTOR;
-      Physics::BuoyancyForceAtCenterOfPressure(
-        wavefieldSampler, subTri, center, force);
-      this->data->fBuoyancy.push_back(force);
-      this->data->cBuoyancy.push_back(center);
-
-      // Torque    
-      cgal::Vector3 xr = center - position;
-      cgal::Vector3 torque = CGAL::cross_product(xr, force);
-      sumForce += force;
-      sumTorque += torque;    
-    }
-
-    this->data->force  += sumForce;
-    this->data->torque += sumTorque;
-  }
-
-  void Hydrodynamics::ComputeDampingForce()
-  {
-    auto& params = *this->data->params;
-
-     // Linear drag coefficients
-    double cDampL1 = params.CDampL1();
-    double cDampR1 = params.CDampR1();
-
-    // Quadratic drag coefficients
-    double cDampL2 = params.CDampL2();
-    double cDampR2 = params.CDampR2();
-
-    double area = this->data->area;
-    double subArea = this->data->submergedArea;
-    double rs = subArea / area;
-     
     // Force
-    auto& v = this->data->linVelocity;
-    double linSpeed = std::sqrt(v.squared_length());
-    double cL = - rs * (cDampL1 + cDampL2 * linSpeed);
-    cgal::Vector3 force = v * cL;
- 
-    auto& omega = this->data->angVelocity;
-    double angSpeed = std::sqrt(omega.squared_length());
-    double cR = - rs * (cDampR1 + cDampR2 * angSpeed);    
-    cgal::Vector3 torque = omega * cR;
+    double fDrag = 0.5 * rho * cF * subTriProps.area
+      * std::sqrt(subTriProps.vf.squared_length());
+    cgal::Vector3 force = subTriProps.vf * fDrag;
+    sumForce += force;
 
-    this->data->force  += force;
-    this->data->torque += torque;
-
-    // @DEBUG_INF0
-    // gzmsg << "area:       " << area << std::endl; 
-    // gzmsg << "subArea:    " << subArea << std::endl; 
-    // gzmsg << "v:          " << v << std::endl; 
-    // gzmsg << "omega:      " << omega << std::endl; 
-    // gzmsg << "linSpeed:   " << linSpeed << std::endl; 
-    // gzmsg << "angSpeed:   " << angSpeed << std::endl; 
-    // gzmsg << "cR:         " << cR << std::endl; 
-    // gzmsg << "cL:         " << cL << std::endl; 
-    // gzmsg << "force:      " << force << std::endl; 
-    // gzmsg << "torque:     " << torque << std::endl; 
-
+    // Torque;
+    cgal::Vector3 torque = CGAL::cross_product(subTriProps.xr, force);
+    sumTorque += torque;
   }
 
-  // Viscous drag force - applied at triangle centroid.
-  void Hydrodynamics::ComputeViscousDragForce()
-  {    
-    double rho = PhysicalConstants::WaterDensity();
-    double Rn = this->ComputeReynoldsNumber();
-    double cF = Physics::ViscousDragCoefficient(Rn);
- 
-    cgal::Vector3 sumForce  = CGAL::NULL_VECTOR;
-    cgal::Vector3 sumTorque = CGAL::NULL_VECTOR;
-    for (auto&& subTriProps : this->data->submergedTriangleProperties)
-    {
-      // Force
-      double fDrag = 0.5 * rho * cF * subTriProps.area 
-        * std::sqrt(subTriProps.vf.squared_length());
-      cgal::Vector3 force = subTriProps.vf * fDrag;  
-      sumForce += force;
+  this->data->force  += sumForce;
+  this->data->torque += sumTorque;
+}
 
-      // Torque;
-      cgal::Vector3 torque = CGAL::cross_product(subTriProps.xr, force);
-      sumTorque += torque;
-    }
+//////////////////////////////////////////////////
+// Pressure drag force - applied at triangle centroid.
+void Hydrodynamics::ComputePressureDragForce()
+{
+  auto& params = *this->data->params;
 
-    this->data->force  += sumForce;
-    this->data->torque += sumTorque;
-  }
+  // Positive pressure
+  double cPDrag1 = params.CPDrag1();
+  double cPDrag2 = params.CPDrag2();
+  double fPDrag  = params.FPDrag();
+  // Negative pressure (suction)
+  double cSDrag1 = params.CSDrag1();
+  double cSDrag2 = params.CSDrag2();
+  double fSDrag  = params.FSDrag();
 
-  // Pressure drag force - applied at triangle centroid.
-  void Hydrodynamics::ComputePressureDragForce()
+  // Reference speed
+  double vRDrag  = params.VRDrag();
+
+  cgal::Vector3 sumForce  = CGAL::NULL_VECTOR;
+  cgal::Vector3 sumTorque = CGAL::NULL_VECTOR;
+  for (auto&& subTriProps : this->data->submergedTriangleProperties)
   {
-    auto& params = *this->data->params;
+    // General
+    double S    = subTriProps.area;
+    double vp   = std::sqrt(subTriProps.vp.squared_length());
+    double cosTheta = subTriProps.cosTheta;
 
-    // Positive pressure
-    double cPDrag1 = params.CPDrag1();
-    double cPDrag2 = params.CPDrag2();
-    double fPDrag  = params.FPDrag();
-    // Negative pressure (suction)
-    double cSDrag1 = params.CSDrag1();
-    double cSDrag2 = params.CSDrag2();
-    double fSDrag  = params.FSDrag();
-
-    // Reference speed
-    double vRDrag  = params.VRDrag();
-
-    cgal::Vector3 sumForce  = CGAL::NULL_VECTOR;
-    cgal::Vector3 sumTorque = CGAL::NULL_VECTOR;
-    for (auto&& subTriProps : this->data->submergedTriangleProperties)
+    double v    = vp / vRDrag;
+    double drag = 0.0;
+    if (cosTheta >= 0.0)
     {
-      // General
-      double S    = subTriProps.area;
-      double vp   = std::sqrt(subTriProps.vp.squared_length());
-      double cosTheta = subTriProps.cosTheta;
-
-      double v    = vp / vRDrag;
-      double drag = 0.0;
-      if (cosTheta >= 0.0)
-      {
-        drag = -(cPDrag1 * v + cPDrag2 * v * v) * S * std::pow( cosTheta, fPDrag);
-      }
-      else
-      {
-        drag =  (cSDrag1 * v + cSDrag2 * v * v) * S * std::pow(-cosTheta, fSDrag);
-      }
-      cgal::Vector3 force = subTriProps.normal * drag;
-      sumForce += force;
-
-      // Torque;
-      cgal::Vector3 torque = CGAL::cross_product(subTriProps.xr, force);
-      sumTorque += torque;
+      drag = -(cPDrag1 * v + cPDrag2 * v * v) * S * std::pow(cosTheta, fPDrag);
+    } else {
+      drag =  (cSDrag1 * v + cSDrag2 * v * v) * S * std::pow(-cosTheta, fSDrag);
     }
+    cgal::Vector3 force = subTriProps.normal * drag;
+    sumForce += force;
 
-    this->data->force  += sumForce;
-    this->data->torque += sumTorque;
-
-    // @DEBUG_INFO
-    // if (std::abs(sumForce.z()) > 1.0E+10)
-    // {
-    //   gzmsg << "Overflow in ComputePressureDragForce..."    << std::endl;
-    //   gzmsg << "position:     " << this->data->position     << std::endl;
-    //   gzmsg << "linVelocity:  " << this->data->linVelocity  << std::endl;
-    //   gzmsg << "angVelocity:  " << this->data->angVelocity  << std::endl;
-    //   gzmsg << "force:        " << sumForce                 << std::endl;
-    //   gzmsg << "torque:       " << sumTorque                << std::endl;
-    //   for (auto&& subTriProps : this->data->submergedTriangleProperties)
-    //   {
-    //     DebugPrint(subTriProps);
-    //   }
-    // }
+    // Torque;
+    cgal::Vector3 torque = CGAL::cross_product(subTriProps.xr, force);
+    sumTorque += torque;
   }
 
+  this->data->force  += sumForce;
+  this->data->torque += sumTorque;
+
+  // @DEBUG_INFO
+  // if (std::abs(sumForce.z()) > 1.0E+10)
+  // {
+  //   gzmsg << "Overflow in ComputePressureDragForce..."    << "\n";
+  //   gzmsg << "position:     " << this->data->position     << "\n";
+  //   gzmsg << "linVelocity:  " << this->data->linVelocity  << "\n";
+  //   gzmsg << "angVelocity:  " << this->data->angVelocity  << "\n";
+  //   gzmsg << "force:        " << sumForce                 << "\n";
+  //   gzmsg << "torque:       " << sumTorque                << "\n";
+  //   for (auto&& subTriProps : this->data->submergedTriangleProperties)
+  //   {
+  //     DebugPrint(subTriProps);
+  //   }
+  // }
 }
-}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/Physics.cc
+++ b/gz-waves/src/Physics.cc
@@ -307,7 +307,7 @@ namespace waves
     std::array<double, 3> heightMap;
 
     // Calculate the height above the surface (-depth)
-    for (int i=0; i<3; ++i)
+    for (Index i=0; i<3; ++i)
     {
       cgal::Point3 vertex = _triangle[i];
       heightMap[i] = -_wavefieldSampler.ComputeDepth(vertex);
@@ -522,7 +522,7 @@ namespace waves
     {
     }
 
-    public: size_t index;                       // index to the original triangle  
+    public: Index index;                       // index to the original triangle  
     public: cgal::Vector3 normal;                     // triangle normal
     public: double area;                        // area
     public: double subArea;                     // submerged area
@@ -568,7 +568,7 @@ namespace waves
     {          
     }
 
-    public: int index;              // index to the original triangle  
+    public: Index index;            // index to the original triangle  
     public: cgal::Vector3 normal;   // triangle normal
     public: cgal::Point3 centroid;  // triangle centroid = r
     public: cgal::Vector3 xr;       // xr = centroid - CoM = (r - x)
@@ -795,8 +795,8 @@ namespace waves
     TriangleProperties& _triProps)
   {
     // Calculations
-    const size_t H=0, M=1, L=2;
-    std::array<size_t, 3> idx = algorithm::sort_indexes(_triProps.heightMap);
+    const Index H=0, M=1, L=2;
+    std::array<Index, 3> idx = algorithm::sort_indexes(_triProps.heightMap);
   
     _triProps.hh = _triProps.heightMap[idx[H]];
     _triProps.hm = _triProps.heightMap[idx[M]];

--- a/gz-waves/src/Physics_TEST.cc
+++ b/gz-waves/src/Physics_TEST.cc
@@ -229,7 +229,7 @@ TEST(Hydrodynamics, Buoyancy10x4x2Box)
   //   // Set Pose - 45 deg rotation about z
   //   std::cout << "Pose: rotate about Z..." << std::endl;
   //   Pose3d linkPose(0, 0, 0, 0, 0, M_PI/4.0);
-  //   for (size_t i=0; i<linkMesh->GetVertexCount(); ++i)
+  //   for (Index i=0; i<linkMesh->GetVertexCount(); ++i)
   //   {
   //     gz::math::Vector3d v0 = initLinkMesh->GetVertex(i);
   //     gz::math::Vector3d v1 = linkPose.Rot().RotateVector(v0) + linkPose.Pos();
@@ -248,7 +248,7 @@ TEST(Hydrodynamics, Buoyancy10x4x2Box)
   //   // Set Pose - 45 deg rotation about x
   //   std::cout << "Pose: rotate about X..." << std::endl;
   //   Pose3d linkPose(0, 0, 0, M_PI/4.0, 0, 0);
-  //   for (size_t i=0; i<linkMesh->GetVertexCount(); ++i)
+  //   for (Index i=0; i<linkMesh->GetVertexCount(); ++i)
   //   {
   //     gz::math::Vector3d v0 = initLinkMesh->GetVertex(i);
   //     gz::math::Vector3d v1 = linkPose.Rot().RotateVector(v0) + linkPose.Pos();
@@ -267,7 +267,7 @@ TEST(Hydrodynamics, Buoyancy10x4x2Box)
   //   // Set Pose - overflow example
   //   std::cout << "Pose: overflow example..." << std::endl;
   //   Pose3d linkPose(0, 0, 0.973235, -0.737731, 0, 0);
-  //   for (size_t i=0; i<linkMesh->GetVertexCount(); ++i)
+  //   for (Index i=0; i<linkMesh->GetVertexCount(); ++i)
   //   {
   //     gz::math::Vector3d v0 = initLinkMesh->GetVertex(i);
   //     gz::math::Vector3d v1 = linkPose.Rot().RotateVector(v0) + linkPose.Pos();

--- a/gz-waves/src/SubMeshWithTangents.cc
+++ b/gz-waves/src/SubMeshWithTangents.cc
@@ -18,19 +18,21 @@
 
 #include "gz/common/SubMeshWithTangents.hh"
 
-#include <gz/common/Console.hh>
-
 #include <string>
 
-using namespace gz;
-using namespace common;
+#include <gz/common/Console.hh>
+
+namespace gz
+{
+namespace common
+{
 
 /// \brief Private data for SubMeshWithTangents
 class gz::common::SubMeshWithTangents::Implementation
 {
+ public:
   /// \brief the tangents array
-  public: std::vector<gz::math::Vector3d> tangents;
-
+  std::vector<gz::math::Vector3d> tangents;
 };
 
 //////////////////////////////////////////////////
@@ -41,14 +43,14 @@ SubMeshWithTangents::SubMeshWithTangents()
 }
 
 //////////////////////////////////////////////////
-SubMeshWithTangents::SubMeshWithTangents(const std::string &_name)
+SubMeshWithTangents::SubMeshWithTangents(const std::string& _name)
     : SubMesh(_name),
     dataPtr(gz::utils::MakeImpl<Implementation>())
 {
 }
 
 //////////////////////////////////////////////////
-SubMeshWithTangents::SubMeshWithTangents(const SubMeshWithTangents &_submesh)
+SubMeshWithTangents::SubMeshWithTangents(const SubMeshWithTangents& _submesh)
   : SubMesh(_submesh),
   dataPtr(gz::utils::MakeImpl<Implementation>())
 {
@@ -57,11 +59,12 @@ SubMeshWithTangents::SubMeshWithTangents(const SubMeshWithTangents &_submesh)
 }
 
 //////////////////////////////////////////////////
-SubMeshWithTangents::SubMeshWithTangents(SubMeshWithTangents &&_submesh)
+SubMeshWithTangents::SubMeshWithTangents(SubMeshWithTangents&& _submesh)
     noexcept = default;
 
 //////////////////////////////////////////////////
-SubMeshWithTangents &SubMeshWithTangents::operator=(const SubMeshWithTangents &_submesh)
+SubMeshWithTangents& SubMeshWithTangents::operator=(
+    const SubMeshWithTangents& _submesh)
 {
   if (this != &_submesh)
   {
@@ -76,7 +79,8 @@ SubMeshWithTangents &SubMeshWithTangents::operator=(const SubMeshWithTangents &_
 }
 
 //////////////////////////////////////////////////
-SubMeshWithTangents &SubMeshWithTangents::operator=(SubMeshWithTangents &&_submesh)
+SubMeshWithTangents& SubMeshWithTangents::operator=(
+    SubMeshWithTangents&& _submesh)
     noexcept = default;
 
 //////////////////////////////////////////////////
@@ -85,19 +89,21 @@ SubMeshWithTangents::~SubMeshWithTangents()
 }
 
 //////////////////////////////////////////////////
-void SubMeshWithTangents::AddTangent(const gz::math::Vector3d &_tanget)
+void SubMeshWithTangents::AddTangent(const gz::math::Vector3d& _tanget)
 {
   this->dataPtr->tangents.push_back(_tanget);
 }
 
 //////////////////////////////////////////////////
-void SubMeshWithTangents::AddTangent(const double _x, const double _y, const double _z)
+void SubMeshWithTangents::AddTangent(
+    const double _x, const double _y, const double _z)
 {
   this->AddTangent(gz::math::Vector3d(_x, _y, _z));
 }
 
 //////////////////////////////////////////////////
-gz::math::Vector3d SubMeshWithTangents::Tangent(const unsigned int _index) const
+gz::math::Vector3d SubMeshWithTangents::Tangent(
+    const unsigned int _index) const
 {
   if (_index >= this->dataPtr->tangents.size())
   {
@@ -116,7 +122,7 @@ bool SubMeshWithTangents::HasTangent(const unsigned int _index) const
 
 //////////////////////////////////////////////////
 void SubMeshWithTangents::SetTangent(const unsigned int _index,
-    const gz::math::Vector3d &_n)
+    const gz::math::Vector3d& _n)
 {
   if (_index >= this->dataPtr->tangents.size())
   {
@@ -132,3 +138,6 @@ unsigned int SubMeshWithTangents::TangentCount() const
 {
   return this->dataPtr->tangents.size();
 }
+
+}  // namespace common
+}  // namespace gz

--- a/gz-waves/src/TriangulatedGrid.cc
+++ b/gz-waves/src/TriangulatedGrid.cc
@@ -14,7 +14,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/TriangulatedGrid.hh"
-#include "gz/waves/Geometry.hh"
 
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
@@ -31,245 +30,290 @@
 #include <CGAL/algorithm.h>
 #include <CGAL/point_generators_2.h>
 
+#include "gz/waves/Geometry.hh"
+
 namespace gz
 {
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////
-// TriangulatedGrid::Private
+//////////////////////////////////////////////////
+class TriangulatedGrid::Private {
+ public:
+  ~Private();
+  Private(Index num_segments, double length);
+  void CreateMesh();
+  void CreateTriangulation();
 
-  class TriangulatedGrid::Private {
-   public:
-    ~Private();
-    Private(Index num_segments, double length);
-    void CreateMesh();
-    void CreateTriangulation();    
+  bool Locate(const cgal::Point3& query, int64_t& faceIndex) const;
+  bool Height(const cgal::Point3& query, double& height) const;
+  bool Height(const std::vector<cgal::Point3>& queries,
+      std::vector<double>& heights) const;
+  bool Interpolate(TriangulatedGrid& patch) const;
 
-    bool Locate(const cgal::Point3& query, int64_t& faceIndex) const;
-    bool Height(const cgal::Point3& query, double& height) const;
-    bool Height(const std::vector<cgal::Point3>& queries, std::vector<double>& heights) const;
-    bool Interpolate(TriangulatedGrid& patch) const;
+  const Point3Range& Points() const;
+  const Index3Range& Indices() const;
+  const cgal::Point3& Origin() const;
+  void ApplyPose(const gz::math::Pose3d& pose);
 
-    const Point3Range& Points() const;
-    const Index3Range& Indices() const;
-    const cgal::Point3& Origin() const;
-    void ApplyPose(const gz::math::Pose3d& pose);
+  bool IsValid(bool verbose = false) const;
+  void DebugPrintMesh() const;
+  void DebugPrintTriangulation() const;
+  void UpdatePoints(const std::vector<cgal::Point3>& points);
+  void UpdatePoints(const std::vector<gz::math::Vector3d>& from);
 
-    bool IsValid(bool verbose=false) const;
-    void DebugPrintMesh() const;
-    void DebugPrintTriangulation() const;
-    void UpdatePoints(const std::vector<cgal::Point3>& points);
-    void UpdatePoints(const std::vector<gz::math::Vector3d>& from);
+  // void UpdatePoints(const std::vector<Ogre::Vector3>& from);
+  void UpdatePoints(const cgal::Mesh& from);
 
-    // void UpdatePoints(const std::vector<Ogre::Vector3>& from);
-    void UpdatePoints(const cgal::Mesh& from);
+  // Type definitions - use a consistent Kernel
+  // typedef Kernel Kernel;
+  // typedef CGAL::Simple_cartesian<double> Kernel;
+  // typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+  typedef CGAL::Projection_traits_xy_3<cgal::Kernel> Gt;
+  typedef CGAL::Triangulation_vertex_base_with_info_2<int64_t, Gt> Vbb;
+  typedef CGAL::Triangulation_hierarchy_vertex_base_2<Vbb> Vb;
+  typedef CGAL::Constrained_triangulation_face_base_2<Gt> Fbb;
+  typedef CGAL::Triangulation_face_base_with_info_2<int64_t, Gt, Fbb> Fb;
+  typedef CGAL::Triangulation_data_structure_2<Vb, Fb> Tds;
+  typedef CGAL::No_constraint_intersection_tag Itag;
+  typedef CGAL::Constrained_Delaunay_triangulation_2<Gt, Tds, Itag> Tb;
+  typedef CGAL::Triangulation_hierarchy_2<Tb> Triangulation;
+  typedef Triangulation::Vertex_handle Vertex_handle;
+  typedef Triangulation::Face_handle Face_handle;
+  typedef Triangulation::Face Face;
 
-    // Type definitions - use a consistent Kernel
-    // typedef Kernel                                                      Kernel;
-    // typedef CGAL::Simple_cartesian<double>                              Kernel;
-    // typedef CGAL::Exact_predicates_inexact_constructions_kernel         Kernel;
-    typedef CGAL::Projection_traits_xy_3<cgal::Kernel>                    Gt;
-    typedef CGAL::Triangulation_vertex_base_with_info_2<int64_t, Gt>      Vbb;
-    typedef CGAL::Triangulation_hierarchy_vertex_base_2<Vbb>              Vb;
-    typedef CGAL::Constrained_triangulation_face_base_2<Gt>               Fbb;
-    typedef CGAL::Triangulation_face_base_with_info_2<int64_t, Gt, Fbb>   Fb;
-    typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                  Tds;
-    typedef CGAL::No_constraint_intersection_tag                          Itag;
-    typedef CGAL::Constrained_Delaunay_triangulation_2<Gt, Tds, Itag>     Tb;
-    typedef CGAL::Triangulation_hierarchy_2<Tb>                           Triangulation;
-    typedef Triangulation::Vertex_handle                                  Vertex_handle;
-    typedef Triangulation::Face_handle                                    Face_handle;
-    typedef Triangulation::Face                                           Face;
+  // Dimensions
+  Index num_segments_;
+  double length_;
 
-    // Dimensions
-    Index num_segments_;
-    double length_;
+  // Mesh
+  cgal::Point3              origin_;
+  std::vector<cgal::Point3> points0_;
+  std::vector<cgal::Point3> points_;
+  std::vector<Index3> indices_;
+  std::vector<Index3> infinite_indices_;
 
-    // Mesh
-    cgal::Point3              origin_;
-    std::vector<cgal::Point3> points0_;
-    std::vector<cgal::Point3> points_;
-    std::vector<Index3> indices_;
-    std::vector<Index3> infinite_indices_;
+  // Triangulation / Triangulation Hierarchy
+  Triangulation       tri_;
+};
 
-    // Triangulation / Triangulation Hierarchy
-    Triangulation       tri_;
-  };
+//////////////////////////////////////////////////
+TriangulatedGrid::Private::~Private() {
+}
 
-  TriangulatedGrid::Private::~Private() {
-  }
+//////////////////////////////////////////////////
+TriangulatedGrid::Private::Private(Index num_segments, double length) :
+  num_segments_(num_segments), length_(length), origin_(CGAL::ORIGIN) {
+}
 
-  TriangulatedGrid::Private::Private(Index num_segments, double length) : 
-    num_segments_(num_segments), length_(length), origin_(CGAL::ORIGIN) {  
-  }
+//////////////////////////////////////////////////
+void TriangulatedGrid::Private::CreateMesh() {
+  double dl = length_ / num_segments_;
+  double lm = - length_ / 2.0;
+  const Index nplus1 = num_segments_ + 1;
 
-  void TriangulatedGrid::Private::CreateMesh() {
-    double dl = length_ / num_segments_;
-    double lm = - length_ / 2.0;
-    const Index nplus1 = num_segments_ + 1; 
-
-    // Points - (num_segments_+1) points_ in each row / column 
-    for (int64_t iy=0; iy<=num_segments_; ++iy) {
-      double py = iy * dl + lm;
-      for (int64_t ix=0; ix<=num_segments_; ++ix) {
-        // Vertex position
-        double px = ix * dl + lm;
-        cgal::Point3 point(px, py, 0.0);
-        points_.push_back(point);
-      }
+  // Points - (num_segments_+1) points_ in each row / column
+  for (int64_t iy=0; iy <= num_segments_; ++iy) {
+    double py = iy * dl + lm;
+    for (int64_t ix=0; ix <= num_segments_; ++ix) {
+      // Vertex position
+      double px = ix * dl + lm;
+      cgal::Point3 point(px, py, 0.0);
+      points_.push_back(point);
     }
-    // Copy initial points
-    points0_ = points_;
+  }
+  // Copy initial points
+  points0_ = points_;
 
-    // Face indices
-    for (int64_t iy=0; iy<num_segments_; ++iy) {
-      for (int64_t ix=0; ix<num_segments_; ++ix) {
-        // Get the points in the cell coordinates
-        int64_t idx0 = iy * nplus1 + ix;
-        int64_t idx1 = iy * nplus1 + ix + 1;
-        int64_t idx2 = (iy+1) * nplus1 + ix + 1;
-        int64_t idx3 = (iy+1) * nplus1 + ix;
+  // Face indices
+  for (int64_t iy=0; iy < num_segments_; ++iy) {
+    for (int64_t ix=0; ix < num_segments_; ++ix) {
+      // Get the points in the cell coordinates
+      int64_t idx0 = iy * nplus1 + ix;
+      int64_t idx1 = iy * nplus1 + ix + 1;
+      int64_t idx2 = (iy+1) * nplus1 + ix + 1;
+      int64_t idx3 = (iy+1) * nplus1 + ix;
 
-        // Face indices
-        indices_.push_back({ idx0, idx1, idx2 });
-        indices_.push_back({ idx0, idx2, idx3 });
-      }
-    }
-
-    // Infinite indices (follow edges counter clockwise around grid)
-    infinite_indices_.resize(4*num_segments_);
-    for (int64_t i=0; i<num_segments_; ++i) {
-      // bottom
-      int64_t idx = i;
-      infinite_indices_[i] = { idx, idx+1 };
-
-      // right
-      idx = i * nplus1 + num_segments_;
-      infinite_indices_[num_segments_+i] = { idx, idx+nplus1 };
-
-      // top
-      idx = num_segments_ * nplus1 + i;
-      infinite_indices_[3*num_segments_-1-i] = { idx+1, idx };
-
-      // left
-      idx = i * nplus1;
-      infinite_indices_[4*num_segments_-1-i] = { idx+nplus1, idx };
+      // Face indices
+      indices_.push_back({ idx0, idx1, idx2 });
+      indices_.push_back({ idx0, idx2, idx3 });
     }
   }
 
-  void TriangulatedGrid::Private::CreateTriangulation() {
-    // Insert points - NOTE: must insert the points to build the triangulation hierarchy.
-    // CGAL::Timer timer;
+  // Infinite indices (follow edges counter clockwise around grid)
+  infinite_indices_.resize(4*num_segments_);
+  for (int64_t i=0; i < num_segments_; ++i) {
+    // bottom
+    int64_t idx = i;
+    infinite_indices_[i] = { idx, idx+1 };
 
-    // Point with info
-    // std::vector<std::pair<cgal::Point3, int64_t>> pointsWithInfo;
-    // for (int64_t i=0; i<points_.size(); ++i) {
-    //   pointsWithInfo.push_back(std::make_pair(points_[i], i));
-    // }
+    // right
+    idx = i * nplus1 + num_segments_;
+    infinite_indices_[num_segments_+i] = { idx, idx+nplus1 };
 
-    // timer.start();
-    // @NOTE insert poinst with info not compiling for a triangulation hierarcy. See below. 
-    // tri_.insert(pointsWithInfo.begin(), pointsWithInfo.end());
-    tri_.insert(points_.begin(), points_.end());
-    // timer.stop();
-    // std::cout << "insert points: " << timer.time() << " s" << std::endl;
+    // top
+    idx = num_segments_ * nplus1 + i;
+    infinite_indices_[3*num_segments_-1-i] = { idx+1, idx };
 
-    // Set vertex info
-    // @NOTE - use this work around because the insert for points with info
-    // does not compile for a triangulation hierarchy.
-    // timer.reset();
-    // timer.start();
-    Face_handle fh;
-    for (uint64_t i=0; i<points_.size(); ++i) {
-      auto vh = tri_.insert(points_[i] ,fh);
-      if (vh != nullptr) {
-        vh->info() = i;
-      }
+    // left
+    idx = i * nplus1;
+    infinite_indices_[4*num_segments_-1-i] = { idx+nplus1, idx };
+  }
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::Private::CreateTriangulation() {
+  // Insert points - NOTE: must insert the points to build the
+  // triangulation hierarchy.
+  // CGAL::Timer timer;
+
+  // Point with info
+  // std::vector<std::pair<cgal::Point3, int64_t>> pointsWithInfo;
+  // for (int64_t i=0; i<points_.size(); ++i) {
+  //   pointsWithInfo.push_back(std::make_pair(points_[i], i));
+  // }
+
+  // timer.start();
+  // @NOTE insert poinst with info not compiling for a triangulation hierarcy.
+  // See below.
+  // tri_.insert(pointsWithInfo.begin(), pointsWithInfo.end());
+  tri_.insert(points_.begin(), points_.end());
+  // timer.stop();
+  // std::cout << "insert points: " << timer.time() << " s" << "\n";
+
+  // Set vertex info
+  // @NOTE - use this work around because the insert for points with info
+  // does not compile for a triangulation hierarchy.
+  // timer.reset();
+  // timer.start();
+  Face_handle fh;
+  for (uint64_t i=0; i < points_.size(); ++i) {
+    auto vh = tri_.insert(points_[i], fh);
+    if (vh != nullptr) {
+      vh->info() = i;
     }
-    // timer.stop();
-    // std::cout << "set vertex info: " << timer.time() << " s" << std::endl;
+  }
+  // timer.stop();
+  // std::cout << "set vertex info: " << timer.time() << " s" << "\n";
 
-    // Constraint indices 
-    const Index nplus1 = num_segments_ + 1; 
-    std::vector<std::pair<size_t, int64_t>> cindices;
-    for (int64_t iy=0; iy<num_segments_; ++iy) {
-      for (int64_t ix=0; ix<num_segments_; ++ix) {
-        int64_t idx1 = iy * nplus1 + ix;
-        int64_t idx2 = (iy + 1) * nplus1 + (ix + 1);
-        cindices.push_back(std::make_pair(idx1, idx2));
-      }
+  // Constraint indices
+  const Index nplus1 = num_segments_ + 1;
+  std::vector<std::pair < size_t, int64_t>> cindices;
+  for (int64_t iy=0; iy < num_segments_; ++iy) {
+    for (int64_t ix=0; ix < num_segments_; ++ix) {
+      int64_t idx1 = iy * nplus1 + ix;
+      int64_t idx2 = (iy + 1) * nplus1 + (ix + 1);
+      cindices.push_back(std::make_pair(idx1, idx2));
     }
-
-    // Insert constraints
-    // timer.reset();
-    // timer.start();
-    tri_.insert_constraints(points_.begin(), points_.end(), cindices.begin(), cindices.end());   
-    // timer.stop();
-    // std::cout << "insert constraints: " << timer.time() << " s" << std::endl;
-
-    // Set info on infinite vertex
-    tri_.infinite_vertex()->info() = -1;
-
-    // Face list mapping
-
-    // Initialise face info
-    // timer.reset();
-    // timer.start();
-    for (auto f = tri_.all_faces_begin(); f != tri_.all_faces_end(); ++f) {
-      f->info() = -1; 
-    }
-    // timer.stop();
-    // std::cout << "initialise face info: (" << timer.time() << " s)" << std::endl;
-
-    // Face matching
-    fh = nullptr;
-    int64_t idx = 0;
-    // timer.reset();
-    // timer.start();
-    for (auto f = indices_.begin(); f != indices_.end(); ++f, ++idx) {
-      // Compute the centroid of f and locate the tri_ face containing this point.
-      auto& p0 = points_[f->at(0)];
-      auto& p1 = points_[f->at(1)];
-      auto& p2 = points_[f->at(2)];
-      cgal::Point3 p(
-        (p0.x() + p1.x() + p2.x())/3.0,
-        (p0.y() + p1.y() + p2.y())/3.0,
-        0.0
-      );
-      fh = tri_.locate(p, fh);
-
-      // Set the info value on the found face.
-      if (fh != nullptr)
-      {
-        fh->info() = idx;
-      }
-    }
-    // timer.stop();
-    // std::cout << "face mapping: (" << timer.time() << " s)" << std::endl;    
   }
 
-  bool TriangulatedGrid::Private::Locate(const cgal::Point3& query, int64_t& faceIndex) const {
-    auto fh = tri_.locate(query);
-    if (fh != nullptr) {
-      faceIndex = fh->info();
-      return true;
-    }
-    return false;
-  }
+  // Insert constraints
+  // timer.reset();
+  // timer.start();
+  tri_.insert_constraints(points_.begin(), points_.end(),
+      cindices.begin(), cindices.end());
+  // timer.stop();
+  // std::cout << "insert constraints: " << timer.time() << " s" << "\n";
 
-  bool TriangulatedGrid::Private::Height(const cgal::Point3& query, double& height) const {
-    bool found = false;
-    height = 0.0;
-    auto fh = tri_.locate(query);
-    if (fh != nullptr) {
+  // Set info on infinite vertex
+  tri_.infinite_vertex()->info() = -1;
+
+  // Face list mapping
+
+  // Initialise face info
+  // timer.reset();
+  // timer.start();
+  for (auto f = tri_.all_faces_begin(); f != tri_.all_faces_end(); ++f) {
+    f->info() = -1;
+  }
+  // timer.stop();
+  // std::cout << "initialise face info: (" << timer.time() << " s)" << "\n";
+
+  // Face matching
+  fh = nullptr;
+  int64_t idx = 0;
+  // timer.reset();
+  // timer.start();
+  for (auto f = indices_.begin(); f != indices_.end(); ++f, ++idx) {
+    // Compute the centroid of f and locate the tri_ face containing this point.
+    auto& p0 = points_[f->at(0)];
+    auto& p1 = points_[f->at(1)];
+    auto& p2 = points_[f->at(2)];
+    cgal::Point3 p(
+      (p0.x() + p1.x() + p2.x())/3.0,
+      (p0.y() + p1.y() + p2.y())/3.0,
+      0.0);
+    fh = tri_.locate(p, fh);
+
+    // Set the info value on the found face.
+    if (fh != nullptr)
+    {
+      fh->info() = idx;
+    }
+  }
+  // timer.stop();
+  // std::cout << "face mapping: (" << timer.time() << " s)" << "\n";
+}
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::Private::Locate(
+    const cgal::Point3& query, int64_t& faceIndex) const {
+  auto fh = tri_.locate(query);
+  if (fh != nullptr) {
+    faceIndex = fh->info();
+    return true;
+  }
+  return false;
+}
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::Private::Height(
+    const cgal::Point3& query, double& height) const {
+  bool found = false;
+  height = 0.0;
+  auto fh = tri_.locate(query);
+  if (fh != nullptr) {
+    // Triangle vertices
+    const auto& p0 = fh->vertex(0)->point();
+    const auto& p1 = fh->vertex(1)->point();
+    const auto& p2 = fh->vertex(2)->point();
+
+    // Height query
+    const cgal::Direction3 direction(0, 0, 1);
+    cgal::Point3 intersection(query);
+    cgal::Triangle triangle(p0, p1, p2);
+
+    found = Geometry::LineIntersectsTriangle(
+        query, direction, triangle, intersection);
+
+    if (found) {
+      height = intersection.z() - query.z();
+    }
+  }
+  return found;
+}
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::Private::Height(
+    const std::vector<cgal::Point3>& queries,
+    std::vector<double>& heights) const
+{
+  bool foundAll = true;
+  Face_handle fh = nullptr;
+  for (uint64_t i=0; i < heights.size(); ++i)
+  {
+    double height_i = 0.0;
+    const cgal::Point3& query = queries[i];
+    fh = tri_.locate(query, fh);
+    bool found = fh != nullptr;
+    if (found) {
       // Triangle vertices
       const auto& p0 = fh->vertex(0)->point();
       const auto& p1 = fh->vertex(1)->point();
       const auto& p2 = fh->vertex(2)->point();
 
       // Height query
-      const cgal::Direction3 direction(0, 0, 1);      
+      const cgal::Direction3 direction(0, 0, 1);
       cgal::Point3 intersection(query);
       cgal::Triangle triangle(p0, p1, p2);
 
@@ -277,356 +321,347 @@ namespace waves
           query, direction, triangle, intersection);
 
       if (found) {
-        height = intersection.z() - query.z();
+        height_i = intersection.z() - query.z();
       }
     }
-    return found;
+    heights[i] = height_i;
+    foundAll &= found;
   }
-
-  bool TriangulatedGrid::Private::Height(const std::vector<cgal::Point3>& queries, std::vector<double>& heights) const {
-    bool foundAll = true;
-    Face_handle fh = nullptr;
-    for (uint64_t i=0; i<heights.size(); ++i)
-    {
-      double height_i = 0.0;
-      const cgal::Point3& query = queries[i];
-      fh = tri_.locate(query, fh);
-      bool found = fh != nullptr;
-      if (found) {
-        // Triangle vertices
-        const auto& p0 = fh->vertex(0)->point();
-        const auto& p1 = fh->vertex(1)->point();
-        const auto& p2 = fh->vertex(2)->point();
-
-        // Height query
-        const cgal::Direction3 direction(0, 0, 1);      
-        cgal::Point3 intersection(query);
-        cgal::Triangle triangle(p0, p1, p2);
-
-        found = Geometry::LineIntersectsTriangle(
-            query, direction, triangle, intersection);
-
-        if (found) {
-          height_i = intersection.z() - query.z();
-        }
-      }
-      heights[i] = height_i;
-      foundAll &= found;
-    }
-    return foundAll;
-  }
-
-  bool TriangulatedGrid::Private::Interpolate(TriangulatedGrid& patch) const {
-    bool foundAll = true;
-
-    Face_handle fh = nullptr;
-    for (auto it = patch.impl_->points_.begin(); it != patch.impl_->points_.end(); ++it) {
-      double height = 0.0;        
-      const cgal::Point3& query = *it;
-      fh = tri_.locate(query, fh);
-      bool found = fh != nullptr;
-      if (found) {
-        // Triangle vertices
-        const auto& p0 = fh->vertex(0)->point();
-        const auto& p1 = fh->vertex(1)->point();
-        const auto& p2 = fh->vertex(2)->point();
-
-        // Height query
-        const cgal::Direction3 direction(0, 0, 1);      
-        cgal::Point3 intersection(query);
-        cgal::Triangle triangle(p0, p1, p2);
-
-        found = Geometry::LineIntersectsTriangle(
-            query, direction, triangle, intersection);
-
-        // @DEBUG_INFO
-        // std::cout << "query:        " << query << std::endl;
-        // std::cout << "triangle:     " << triangle << std::endl;
-        // std::cout << "intersection: " << intersection << std::endl;
-
-        if (found) {
-          height = intersection.z();
-        }
-      }
-      // @NOTE this assumes the patch initially has height = 0.0;
-      *it = cgal::Point3(query.x(), query.y(), height);
-
-      foundAll &= found;
-    }
-    return foundAll;
-  }
-
-  const Point3Range& TriangulatedGrid::Private::Points() const {
-    return points_;
-  }
-
-  const Index3Range& TriangulatedGrid::Private::Indices() const {
-    return indices_;
-  }
-
-  const cgal::Point3& TriangulatedGrid::Private::Origin() const {
-    return origin_;
-  }
-
-  void TriangulatedGrid::Private::ApplyPose(const gz::math::Pose3d& pose) {
-    // Origin - slide the patch in the xy - plane only
-    cgal::Point3 o = CGAL::ORIGIN;
-    origin_ = cgal::Point3(o.x() + pose.Pos().X(), o.y() + pose.Pos().Y(), o.z());
-
-    // Mesh points
-    for (
-      auto&& it = std::make_pair(std::begin(points0_), std::begin(points_));
-      it.first != std::end(points0_) && it.second != std::end(points_);
-      ++it.first, ++it.second)
-    {
-      const auto& p0 = *it.first;
-      auto& p = *it.second;
-      p = cgal::Point3(p0.x() + pose.Pos().X(), p0.y() + pose.Pos().Y(), p0.z());
-    }
-
-    // Triangulation points
-    for (auto v = tri_.finite_vertices_begin(); v != tri_.finite_vertices_end(); ++v) {
-      int64_t idx = v->info();
-      v->set_point(points_[idx]);
-    }
-  }
-
-  bool TriangulatedGrid::Private::IsValid(bool verbose) const {
-    bool isValid = true;
-
-    // Triangulation Hierarchy
-    const Triangulation::Triangulation_data_structure& tds = tri_.tds();
-
-    // Verify infinite vertex
-    auto vi = tri_.infinite_vertex();
-    isValid &= vi->is_valid(verbose);
-
-    // Verify vertices
-    for (auto v = tds.vertices_begin(); v !=  tds.vertices_end(); ++v) {
-      isValid &= v->is_valid(verbose);
-    }
-
-    // Verify faces
-    for (auto f = tds.faces_begin(); f !=  tds.faces_end(); ++f) {
-      isValid &= f->is_valid(verbose);
-    }
-
-    // Verify triangulation hierarchy data structure
-    isValid &= tds.is_valid(verbose);
-
-    // Verify triangulation hierarchy
-    isValid &= tri_.is_valid(verbose);
-
-    return isValid;
-  }
-
-  void TriangulatedGrid::Private::DebugPrintMesh() const {
-    std::cout << "num_segments: " << num_segments_ << std::endl;
-    std::cout << "length: " << length_ << std::endl;
-
-    std::cout << "points: [" << points_.size() << "]" << std::endl;
-    for (auto&& p : points_) {
-      std::cout << p << std::endl;
-    }
-    std::cout << "indices: [" << indices_.size() << "]" << std::endl;
-    for (auto&& i : indices_) {
-      std::cout << i[0] << " " << i[1] << " " << i[2]  << std::endl;
-    }
-    std::cout << "infinite indices: [" << infinite_indices_.size() << "]" << std::endl;
-    for (auto&& i : infinite_indices_) {
-      std::cout << i[0] << " " << i[1] << std::endl;
-    }
-  }
-
-  void TriangulatedGrid::Private::DebugPrintTriangulation() const {
-    const Triangulation::Triangulation_data_structure& ctds = tri_.tds();
-
-    std::cout << "triangulation hierarchy data structure" << std::endl;
-    std::cout << ctds << std::endl;
-
-    std::cout << "is valid: " << ctds.is_valid() << std::endl;
-    std::cout << "dimension: " << ctds.dimension() << std::endl;
-    std::cout << "number of vertices : " << ctds.number_of_vertices() << std::endl;
-    std::cout << "number of faces : " << ctds.number_of_faces() << std::endl;
-    std::cout << "number of edges : " << ctds.number_of_edges() << std::endl;
-    std::cout << std::endl;
-
-    std::cout << "triangulation hierarchy" << std::endl;
-    std::cout << tri_ << std::endl; 
-    
-    std::cout << "is valid: " << tri_.is_valid() << std::endl;
-    std::cout << "dimension: " << tri_.dimension() << std::endl;
-    std::cout << "number of vertices : " << tri_.number_of_vertices() << std::endl;
-    std::cout << "number of faces : " << tri_.number_of_faces() << std::endl;
-
-    std::cout << "hierarchy: " << tri_.is_valid() << std::endl;
-    tri_.is_valid(true);
-
-    int64_t idx = 0;
-    std::cout << "vertex -> mesh vertex:" << std::endl;
-    for (auto v = tri_.all_vertices_begin(); v != tri_.all_vertices_end(); ++v, ++idx) {
-      std::cout << "vertex: " << idx
-        << ", mesh vertex: " << v->info()
-        << std::endl; 
-    }
-
-    idx = 0;
-    std::cout << "face -> mesh face:" << std::endl;
-    for (auto f = tri_.all_faces_begin(); f != tri_.all_faces_end(); ++f, ++idx) {
-      std::cout << "face: " << idx
-        << ", mesh face: " << f->info()
-        << std::endl; 
-    }
-  }
-
-  void TriangulatedGrid::Private::UpdatePoints(const std::vector<cgal::Point3>& from) {
-    // Mesh points
-    points_ = from;
-
-    // Triangulation points
-    for (auto v = tri_.finite_vertices_begin(); v != tri_.finite_vertices_end(); ++v) {
-      int64_t idx = v->info();
-      v->set_point(points_[idx]);
-    }
-  }
-
-  void TriangulatedGrid::Private::UpdatePoints(const std::vector<gz::math::Vector3d>& from) {
-    // Mesh points
-    auto it_to = points_.begin();
-    auto it_from = from.begin();
-    for ( ; it_to != points_.end() && it_from != from.end(); ++it_to, ++it_from) {
-      *it_to = cgal::Point3(it_from->X(), it_from->Y(), it_from->Z());
-    }
-
-    // Triangulation points
-    for (auto v = tri_.finite_vertices_begin(); v != tri_.finite_vertices_end(); ++v) {
-      int64_t idx = v->info();
-      v->set_point(points_[idx]);
-    }
-  }
-
-#if 0
-  void TriangulatedGrid::Private::UpdatePoints(const std::vector<Ogre::Vector3>& from) {
-    // Mesh points
-    auto it_to = points_.begin();
-    auto it_from = from.begin();
-    for ( ; it_to != points_.end() && it_from != from.end(); ++it_to, ++it_from) {
-      *it_to = cgal::Point3(it_from->x, it_from->y, it_from->z);
-    }
-
-    // Triangulation points
-    for (auto v = tri_.finite_vertices_begin(); v != tri_.finite_vertices_end(); ++v) {
-      int64_t idx = v->info();
-      v->set_point(points_[idx]);
-    }
-  }
-#endif
-
-  void TriangulatedGrid::Private::UpdatePoints(const cgal::Mesh& from) {
-    // Mesh points
-    auto it_to = points_.begin();
-    auto it_from = std::begin(from.vertices());
-    for ( ; it_to != points_.end() && it_from != std::end(from.vertices()); ++it_to, ++it_from) {
-      const cgal::Point3& p = from.point(*it_from);
-      *it_to = cgal::Point3(p.x(), p.y(), p.z());
-    }
-
-    // Triangulation points
-    for (auto v = tri_.finite_vertices_begin(); v != tri_.finite_vertices_end(); ++v) {
-      int64_t idx = v->info();
-      v->set_point(points_[idx]);
-    }
-  }
-
-///////////////////////////////////////////////////////////////////////////////
-// TriangulatedGrid
-
-  TriangulatedGrid::~TriangulatedGrid() {  
-  }
-
-  TriangulatedGrid::TriangulatedGrid(Index num_segments, double length) :
-    impl_(new TriangulatedGrid::Private(num_segments, length))
-  {  
-  }
-
-  void TriangulatedGrid::CreateMesh() {
-    impl_->CreateMesh();
-  }
-
-  void TriangulatedGrid::CreateTriangulation() {
-    impl_->CreateTriangulation();
-  }
-
-  std::unique_ptr<TriangulatedGrid> TriangulatedGrid::Create(Index num_segments, double length) {
-    std::unique_ptr<TriangulatedGrid> instance = std::make_unique<TriangulatedGrid>(num_segments, length);
-    instance->CreateMesh();
-    instance->CreateTriangulation();
-    return instance;
-  }
-
-  bool TriangulatedGrid::Locate(const cgal::Point3& query, int64_t& faceIndex) const {
-    return impl_->Locate(query, faceIndex);
-  }
-
-  bool TriangulatedGrid::Height(const cgal::Point3& query, double& height) const {
-    return impl_->Height(query, height);
-  }
-
-  bool TriangulatedGrid::Height(const std::vector<cgal::Point3>& queries, std::vector<double>& heights) const {
-    return impl_->Height(queries, heights);
-  }
-
-  bool TriangulatedGrid::Interpolate(TriangulatedGrid& patch) const {
-    return impl_->Interpolate(patch);
-  }
-
-  const Point3Range& TriangulatedGrid::Points() const {
-    return impl_->Points();
-  }
-
-  const Index3Range& TriangulatedGrid::Indices() const {
-    return impl_->Indices();
-  }
-
-  const cgal::Point3& TriangulatedGrid::Origin() const {
-    return impl_->Origin();    
-  }
-
-  void TriangulatedGrid::ApplyPose(const gz::math::Pose3d& pose) {
-    impl_->ApplyPose(pose);    
-  }
-
-  bool TriangulatedGrid::IsValid(bool verbose) const {
-    return impl_->IsValid(verbose);
-  }
-
-  void TriangulatedGrid::DebugPrintMesh() const {
-    impl_->DebugPrintMesh();
-  }
-
-  void TriangulatedGrid::DebugPrintTriangulation() const {
-    impl_->DebugPrintTriangulation();
-  }
-
-  void TriangulatedGrid::UpdatePoints(const std::vector<cgal::Point3>& from) {
-    impl_->UpdatePoints(from);
-  }
-
-  void TriangulatedGrid::UpdatePoints(const std::vector<gz::math::Vector3d>& from) {
-    impl_->UpdatePoints(from);
-  }
-
-#if 0
-  void TriangulatedGrid::UpdatePoints(const std::vector<Ogre::Vector3>& from) {
-    impl_->UpdatePoints(from);
-  }
-#endif
-
-  void TriangulatedGrid::UpdatePoints(const cgal::Mesh& from) {
-    impl_->UpdatePoints(from);
-  }
-
-///////////////////////////////////////////////////////////////////////////////
-
+  return foundAll;
 }
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::Private::Interpolate(TriangulatedGrid& patch) const {
+  bool foundAll = true;
+
+  Face_handle fh = nullptr;
+  for (auto it = patch.impl_->points_.begin();
+      it != patch.impl_->points_.end(); ++it) {
+    double height = 0.0;
+    const cgal::Point3& query = *it;
+    fh = tri_.locate(query, fh);
+    bool found = fh != nullptr;
+    if (found) {
+      // Triangle vertices
+      const auto& p0 = fh->vertex(0)->point();
+      const auto& p1 = fh->vertex(1)->point();
+      const auto& p2 = fh->vertex(2)->point();
+
+      // Height query
+      const cgal::Direction3 direction(0, 0, 1);
+      cgal::Point3 intersection(query);
+      cgal::Triangle triangle(p0, p1, p2);
+
+      found = Geometry::LineIntersectsTriangle(
+          query, direction, triangle, intersection);
+
+      // @DEBUG_INFO
+      // std::cout << "query:        " << query << "\n";
+      // std::cout << "triangle:     " << triangle << "\n";
+      // std::cout << "intersection: " << intersection << "\n";
+
+      if (found) {
+        height = intersection.z();
+      }
+    }
+    // @NOTE this assumes the patch initially has height = 0.0;
+    *it = cgal::Point3(query.x(), query.y(), height);
+
+    foundAll &= found;
+  }
+  return foundAll;
 }
+
+//////////////////////////////////////////////////
+const Point3Range& TriangulatedGrid::Private::Points() const {
+  return points_;
+}
+
+//////////////////////////////////////////////////
+const Index3Range& TriangulatedGrid::Private::Indices() const {
+  return indices_;
+}
+
+//////////////////////////////////////////////////
+const cgal::Point3& TriangulatedGrid::Private::Origin() const {
+  return origin_;
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::Private::ApplyPose(const gz::math::Pose3d& pose) {
+  // Origin - slide the patch in the xy - plane only
+  cgal::Point3 o = CGAL::ORIGIN;
+  origin_ = cgal::Point3(o.x() + pose.Pos().X(), o.y() + pose.Pos().Y(), o.z());
+
+  // Mesh points
+  for (
+    auto&& it = std::make_pair(std::begin(points0_), std::begin(points_));
+    it.first != std::end(points0_) && it.second != std::end(points_);
+    ++it.first, ++it.second)
+  {
+    const auto& p0 = *it.first;
+    auto& p = *it.second;
+    p = cgal::Point3(p0.x() + pose.Pos().X(), p0.y() + pose.Pos().Y(), p0.z());
+  }
+
+  // Triangulation points
+  for (auto v = tri_.finite_vertices_begin();
+      v != tri_.finite_vertices_end(); ++v) {
+    int64_t idx = v->info();
+    v->set_point(points_[idx]);
+  }
+}
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::Private::IsValid(bool verbose) const {
+  bool isValid = true;
+
+  // Triangulation Hierarchy
+  const Triangulation::Triangulation_data_structure& tds = tri_.tds();
+
+  // Verify infinite vertex
+  auto vi = tri_.infinite_vertex();
+  isValid &= vi->is_valid(verbose);
+
+  // Verify vertices
+  for (auto v = tds.vertices_begin(); v !=  tds.vertices_end(); ++v) {
+    isValid &= v->is_valid(verbose);
+  }
+
+  // Verify faces
+  for (auto f = tds.faces_begin(); f !=  tds.faces_end(); ++f) {
+    isValid &= f->is_valid(verbose);
+  }
+
+  // Verify triangulation hierarchy data structure
+  isValid &= tds.is_valid(verbose);
+
+  // Verify triangulation hierarchy
+  isValid &= tri_.is_valid(verbose);
+
+  return isValid;
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::Private::DebugPrintMesh() const {
+  std::cout << "num_segments: " << num_segments_ << "\n";
+  std::cout << "length: " << length_ << "\n";
+
+  std::cout << "points: [" << points_.size() << "]" << "\n";
+  for (auto&& p : points_) {
+    std::cout << p << "\n";
+  }
+  std::cout << "indices: [" << indices_.size() << "]" << "\n";
+  for (auto&& i : indices_) {
+    std::cout << i[0] << " " << i[1] << " " << i[2]  << "\n";
+  }
+  std::cout << "infinite indices: [" << infinite_indices_.size()
+      << "]" << "\n";
+  for (auto&& i : infinite_indices_) {
+    std::cout << i[0] << " " << i[1] << "\n";
+  }
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::Private::DebugPrintTriangulation() const {
+  const Triangulation::Triangulation_data_structure& ctds = tri_.tds();
+
+  std::cout << "triangulation hierarchy data structure" << "\n";
+  std::cout << ctds << "\n";
+
+  std::cout << "is valid: " << ctds.is_valid() << "\n";
+  std::cout << "dimension: " << ctds.dimension() << "\n";
+  std::cout << "number of vertices : " << ctds.number_of_vertices() << "\n";
+  std::cout << "number of faces : " << ctds.number_of_faces() << "\n";
+  std::cout << "number of edges : " << ctds.number_of_edges() << "\n";
+  std::cout << "\n";
+
+  std::cout << "triangulation hierarchy" << "\n";
+  std::cout << tri_ << "\n";
+
+  std::cout << "is valid: " << tri_.is_valid() << "\n";
+  std::cout << "dimension: " << tri_.dimension() << "\n";
+  std::cout << "number of vertices : " << tri_.number_of_vertices() << "\n";
+  std::cout << "number of faces : " << tri_.number_of_faces() << "\n";
+
+  std::cout << "hierarchy: " << tri_.is_valid() << "\n";
+  tri_.is_valid(true);
+
+  int64_t idx = 0;
+  std::cout << "vertex -> mesh vertex:" << "\n";
+  for (auto v = tri_.all_vertices_begin();
+      v != tri_.all_vertices_end(); ++v, ++idx) {
+    std::cout << "vertex: " << idx
+      << ", mesh vertex: " << v->info()
+      << "\n";
+  }
+
+  idx = 0;
+  std::cout << "face -> mesh face:" << "\n";
+  for (auto f = tri_.all_faces_begin();
+      f != tri_.all_faces_end(); ++f, ++idx) {
+    std::cout << "face: " << idx
+      << ", mesh face: " << f->info()
+      << "\n";
+  }
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::Private::UpdatePoints(
+      const std::vector<cgal::Point3>& from) {
+  // Mesh points
+  points_ = from;
+
+  // Triangulation points
+  for (auto v = tri_.finite_vertices_begin();
+      v != tri_.finite_vertices_end(); ++v) {
+    int64_t idx = v->info();
+    v->set_point(points_[idx]);
+  }
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::Private::UpdatePoints(
+    const std::vector<gz::math::Vector3d>& from) {
+  // Mesh points
+  auto it_to = points_.begin();
+  auto it_from = from.begin();
+  for ( ; it_to != points_.end() && it_from != from.end();
+      ++it_to, ++it_from) {
+    *it_to = cgal::Point3(it_from->X(), it_from->Y(), it_from->Z());
+  }
+
+  // Triangulation points
+  for (auto v = tri_.finite_vertices_begin();
+      v != tri_.finite_vertices_end(); ++v) {
+    int64_t idx = v->info();
+    v->set_point(points_[idx]);
+  }
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::Private::UpdatePoints(const cgal::Mesh& from) {
+  // Mesh points
+  auto it_to = points_.begin();
+  auto it_from = std::begin(from.vertices());
+  for ( ; it_to != points_.end() && it_from != std::end(from.vertices());
+      ++it_to, ++it_from) {
+    const cgal::Point3& p = from.point(*it_from);
+    *it_to = cgal::Point3(p.x(), p.y(), p.z());
+  }
+
+  // Triangulation points
+  for (auto v = tri_.finite_vertices_begin();
+      v != tri_.finite_vertices_end(); ++v) {
+    int64_t idx = v->info();
+    v->set_point(points_[idx]);
+  }
+}
+
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+TriangulatedGrid::~TriangulatedGrid() {
+}
+
+//////////////////////////////////////////////////
+TriangulatedGrid::TriangulatedGrid(Index num_segments, double length) :
+  impl_(new TriangulatedGrid::Private(num_segments, length))
+{
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::CreateMesh() {
+  impl_->CreateMesh();
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::CreateTriangulation() {
+  impl_->CreateTriangulation();
+}
+
+//////////////////////////////////////////////////
+std::unique_ptr<TriangulatedGrid> TriangulatedGrid::Create(
+    Index num_segments, double length) {
+  std::unique_ptr<TriangulatedGrid> instance =
+      std::make_unique<TriangulatedGrid>(num_segments, length);
+  instance->CreateMesh();
+  instance->CreateTriangulation();
+  return instance;
+}
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::Locate(const cgal::Point3& query,
+    int64_t& faceIndex) const {
+  return impl_->Locate(query, faceIndex);
+}
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::Height(const cgal::Point3& query,
+    double& height) const {
+  return impl_->Height(query, height);
+}
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::Height(const std::vector<cgal::Point3>& queries,
+    std::vector<double>& heights) const {
+  return impl_->Height(queries, heights);
+}
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::Interpolate(TriangulatedGrid& patch) const {
+  return impl_->Interpolate(patch);
+}
+
+//////////////////////////////////////////////////
+const Point3Range& TriangulatedGrid::Points() const {
+  return impl_->Points();
+}
+
+//////////////////////////////////////////////////
+const Index3Range& TriangulatedGrid::Indices() const {
+  return impl_->Indices();
+}
+
+//////////////////////////////////////////////////
+const cgal::Point3& TriangulatedGrid::Origin() const {
+  return impl_->Origin();
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::ApplyPose(const gz::math::Pose3d& pose) {
+  impl_->ApplyPose(pose);
+}
+
+//////////////////////////////////////////////////
+bool TriangulatedGrid::IsValid(bool verbose) const {
+  return impl_->IsValid(verbose);
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::DebugPrintMesh() const {
+  impl_->DebugPrintMesh();
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::DebugPrintTriangulation() const {
+  impl_->DebugPrintTriangulation();
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::UpdatePoints(const std::vector<cgal::Point3>& from) {
+  impl_->UpdatePoints(from);
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::UpdatePoints(
+    const std::vector<gz::math::Vector3d>& from) {
+  impl_->UpdatePoints(from);
+}
+
+//////////////////////////////////////////////////
+void TriangulatedGrid::UpdatePoints(const cgal::Mesh& from) {
+  impl_->UpdatePoints(from);
+}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/TriangulatedGrid.cc
+++ b/gz-waves/src/TriangulatedGrid.cc
@@ -42,7 +42,7 @@ namespace waves
   class TriangulatedGrid::Private {
    public:
     ~Private();
-    Private(int num_segments, double length);
+    Private(Index num_segments, double length);
     void CreateMesh();
     void CreateTriangulation();    
 
@@ -83,7 +83,7 @@ namespace waves
     typedef Triangulation::Face                                           Face;
 
     // Dimensions
-    int num_segments_;
+    Index num_segments_;
     double length_;
 
     // Mesh
@@ -100,14 +100,14 @@ namespace waves
   TriangulatedGrid::Private::~Private() {
   }
 
-  TriangulatedGrid::Private::Private(int num_segments, double length) : 
+  TriangulatedGrid::Private::Private(Index num_segments, double length) : 
     num_segments_(num_segments), length_(length), origin_(CGAL::ORIGIN) {  
   }
 
   void TriangulatedGrid::Private::CreateMesh() {
     double dl = length_ / num_segments_;
     double lm = - length_ / 2.0;
-    const int nplus1 = num_segments_ + 1; 
+    const Index nplus1 = num_segments_ + 1; 
 
     // Points - (num_segments_+1) points_ in each row / column 
     for (int64_t iy=0; iy<=num_segments_; ++iy) {
@@ -191,7 +191,7 @@ namespace waves
     // std::cout << "set vertex info: " << timer.time() << " s" << std::endl;
 
     // Constraint indices 
-    const int nplus1 = num_segments_ + 1; 
+    const Index nplus1 = num_segments_ + 1; 
     std::vector<std::pair<size_t, int64_t>> cindices;
     for (int64_t iy=0; iy<num_segments_; ++iy) {
       for (int64_t ix=0; ix<num_segments_; ++ix) {
@@ -544,7 +544,7 @@ namespace waves
   TriangulatedGrid::~TriangulatedGrid() {  
   }
 
-  TriangulatedGrid::TriangulatedGrid(int num_segments, double length) :
+  TriangulatedGrid::TriangulatedGrid(Index num_segments, double length) :
     impl_(new TriangulatedGrid::Private(num_segments, length))
   {  
   }
@@ -557,7 +557,7 @@ namespace waves
     impl_->CreateTriangulation();
   }
 
-  std::unique_ptr<TriangulatedGrid> TriangulatedGrid::Create(int num_segments, double length) {
+  std::unique_ptr<TriangulatedGrid> TriangulatedGrid::Create(Index num_segments, double length) {
     std::unique_ptr<TriangulatedGrid> instance = std::make_unique<TriangulatedGrid>(num_segments, length);
     instance->CreateMesh();
     instance->CreateTriangulation();

--- a/gz-waves/src/TriangulatedGrid_TEST.cc
+++ b/gz-waves/src/TriangulatedGrid_TEST.cc
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "gz/waves/TriangulatedGrid.hh"
-#include "gz/waves/Types.hh"
-
 #include <gtest/gtest.h>
-
-#include <gz/math/Pose3.hh>
 
 #include <algorithm>
 #include <iostream>
@@ -27,12 +22,21 @@
 #include <memory>
 #include <string>
 
-///////////////////////////////////////////////////////////////////////////////
-// Define tests
+#include <gz/math/Pose3.hh>
 
-using namespace gz;
-using namespace waves;
+#include "gz/waves/TriangulatedGrid.hh"
+#include "gz/waves/Types.hh"
 
+namespace cgal
+{
+using gz::cgal::Point3;
+}  // namespace cgal
+
+using gz::waves::Index;
+using gz::waves::Point3Range;
+using gz::waves::TriangulatedGrid;
+
+//////////////////////////////////////////////////
 TEST(TriangulatedGrid, Create) {
   // Create
   Index n = 2;
@@ -53,6 +57,7 @@ TEST(TriangulatedGrid, Create) {
   EXPECT_EQ(tri_grid->Origin(), cgal::Point3(10.0, 0.0, 0.0));
 }
 
+//////////////////////////////////////////////////
 TEST(TriangulatedGrid, Height) {
   // Create
   Index n = 16;
@@ -70,8 +75,8 @@ TEST(TriangulatedGrid, Height) {
 
   // Set points
   Point3Range points = source->Points();
-  for (Index iy=0; iy<nplus1; ++iy) {
-    for (Index ix=0; ix<nplus1; ++ix) {
+  for (Index iy=0; iy < nplus1; ++iy) {
+    for (Index ix=0; ix < nplus1; ++ix) {
       int64_t idx = iy * nplus1 + ix;
       double value = ix + iy;
       const cgal::Point3& p = points[idx];
@@ -85,6 +90,7 @@ TEST(TriangulatedGrid, Height) {
   EXPECT_DOUBLE_EQ(height, 14.4);
 }
 
+//////////////////////////////////////////////////
 TEST(TriangulatedGrid, Interpolate) {
   // Create
   Index n = 16;
@@ -96,8 +102,8 @@ TEST(TriangulatedGrid, Interpolate) {
 
   // Set points
   Point3Range points = source->Points();
-  for (Index iy=0; iy<nplus1; ++iy) {
-    for (Index ix=0; ix<nplus1; ++ix) {
+  for (Index iy=0; iy < nplus1; ++iy) {
+    for (Index ix=0; ix < nplus1; ++ix) {
       int64_t idx = iy * nplus1 + ix;
       double value = ix + iy;
       const cgal::Point3& p = points[idx];
@@ -136,11 +142,7 @@ TEST(TriangulatedGrid, Interpolate) {
   EXPECT_TRUE(found);
 }
 
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Run tests
-
+//////////////////////////////////////////////////
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/gz-waves/src/TriangulatedGrid_TEST.cc
+++ b/gz-waves/src/TriangulatedGrid_TEST.cc
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/TriangulatedGrid.hh"
+#include "gz/waves/Types.hh"
 
 #include <gtest/gtest.h>
 
@@ -34,8 +35,8 @@ using namespace waves;
 
 TEST(TriangulatedGrid, Create) {
   // Create
-  int n = 2;
-  int length = 100.0;
+  Index n = 2;
+  Index length = 100.0;
   auto grid = TriangulatedGrid::Create(n, length);
   std::unique_ptr<TriangulatedGrid> tri_grid = std::move(grid);
   // tri_grid->DebugPrintMesh();
@@ -54,9 +55,9 @@ TEST(TriangulatedGrid, Create) {
 
 TEST(TriangulatedGrid, Height) {
   // Create
-  int n = 16;
-  int length = 100.0;
-  int nplus1 = n + 1;
+  Index n = 16;
+  Index length = 100.0;
+  Index nplus1 = n + 1;
   auto grid = TriangulatedGrid::Create(n, length);
   std::unique_ptr<TriangulatedGrid> source = std::move(grid);
   EXPECT_TRUE(source->IsValid());
@@ -69,8 +70,8 @@ TEST(TriangulatedGrid, Height) {
 
   // Set points
   Point3Range points = source->Points();
-  for (int iy=0; iy<nplus1; ++iy) {
-    for (int ix=0; ix<nplus1; ++ix) {
+  for (Index iy=0; iy<nplus1; ++iy) {
+    for (Index ix=0; ix<nplus1; ++ix) {
       int64_t idx = iy * nplus1 + ix;
       double value = ix + iy;
       const cgal::Point3& p = points[idx];
@@ -86,17 +87,17 @@ TEST(TriangulatedGrid, Height) {
 
 TEST(TriangulatedGrid, Interpolate) {
   // Create
-  int n = 16;
-  int length = 100.0;
-  int nplus1 = n + 1;
+  Index n = 16;
+  Index length = 100.0;
+  Index nplus1 = n + 1;
   auto grid1 = TriangulatedGrid::Create(n, length);
   std::unique_ptr<TriangulatedGrid> source = std::move(grid1);
   EXPECT_TRUE(source->IsValid());
 
   // Set points
   Point3Range points = source->Points();
-  for (int iy=0; iy<nplus1; ++iy) {
-    for (int ix=0; ix<nplus1; ++ix) {
+  for (Index iy=0; iy<nplus1; ++iy) {
+    for (Index ix=0; ix<nplus1; ++ix) {
       int64_t idx = iy * nplus1 + ix;
       double value = ix + iy;
       const cgal::Point3& p = points[idx];

--- a/gz-waves/src/TrochoidIrregularWaveSimulation.cc
+++ b/gz-waves/src/TrochoidIrregularWaveSimulation.cc
@@ -15,6 +15,7 @@
 
 #include "gz/waves/TrochoidIrregularWaveSimulation.hh"
 
+#include "gz/waves/Types.hh"
 #include "gz/waves/Wavefield.hh"
 #include "gz/waves/WaveParameters.hh"
 
@@ -113,7 +114,7 @@ namespace waves
 
     // Multiple wave update 
     h = Eigen::ArrayXXd::Zero(this->N2_, 0);
-    for (size_t i=0; i<number; ++i)
+    for (Index i=0; i<number; ++i)
     {        
       const auto& amplitude_i = amplitude[i];
       const auto& wavenumber_i = wavenumber[i];
@@ -173,7 +174,7 @@ namespace waves
     // Multiple wave update
     sx = Eigen::ArrayXXd::Zero(this->N2_, 0);
     sy = Eigen::ArrayXXd::Zero(this->N2_, 0);
-    for (size_t i=0; i<number; ++i)
+    for (Index i=0; i<number; ++i)
     {        
       const auto& amplitude_i = amplitude[i];
       const auto& wavenumber_i = wavenumber[i];
@@ -187,7 +188,7 @@ namespace waves
         for (Index ix=0; ix<this->N_; ++ix)
         {
           // Col major index
-          size_t idx = iy * this->N_ + ix;
+          Index idx = iy * this->N_ + ix;
 
           // Regular grid
           double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;

--- a/gz-waves/src/TrochoidIrregularWaveSimulation.cc
+++ b/gz-waves/src/TrochoidIrregularWaveSimulation.cc
@@ -15,334 +15,334 @@
 
 #include "gz/waves/TrochoidIrregularWaveSimulation.hh"
 
+#include <vector>
+
 #include "gz/waves/Types.hh"
 #include "gz/waves/Wavefield.hh"
 #include "gz/waves/WaveParameters.hh"
-
-#include <vector>
 
 namespace gz
 {
 namespace waves
 {
 
-  //////////////////////////////////////////////////
-  class TrochoidIrregularWaveSimulation::Impl
+//////////////////////////////////////////////////
+class TrochoidIrregularWaveSimulation::Impl
+{
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  ~Impl();
+
+  Impl(
+      Index N,
+      double L,
+      std::shared_ptr<WaveParameters> params);
+
+  void SetWindVelocity(double ux, double uy);
+
+  void SetTime(double time);
+
+  void ElevationAt(
+      Eigen::Ref<Eigen::ArrayXXd> _heights);
+
+  void ElevationDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> _dhdx,
+      Eigen::Ref<Eigen::ArrayXXd> _dhdy);
+
+  void DisplacementAt(
+      Eigen::Ref<Eigen::ArrayXXd> _sx,
+      Eigen::Ref<Eigen::ArrayXXd> _sy);
+
+  void DisplacementDerivAt(
+      Eigen::Ref<Eigen::ArrayXXd> _dsxdx,
+      Eigen::Ref<Eigen::ArrayXXd> _dsydy,
+      Eigen::Ref<Eigen::ArrayXXd> _dsxdy);
+
+  Index N_;
+  Index N2_;
+  Index NOver2_;
+  double L_;
+  double time_;
+  std::shared_ptr<WaveParameters> params_;
+};
+
+//////////////////////////////////////////////////
+TrochoidIrregularWaveSimulation::Impl::~Impl()
+{
+}
+
+//////////////////////////////////////////////////
+TrochoidIrregularWaveSimulation::Impl::Impl(
+  Index N,
+  double L,
+  std::shared_ptr<WaveParameters> params) :
+  N_(N),
+  N2_(N * N),
+  NOver2_(N / 2),
+  L_(L),
+  params_(params)
+{
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::SetWindVelocity(
+    double /*ux*/, double /*uy*/)
+{
+  // @TODO NO IMPLEMENTATION
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::SetTime(double time)
+{
+  // @TODO NO IMPLEMENTATION
+  this->time_ = time;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::ElevationAt(
+  Eigen::Ref<Eigen::ArrayXXd> h)
+{
+  // Multiple wave params
+  const auto  number     = this->params_->Number();
+  const auto& amplitude  = this->params_->Amplitude_V();
+  const auto& wavenumber = this->params_->Wavenumber_V();
+  const auto& omega      = this->params_->AngularFrequency_V();
+  const auto& phase      = this->params_->Phase_V();
+  // const auto& q          = this->params_->Steepness_V();
+  const auto& direction  = this->params_->Direction_V();
+
+  // Multiple wave update
+  h = Eigen::ArrayXXd::Zero(this->N2_, 0);
+  for (Index i=0; i < number; ++i)
   {
-  public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    const auto& amplitude_i = amplitude[i];
+    const auto& wavenumber_i = wavenumber[i];
+    const auto& omega_i = omega[i];
+    const auto& phase_i = phase[i];
+    const auto& direction_i = direction[i];
+    // const auto& q_i = q[i];
 
-    ~Impl();
-
-    Impl(
-        Index N,
-        double L,
-        std::shared_ptr<WaveParameters> params);
-
-    void SetWindVelocity(double ux, double uy);
-
-    void SetTime(double time);
-
-    void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> _heights);
-
-    void ElevationDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> _dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> _dhdy);
-
-    void DisplacementAt(
-        Eigen::Ref<Eigen::ArrayXXd> _sx,
-        Eigen::Ref<Eigen::ArrayXXd> _sy);
-
-    void DisplacementDerivAt(
-        Eigen::Ref<Eigen::ArrayXXd> _dsxdx,
-        Eigen::Ref<Eigen::ArrayXXd> _dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> _dsxdy);
-  
-    Index N_;
-    Index N2_;
-    Index NOver2_;
-    double L_;
-    double time_;
-    std::shared_ptr<WaveParameters> params_;
-  };
-
-  //////////////////////////////////////////////////
-  TrochoidIrregularWaveSimulation::Impl::~Impl()
-  {
-  }
-
-  //////////////////////////////////////////////////
-  TrochoidIrregularWaveSimulation::Impl::Impl(
-    Index N,
-    double L,
-    std::shared_ptr<WaveParameters> params) :
-    N_(N),
-    N2_(N * N),
-    NOver2_(N / 2),
-    L_(L),
-    params_(params)
-  {
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::Impl::SetWindVelocity(
-      double /*ux*/, double /*uy*/)
-  {
-    // @TODO NO IMPLEMENTATION
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::Impl::SetTime(double time)
-  {
-    // @TODO NO IMPLEMENTATION
-    this->time_ = time;
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::Impl::ElevationAt(
-    Eigen::Ref<Eigen::ArrayXXd> h)
-  {
-    // Multiple wave params
-    const auto  number     = this->params_->Number();
-    const auto& amplitude  = this->params_->Amplitude_V();
-    const auto& wavenumber = this->params_->Wavenumber_V();
-    const auto& omega      = this->params_->AngularFrequency_V();
-    const auto& phase      = this->params_->Phase_V();
-    // const auto& q          = this->params_->Steepness_V();
-    const auto& direction  = this->params_->Direction_V();
-
-    // Multiple wave update 
-    h = Eigen::ArrayXXd::Zero(this->N2_, 0);
-    for (Index i=0; i<number; ++i)
-    {        
-      const auto& amplitude_i = amplitude[i];
-      const auto& wavenumber_i = wavenumber[i];
-      const auto& omega_i = omega[i];
-      const auto& phase_i = phase[i];
-      const auto& direction_i = direction[i];
-      // const auto& q_i = q[i];
-
-      for (Index iy=0; iy<this->N_; ++iy)
+    for (Index iy=0; iy < this->N_; ++iy)
+    {
+      for (Index ix=0; i < this->N_; ++ix)
       {
-        for (Index ix=0; ix<this->N_; ++ix)
-        {
-          // Col major index
-          Index idx = iy * this->N_ + ix;
+        // Col major index
+        Index idx = iy * this->N_ + ix;
 
-          // Regular grid
-          double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;
-          double vy = iy * this->L_ / this->N_ - this->L_ / 2.0;
+        // Regular grid
+        double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;
+        double vy = iy * this->L_ / this->N_ - this->L_ / 2.0;
 
-          // Multiple waves
-          double ddotx = direction_i.X() * vx + direction_i.Y() * vy;
-          double angle  = ddotx * wavenumber_i - omega_i * time_ + phase_i;
-          // double s = std::sin(angle);
-          double c = std::cos(angle);
-          // double sx = - direction_i.X() * q_i * amplitude_i * s;
-          // double sy = - direction_i.Y() * q_i * amplitude_i * s;
-          double h1 = amplitude_i * c;
+        // Multiple waves
+        double ddotx = direction_i.X() * vx + direction_i.Y() * vy;
+        double angle  = ddotx * wavenumber_i - omega_i * time_ + phase_i;
+        // double s = std::sin(angle);
+        double c = std::cos(angle);
+        // double sx = - direction_i.X() * q_i * amplitude_i * s;
+        // double sy = - direction_i.Y() * q_i * amplitude_i * s;
+        double h1 = amplitude_i * c;
 
-          h(idx, 0) += h1;
-        }
+        h(idx, 0) += h1;
       }
     }
   }
+}
 
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::Impl::ElevationDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> /*dhdx*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*dhdy*/)
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::ElevationDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> /*dhdx*/,
+  Eigen::Ref<Eigen::ArrayXXd> /*dhdy*/)
+{
+  // @TODO NO IMPLEMENTATION
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::DisplacementAt(
+  Eigen::Ref<Eigen::ArrayXXd> sx,
+  Eigen::Ref<Eigen::ArrayXXd> sy)
+{
+  // Multiple wave params
+  const auto  number     = this->params_->Number();
+  const auto& amplitude  = this->params_->Amplitude_V();
+  const auto& wavenumber = this->params_->Wavenumber_V();
+  const auto& omega      = this->params_->AngularFrequency_V();
+  const auto& phase      = this->params_->Phase_V();
+  const auto& q          = this->params_->Steepness_V();
+  const auto& direction  = this->params_->Direction_V();
+
+  // Multiple wave update
+  sx = Eigen::ArrayXXd::Zero(this->N2_, 0);
+  sy = Eigen::ArrayXXd::Zero(this->N2_, 0);
+  for (Index i=0; i < number; ++i)
   {
-    // @TODO NO IMPLEMENTATION
-  }
+    const auto& amplitude_i = amplitude[i];
+    const auto& wavenumber_i = wavenumber[i];
+    const auto& omega_i = omega[i];
+    const auto& phase_i = phase[i];
+    const auto& direction_i = direction[i];
+    const auto& q_i = q[i];
 
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::Impl::DisplacementAt(
-    Eigen::Ref<Eigen::ArrayXXd> sx,
-    Eigen::Ref<Eigen::ArrayXXd> sy)
-  {
-    // Multiple wave params
-    const auto  number     = this->params_->Number();
-    const auto& amplitude  = this->params_->Amplitude_V();
-    const auto& wavenumber = this->params_->Wavenumber_V();
-    const auto& omega      = this->params_->AngularFrequency_V();
-    const auto& phase      = this->params_->Phase_V();
-    const auto& q          = this->params_->Steepness_V();
-    const auto& direction  = this->params_->Direction_V();
-
-    // Multiple wave update
-    sx = Eigen::ArrayXXd::Zero(this->N2_, 0);
-    sy = Eigen::ArrayXXd::Zero(this->N2_, 0);
-    for (Index i=0; i<number; ++i)
-    {        
-      const auto& amplitude_i = amplitude[i];
-      const auto& wavenumber_i = wavenumber[i];
-      const auto& omega_i = omega[i];
-      const auto& phase_i = phase[i];
-      const auto& direction_i = direction[i];
-      const auto& q_i = q[i];
-
-      for (Index iy=0; iy<this->N_; ++iy)
+    for (Index iy=0; iy < this->N_; ++iy)
+    {
+      for (Index ix=0; ix < this->N_; ++ix)
       {
-        for (Index ix=0; ix<this->N_; ++ix)
-        {
-          // Col major index
-          Index idx = iy * this->N_ + ix;
+        // Col major index
+        Index idx = iy * this->N_ + ix;
 
-          // Regular grid
-          double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;
-          double vy = iy * this->L_ / this->N_ - this->L_ / 2.0;
+        // Regular grid
+        double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;
+        double vy = iy * this->L_ / this->N_ - this->L_ / 2.0;
 
-          // Multiple waves
-          double ddotx = direction_i.X() * vx + direction_i.Y() * vy;
-          double angle  = ddotx * wavenumber_i - omega_i * time_ + phase_i;
-          double s = std::sin(angle);
-          // double c = std::cos(angle);
-          double sx1 = - direction_i.X() * q_i * amplitude_i * s;
-          double sy1 = - direction_i.Y() * q_i * amplitude_i * s;
-          // double h = amplitude_i * c;
+        // Multiple waves
+        double ddotx = direction_i.X() * vx + direction_i.Y() * vy;
+        double angle  = ddotx * wavenumber_i - omega_i * time_ + phase_i;
+        double s = std::sin(angle);
+        // double c = std::cos(angle);
+        double sx1 = - direction_i.X() * q_i * amplitude_i * s;
+        double sy1 = - direction_i.Y() * q_i * amplitude_i * s;
+        // double h = amplitude_i * c;
 
-          sx(idx, 0) += sx1;
-          sy(idx, 0) += sy1;
-        }
+        sx(idx, 0) += sx1;
+        sy(idx, 0) += sy1;
       }
     }
   }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::Impl::DisplacementDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
-  {
-    // @TODO NO IMPLEMENTATION
-  }
-
-  //////////////////////////////////////////////////
-  TrochoidIrregularWaveSimulation::~TrochoidIrregularWaveSimulation()
-  {
-  }
-
-  //////////////////////////////////////////////////
-  TrochoidIrregularWaveSimulation::TrochoidIrregularWaveSimulation(
-    Index N,
-    double L,
-    std::shared_ptr<WaveParameters> params) :
-    impl_(new TrochoidIrregularWaveSimulation::Impl(N, L, params))
-  {
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::SetWindVelocity(double ux, double uy)
-  {
-    impl_->SetWindVelocity(ux, uy);
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::SetTime(double time)
-  {
-    impl_->SetTime(time);
-  }
-
-  //////////////////////////////////////////////////
-  Index TrochoidIrregularWaveSimulation::SizeX() const
-  {
-    return impl_->N_;
-  }
-
-  //////////////////////////////////////////////////
-  Index TrochoidIrregularWaveSimulation::SizeY() const
-  {
-    return impl_->N_;
-  }
-
-  //////////////////////////////////////////////////
-  Index TrochoidIrregularWaveSimulation::SizeZ() const
-  {
-    return 0;
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::ElevationAt(
-    Eigen::Ref<Eigen::ArrayXXd> h)
-  {
-    impl_->ElevationAt(h);
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::ElevationDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> dhdx,
-    Eigen::Ref<Eigen::ArrayXXd> dhdy)
-  {
-    impl_->ElevationDerivAt(dhdx, dhdy);
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::DisplacementAt(
-    Eigen::Ref<Eigen::ArrayXXd> sx,
-    Eigen::Ref<Eigen::ArrayXXd> sy)
-  {
-    impl_->DisplacementAt(sx, sy);
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::DisplacementDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-    Eigen::Ref<Eigen::ArrayXXd> dsydy,
-    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-  {
-    impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::DisplacementAndDerivAt(
-    Eigen::Ref<Eigen::ArrayXXd> h,
-    Eigen::Ref<Eigen::ArrayXXd> sx,
-    Eigen::Ref<Eigen::ArrayXXd> sy,
-    Eigen::Ref<Eigen::ArrayXXd> dhdx,
-    Eigen::Ref<Eigen::ArrayXXd> dhdy,
-    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-    Eigen::Ref<Eigen::ArrayXXd> dsydy,
-    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
-  {
-    impl_->ElevationAt(h);
-    impl_->ElevationDerivAt(dhdx, dhdy);
-    impl_->DisplacementAt(sx, sy);
-    impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::PressureAt(
-      Index ,
-      Eigen::Ref<Eigen::ArrayXXd> )
-  {
-    assert(0 && "Not implemented");
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::ElevationAt(
-      Index , Index ,
-      double &)
-  {
-    assert(0 && "Not implemented");
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::DisplacementAt(
-      Index , Index ,
-      double &, double &)
-  {
-    assert(0 && "Not implemented");
-  }
-
-  //////////////////////////////////////////////////
-  void TrochoidIrregularWaveSimulation::PressureAt(
-      Index , Index , Index ,
-      double &)
-  {
-    assert(0 && "Not implemented");
-  }
-
 }
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::DisplacementDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
+  Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
+  Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+{
+  // @TODO NO IMPLEMENTATION
 }
+
+//////////////////////////////////////////////////
+TrochoidIrregularWaveSimulation::~TrochoidIrregularWaveSimulation()
+{
+}
+
+//////////////////////////////////////////////////
+TrochoidIrregularWaveSimulation::TrochoidIrregularWaveSimulation(
+  Index N,
+  double L,
+  std::shared_ptr<WaveParameters> params) :
+  impl_(new TrochoidIrregularWaveSimulation::Impl(N, L, params))
+{
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetWindVelocity(double ux, double uy)
+{
+  impl_->SetWindVelocity(ux, uy);
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetTime(double time)
+{
+  impl_->SetTime(time);
+}
+
+//////////////////////////////////////////////////
+Index TrochoidIrregularWaveSimulation::SizeX() const
+{
+  return impl_->N_;
+}
+
+//////////////////////////////////////////////////
+Index TrochoidIrregularWaveSimulation::SizeY() const
+{
+  return impl_->N_;
+}
+
+//////////////////////////////////////////////////
+Index TrochoidIrregularWaveSimulation::SizeZ() const
+{
+  return 0;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::ElevationAt(
+  Eigen::Ref<Eigen::ArrayXXd> h)
+{
+  impl_->ElevationAt(h);
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::ElevationDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> dhdx,
+  Eigen::Ref<Eigen::ArrayXXd> dhdy)
+{
+  impl_->ElevationDerivAt(dhdx, dhdy);
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::DisplacementAt(
+  Eigen::Ref<Eigen::ArrayXXd> sx,
+  Eigen::Ref<Eigen::ArrayXXd> sy)
+{
+  impl_->DisplacementAt(sx, sy);
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::DisplacementDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+  Eigen::Ref<Eigen::ArrayXXd> dsydy,
+  Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+{
+  impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::DisplacementAndDerivAt(
+  Eigen::Ref<Eigen::ArrayXXd> h,
+  Eigen::Ref<Eigen::ArrayXXd> sx,
+  Eigen::Ref<Eigen::ArrayXXd> sy,
+  Eigen::Ref<Eigen::ArrayXXd> dhdx,
+  Eigen::Ref<Eigen::ArrayXXd> dhdy,
+  Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+  Eigen::Ref<Eigen::ArrayXXd> dsydy,
+  Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+{
+  impl_->ElevationAt(h);
+  impl_->ElevationDerivAt(dhdx, dhdy);
+  impl_->DisplacementAt(sx, sy);
+  impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::PressureAt(
+    Index ,
+    Eigen::Ref<Eigen::ArrayXXd> )
+{
+  assert(0 && "Not implemented");
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::ElevationAt(
+    Index , Index ,
+    double&)
+{
+  assert(0 && "Not implemented");
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::DisplacementAt(
+    Index , Index ,
+    double&, double&)
+{
+  assert(0 && "Not implemented");
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::PressureAt(
+    Index , Index , Index ,
+    double&)
+{
+  assert(0 && "Not implemented");
+}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/Utilities.cc
+++ b/gz-waves/src/Utilities.cc
@@ -14,37 +14,39 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/Utilities.hh"
-#include "gz/waves/Convert.hh"
+
+#include <algorithm>
+#include <iostream>
+#include <string>
 
 #include <gz/common.hh>
 #include <gz/math.hh>
 #include <sdf/sdf.hh>
 
-#include <algorithm>
-#include <iostream>
-#include <string>
+#include "gz/waves/Convert.hh"
 
 namespace gz
 {
 namespace waves
 {
 
-///////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////
 // Templates
 
 // This code adapted vmrc/usv_gazebo_plugins/usv_gazebo_dynamics_plugin.cc
 template <typename T>
-T SdfParam(const sdf::Element& _sdf, const std::string &_paramName, const T _defaultVal)
+T SdfParam(const sdf::Element& _sdf, const std::string &_paramName,
+    const T _defaultVal)
 {
   if (!_sdf.HasElement(_paramName))
   {
-    gzmsg << "Parameter <" << _paramName << "> not found: " 
+    gzmsg << "Parameter <" << _paramName << "> not found: "
       <<  "Using default value of <" << _defaultVal << ">." << std::endl;
     return _defaultVal;
   }
 
   T val = _sdf.Get<T>(_paramName);
-  gzmsg << "Parameter found - setting <" << _paramName 
+  gzmsg << "Parameter found - setting <" << _paramName
     << "> to <" << val << ">." << std::endl;
   return val;
 }
@@ -54,79 +56,88 @@ template <typename T>
 T MsgParamGetValue(const gz::msgs::Param& /*_msg*/)
 {
   gzwarn << "Using default template for MsgParamGetValue" << std::endl;
-  return T();  
+  return T();
 }
 
-/// \brief Template specialization for extracting a bool from a parameter message.
+/// \brief Template specialization for extracting a bool
+///        from a parameter message.
 template <>
 bool MsgParamGetValue<bool>(const gz::msgs::Param& _msg)
-{ 
+{
   auto paramValue = _msg.params().begin()->second;
   // auto paramValue = _msg.value();
   return paramValue.bool_value();
 }
 
-/// \brief Template specialization for extracting an int from a parameter message.
+/// \brief Template specialization for extracting an int
+///        from a parameter message.
 template <>
 int MsgParamGetValue<int>(const gz::msgs::Param& _msg)
-{ 
+{
   auto paramValue = _msg.params().begin()->second;
   // auto paramValue = _msg.value();
   return paramValue.int_value();
 }
 
-/// \brief Template specialization for extracting a size_t from a parameter message.
+/// \brief Template specialization for extracting a size_t
+///        from a parameter message.
 template <>
 size_t MsgParamGetValue<size_t>(const gz::msgs::Param& _msg)
-{ 
+{
   auto paramValue = _msg.params().begin()->second;
   // auto paramValue = _msg.value();
   return paramValue.int_value();
 }
 
-/// \brief Template specialization for extracting a double from a parameter message.
+/// \brief Template specialization for extracting a double
+///        from a parameter message.
 template <>
 double MsgParamGetValue<double>(const gz::msgs::Param& _msg)
-{ 
+{
   auto paramValue = _msg.params().begin()->second;
   // auto paramValue = _msg.value();
   return paramValue.double_value();
 }
 
-/// \brief Template specialization for extracting a string from a parameter message.
+/// \brief Template specialization for extracting a string
+///        from a parameter message.
 template <>
 std::string MsgParamGetValue<std::string>(const gz::msgs::Param& _msg)
-{ 
+{
   auto paramValue = _msg.params().begin()->second;
   // auto paramValue = _msg.value();
   return paramValue.string_value();
 }
 
-/// \brief Template specialization for extracting a Vector2i from a parameter message.
+/// \brief Template specialization for extracting a Vector2i
+///        from a parameter message.
 template <>
 gz::math::Vector2i MsgParamGetValue<gz::math::Vector2i>(
     const gz::msgs::Param& _msg)
-{ 
+{
   auto paramValue = _msg.params().begin()->second;
   // auto paramValue = _msg.value();
   auto vec = paramValue.vector3d_value();
   return gz::math::Vector2i(vec.x(), vec.y());
 }
 
-/// \brief Template specialization for extracting a Vector3 from a parameter message.
+/// \brief Template specialization for extracting a Vector3
+///        from a parameter message.
 template <>
 gz::math::Vector3d MsgParamGetValue<gz::math::Vector3d>(
     const gz::msgs::Param& _msg)
-{ 
+{
   auto paramValue = _msg.params().begin()->second;
   // auto paramValue = _msg.value();
   auto vec = paramValue.vector3d_value();
   return gz::math::Vector3d(vec.x(), vec.y(), vec.z());
 }
 
-/// \brief Template for extracting a named parameter from a parameter vector message.
+/// \brief Template for extracting a named parameter from
+///        a parameter vector message.
 template <typename T>
-T MsgParam(const gz::msgs::Param_V& _msg, const std::string &_paramName, const T _defaultVal)
+T MsgParam(const gz::msgs::Param_V& _msg, const std::string &_paramName,
+    const T _defaultVal)
 {
   // Custom compare for params
   auto compare = [=](auto& _param)
@@ -136,13 +147,14 @@ T MsgParam(const gz::msgs::Param_V& _msg, const std::string &_paramName, const T
     // return _param.name() == _paramName;
   };
 
-  auto it = std::find_if(std::begin(_msg.param()), std::end(_msg.param()), compare);
-  
+  auto it = std::find_if(std::begin(_msg.param()),
+      std::end(_msg.param()), compare);
+
   // Not found
   if (it == std::end(_msg.param()))
   {
   // @DEBUG_INFO
-    // gzmsg << "Parameter <" << _paramName << "> not found: " 
+    // gzmsg << "Parameter <" << _paramName << "> not found: "
     //   <<  "Using default value of <" << _defaultVal << ">." << std::endl;
     return _defaultVal;
   }
@@ -152,13 +164,13 @@ T MsgParam(const gz::msgs::Param_V& _msg, const std::string &_paramName, const T
   T val = MsgParamGetValue<T>(param);
 
   // @DEBUG_INFO
-  // gzmsg << "Parameter found - setting <" << _paramName 
+  // gzmsg << "Parameter found - setting <" << _paramName
   //   << "> to <" << val << ">." << std::endl;
   return val;
 }
 
 
-///////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////
 // Utilities
 
 bool Utilities::SdfParamBool(const sdf::Element& _sdf,
@@ -248,8 +260,5 @@ gz::math::Vector3d Utilities::MsgParamVector3d(const gz::msgs::Param_V& _msg,
   return MsgParam<gz::math::Vector3d>(_msg, _paramName, _defaultVal);
 }
 
-
-///////////////////////////////////////////////////////////////////////////////
-
-}
-}
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/WaveParameters.cc
+++ b/gz-waves/src/WaveParameters.cc
@@ -14,21 +14,23 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/WaveParameters.hh"
-#include "gz/waves/Convert.hh"
-#include "gz/waves/Geometry.hh"
-#include "gz/waves/Physics.hh"
-#include "gz/waves/Utilities.hh"
+
+#include <cmath>
+#include <iostream>
+#include <string>
 
 #include <gz/common.hh>
 #include <gz/msgs.hh>
-
 #include <gz/math/Pose3.hh>
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
 
-#include <iostream>
-#include <cmath>
-#include <string>
+#include "gz/waves/Convert.hh"
+#include "gz/waves/Geometry.hh"
+#include "gz/waves/Physics.hh"
+#include "gz/waves/Types.hh"
+#include "gz/waves/Utilities.hh"
+
 
 namespace gz
 {
@@ -36,7 +38,7 @@ namespace waves
 {
   //////////////////////////////////////////////////
   // Utilities
-  std::ostream& operator<<(std::ostream& os, const std::vector<double>& _vec)
+  std::ostream& operator<<(std::ostream &os, const std::vector<double> &_vec)
   { 
     for (auto&& v : _vec )
       os << v << ", ";
@@ -50,121 +52,120 @@ namespace waves
   /// \brief Private data for the WavefieldParameters.
   class WaveParametersPrivate
   {
-    /// \brief Constructor.
-    public: WaveParametersPrivate() { }
-
+  public:
     /// \brief The wave algorithm.
-    public: std::string algorithm{"fft"};
+    std::string algorithm_{"fft"};
 
     /// \brief The size of the wave tile.
-    public: double tileSize{256.0};
+    double tile_size_{256.0};
 
     /// \brief The size of the wave tile.
-    public: size_t cellCount{128};
+    Index cell_count_{128};
 
     /// \brief The number of component waves.
-    public: size_t number{1};
+    Index number_{1};
 
     /// \brief Set the scale of the largest and smallest waves. 
-    public: double scale{2.0};
+    double scale_{2.0};
 
     /// \brief Set the angle between component waves and the mean direction.
-    public: double angle{2.0*M_PI/10.0};
+    double angle_{2.0*M_PI/10.0};
 
     /// \brief Control the wave steepness. 0 is sine waves, 1 is Gerstner waves.
-    public: double steepness{1.0};
+    double steepness_{1.0};
 
     /// \brief The mean wave amplitude [m].
-    public: double amplitude{0.0};
+    double amplitude_{0.0};
 
     /// \brief The mean wave period [s]
-    public: double period{1.0};
+    double period_{1.0};
 
     /// \brief The mean wve phase (not currently enabled).
-    public: double phase{0.0};
+    double phase_{0.0};
 
     /// \brief The mean wave direction.
-    public: gz::math::Vector2d direction = gz::math::Vector2d(1.0, 0.0);
+    gz::math::Vector2d direction_ = gz::math::Vector2d(1.0, 0.0);
 
     /// \brief The horizontal wind velocity [m/s].
-    public: gz::math::Vector2d windVelocity = gz::math::Vector2d(5.0, 0.0);
+    gz::math::Vector2d wind_velocity_ = gz::math::Vector2d(5.0, 0.0);
 
     /// \brief The mean wave angular frequency (derived).    
-    public: double angularFrequency{2.0*M_PI};
+    double angular_frequency_{2.0*M_PI};
 
     /// \brief The mean wavelength (derived).
-    public: double wavelength{
+    double wavelength_{
         2*M_PI/Physics::DeepWaterDispersionToWavenumber(2.0*M_PI)};
 
     /// \brief The mean wavenumber (derived).
-    public: double wavenumber{
+    double wavenumber_{
         Physics::DeepWaterDispersionToWavenumber(2.0*M_PI)};
 
     /// \brief The component wave angular frequencies (derived).
-    public: std::vector<double> angularFrequencies;
+    std::vector<double> angular_frequencies_;
 
     /// \brief The component wave amplitudes (derived).
-    public: std::vector<double> amplitudes;
+    std::vector<double> amplitudes_;
 
     /// \brief The component wave phases (derived).
-    public: std::vector<double> phases;
+    std::vector<double> phases_;
 
     /// \brief The component wave steepness factors (derived).
-    public: std::vector<double> steepnesses;
+    std::vector<double> steepnesses_;
 
     /// \brief The component wavenumbers (derived).
-    public: std::vector<double> wavenumbers;
+    std::vector<double> wavenumbers_;
 
     /// \brief The component wave dirctions (derived).
-    public: std::vector<gz::math::Vector2d> directions;
+    std::vector<gz::math::Vector2d> directions_;
 
     /// \brief Recalculate all derived quantities from inputs.
-    public: void Recalculate()
+    void Recalculate()
     {
       // Normalize direction
-      this->direction.Normalize();
+      direction_.Normalize();
 
       // Derived mean values
-      this->angularFrequency = 2.0 * M_PI / this->period;
-      this->wavenumber = Physics::DeepWaterDispersionToWavenumber(this->angularFrequency);
-      this->wavelength = 2.0 * M_PI / this->wavenumber;
+      angular_frequency_ = 2.0 * M_PI / period_;
+      wavenumber_ = Physics::DeepWaterDispersionToWavenumber(
+          angular_frequency_);
+      wavelength_ = 2.0 * M_PI / wavenumber_;
 
       // Update components
-      this->angularFrequencies.clear();
-      this->amplitudes.clear();
-      this->phases.clear();
-      this->wavenumbers.clear();
-      this->steepnesses.clear();
-      this->directions.clear();
+      angular_frequencies_.clear();
+      amplitudes_.clear();
+      phases_.clear();
+      wavenumbers_.clear();
+      steepnesses_.clear();
+      directions_.clear();
 
-      for (size_t i=0; i<this->number; ++i)
+      for (Index i=0; i<number_; ++i)
       {
-        const int n = i - this->number/2;
-        const double scaleFactor = std::pow(this->scale, n);
-        const double a = scaleFactor * this->amplitude;
-        const double k = this->wavenumber / scaleFactor;
+        const Index n = i - number_/2;
+        const double scale_factor = std::pow(scale_, n);
+        const double a = scale_factor * amplitude_;
+        const double k = wavenumber_ / scale_factor;
         const double omega = Physics::DeepWaterDispersionToOmega(k);
-        const double phi = this->phase;
+        const double phi = phase_;
         double q = 0.0;
         if (a != 0)
         {
-          q = std::min(1.0, this->steepness / (a * k * this->number));
+          q = std::min(1.0, steepness_ / (a * k * number_));
         }
 
-        this->amplitudes.push_back(a);        
-        this->angularFrequencies.push_back(omega);
-        this->phases.push_back(phi);
-        this->steepnesses.push_back(q);
-        this->wavenumbers.push_back(k);
+        amplitudes_.push_back(a);
+        angular_frequencies_.push_back(omega);
+        phases_.push_back(phi);
+        steepnesses_.push_back(q);
+        wavenumbers_.push_back(k);
       
         // Direction
-        const double c = std::cos(n * this->angle);
-        const double s = std::sin(n * this->angle);
-        double x = c * this->direction.X() - s * this->direction.Y();
-        double y = s * this->direction.X() + c * this->direction.Y();
+        const double c = std::cos(n * angle_);
+        const double s = std::sin(n * angle_);
+        double x = c * direction_.X() - s * direction_.Y();
+        double y = s * direction_.X() + c * direction_.Y();
         gz::math::Vector2d d(x, y);
 
-        directions.push_back(d);
+        directions_.push_back(d);
       }
     }
   };
@@ -181,58 +182,58 @@ WaveParameters::~WaveParameters()
 
 //////////////////////////////////////////////////
 WaveParameters::WaveParameters()
-  : dataPtr(new WaveParametersPrivate())
+  : impl_(new WaveParametersPrivate())
 {
-  this->dataPtr->Recalculate();
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::FillMsg(gz::msgs::Param_V& _msg) const
+void WaveParameters::FillMsg(gz::msgs::Param_V &msg) const
 {
   // Clear 
-  _msg.mutable_param()->Clear();
+  msg.mutable_param()->Clear();
 
   // "number"
   {
-    auto nextParam = _msg.add_param();
+    auto nextParam = msg.add_param();
 
     (*nextParam->mutable_params())["number"].set_type(gz::msgs::Any::INT32);
-    (*nextParam->mutable_params())["number"].set_int_value(this->dataPtr->number);
+    (*nextParam->mutable_params())["number"].set_int_value(impl_->number_);
   }
   // "scale"
   {
-    auto nextParam = _msg.add_param();
+    auto nextParam = msg.add_param();
     (*nextParam->mutable_params())["scale"].set_type(gz::msgs::Any::DOUBLE);
-    (*nextParam->mutable_params())["scale"].set_double_value(this->dataPtr->scale);
+    (*nextParam->mutable_params())["scale"].set_double_value(impl_->scale_);
   }
   // "angle"
   {
-    auto nextParam = _msg.add_param();
+    auto nextParam = msg.add_param();
     (*nextParam->mutable_params())["angle"].set_type(gz::msgs::Any::DOUBLE);
-    (*nextParam->mutable_params())["angle"].set_double_value(this->dataPtr->angle);
+    (*nextParam->mutable_params())["angle"].set_double_value(impl_->angle_);
   }
   // "steepness"
   {
-    auto nextParam = _msg.add_param();
+    auto nextParam = msg.add_param();
     (*nextParam->mutable_params())["steepness"].set_type(gz::msgs::Any::DOUBLE);
-    (*nextParam->mutable_params())["steepness"].set_double_value(this->dataPtr->steepness);
+    (*nextParam->mutable_params())["steepness"].set_double_value(impl_->steepness_);
   }
   // "amplitude"
   {
-    auto nextParam = _msg.add_param();
+    auto nextParam = msg.add_param();
     (*nextParam->mutable_params())["amplitude"].set_type(gz::msgs::Any::DOUBLE);
-    (*nextParam->mutable_params())["amplitude"].set_double_value(this->dataPtr->amplitude);
+    (*nextParam->mutable_params())["amplitude"].set_double_value(impl_->amplitude_);
   }
   // "period"
   {
-    auto nextParam = _msg.add_param();
+    auto nextParam = msg.add_param();
     (*nextParam->mutable_params())["period"].set_type(gz::msgs::Any::DOUBLE);
-    (*nextParam->mutable_params())["period"].set_double_value(this->dataPtr->period);
+    (*nextParam->mutable_params())["period"].set_double_value(impl_->period_);
   }
   // "direction"
   {
-    const auto& direction = this->dataPtr->direction;
-    auto nextParam = _msg.add_param();
+    const auto& direction = impl_->direction_;
+    auto nextParam = msg.add_param();
     (*nextParam->mutable_params())["direction"].set_type(gz::msgs::Any::VECTOR3D);
     (*nextParam->mutable_params())["direction"].mutable_vector3d_value()->set_x(direction.X());
     (*nextParam->mutable_params())["direction"].mutable_vector3d_value()->set_y(direction.Y());
@@ -241,151 +242,151 @@ void WaveParameters::FillMsg(gz::msgs::Param_V& _msg) const
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetFromMsg(const gz::msgs::Param_V& _msg)
+void WaveParameters::SetFromMsg(const gz::msgs::Param_V &msg)
 {
   // todo(srmainwaring) add missing entries
-  this->dataPtr->number    = Utilities::MsgParamSizeT(_msg,    "number",     this->dataPtr->number);
-  this->dataPtr->amplitude = Utilities::MsgParamDouble(_msg,   "amplitude",  this->dataPtr->amplitude);
-  this->dataPtr->period    = Utilities::MsgParamDouble(_msg,   "period",     this->dataPtr->period);
-  this->dataPtr->phase     = Utilities::MsgParamDouble(_msg,   "phase",      this->dataPtr->phase);
-  this->dataPtr->direction = Utilities::MsgParamVector2d(_msg, "direction",  this->dataPtr->direction);
-  this->dataPtr->scale     = Utilities::MsgParamDouble(_msg,   "scale",      this->dataPtr->scale);
-  this->dataPtr->angle     = Utilities::MsgParamDouble(_msg,   "angle",      this->dataPtr->angle);
-  this->dataPtr->steepness = Utilities::MsgParamDouble(_msg,   "steepness",  this->dataPtr->steepness);
+  impl_->number_    = Utilities::MsgParamSizeT(msg,    "number",     impl_->number_);
+  impl_->amplitude_ = Utilities::MsgParamDouble(msg,   "amplitude",  impl_->amplitude_);
+  impl_->period_    = Utilities::MsgParamDouble(msg,   "period",     impl_->period_);
+  impl_->phase_     = Utilities::MsgParamDouble(msg,   "phase",      impl_->phase_);
+  impl_->direction_ = Utilities::MsgParamVector2d(msg, "direction",  impl_->direction_);
+  impl_->scale_     = Utilities::MsgParamDouble(msg,   "scale",      impl_->scale_);
+  impl_->angle_     = Utilities::MsgParamDouble(msg,   "angle",      impl_->angle_);
+  impl_->steepness_ = Utilities::MsgParamDouble(msg,   "steepness",  impl_->steepness_);
 
-  this->dataPtr->Recalculate();
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetFromSDF(sdf::Element& _sdf)
+void WaveParameters::SetFromSDF(sdf::Element &sdf)
 {
-  this->dataPtr->algorithm     = Utilities::SdfParamString(_sdf,   "algorithm",  this->dataPtr->algorithm);
-  this->dataPtr->tileSize      = Utilities::SdfParamDouble(_sdf,   "tile_size",  this->dataPtr->tileSize);
-  this->dataPtr->cellCount     = Utilities::SdfParamSizeT(_sdf,    "cell_count", this->dataPtr->tileSize);
-  this->dataPtr->number        = Utilities::SdfParamSizeT(_sdf,    "number",     this->dataPtr->number);
-  this->dataPtr->amplitude     = Utilities::SdfParamDouble(_sdf,   "amplitude",  this->dataPtr->amplitude);
-  this->dataPtr->period        = Utilities::SdfParamDouble(_sdf,   "period",     this->dataPtr->period);
-  this->dataPtr->phase         = Utilities::SdfParamDouble(_sdf,   "phase",      this->dataPtr->phase);
-  this->dataPtr->direction     = Utilities::SdfParamVector2d(_sdf, "direction",  this->dataPtr->direction);
-  this->dataPtr->scale         = Utilities::SdfParamDouble(_sdf,   "scale",      this->dataPtr->scale);
-  this->dataPtr->angle         = Utilities::SdfParamDouble(_sdf,   "angle",      this->dataPtr->angle);
-  this->dataPtr->steepness     = Utilities::SdfParamDouble(_sdf,   "steepness",  this->dataPtr->steepness);
-  this->dataPtr->windVelocity  = Utilities::SdfParamVector2d(_sdf, "wind_velocity",  this->dataPtr->windVelocity);
-  this->dataPtr->Recalculate();
+  impl_->algorithm_     = Utilities::SdfParamString(sdf,    "algorithm",  impl_->algorithm_);
+  impl_->tile_size_      = Utilities::SdfParamDouble(sdf,   "tile_size",  impl_->tile_size_);
+  impl_->cell_count_     = Utilities::SdfParamSizeT(sdf,    "cell_count", impl_->tile_size_);
+  impl_->number_        = Utilities::SdfParamSizeT(sdf,     "number",     impl_->number_);
+  impl_->amplitude_     = Utilities::SdfParamDouble(sdf,    "amplitude",  impl_->amplitude_);
+  impl_->period_        = Utilities::SdfParamDouble(sdf,    "period",     impl_->period_);
+  impl_->phase_         = Utilities::SdfParamDouble(sdf,    "phase",      impl_->phase_);
+  impl_->direction_     = Utilities::SdfParamVector2d(sdf,  "direction",  impl_->direction_);
+  impl_->scale_         = Utilities::SdfParamDouble(sdf,    "scale",      impl_->scale_);
+  impl_->angle_         = Utilities::SdfParamDouble(sdf,    "angle",      impl_->angle_);
+  impl_->steepness_     = Utilities::SdfParamDouble(sdf,    "steepness",  impl_->steepness_);
+  impl_->wind_velocity_  = Utilities::SdfParamVector2d(sdf, "wind_velocity",  impl_->wind_velocity_);
+  impl_->Recalculate();
 
   // override wind speed and angle if parameters are provided
-  if (_sdf.HasElement("wind_speed") || _sdf.HasElement("wind_angle_deg"))
+  if (sdf.HasElement("wind_speed") || sdf.HasElement("wind_angle_deg"))
   {
     gzmsg << "Overriding 'wind_velocity' using 'wind_speed' and 'wind_angle_deg'\n";
 
     // current wind speed and angle
-    double windSpeed = this->WindSpeed();
-    double windAngleRad = this->WindAngleRad();
-    double windAngleDeg = 180.0 / M_PI * windAngleRad;
+    double wind_speed = WindSpeed();
+    double wind_angle_rad = WindAngleRad();
+    double wind_angle_deg = 180.0 / M_PI * wind_angle_rad;
 
     // override wind speed and angle if parameters are provided
-    windSpeed    = Utilities::SdfParamDouble(_sdf, "wind_speed", windSpeed);
-    windAngleDeg = Utilities::SdfParamDouble(_sdf, "wind_angle_deg", windAngleDeg);
-    windAngleRad = M_PI / 180.0 * windAngleDeg;
-    this->SetWindSpeedAndAngle(windSpeed, windAngleRad);
+    wind_speed    = Utilities::SdfParamDouble(sdf, "wind_speed", wind_speed);
+    wind_angle_deg = Utilities::SdfParamDouble(sdf, "wind_angle_deg", wind_angle_deg);
+    wind_angle_rad = M_PI / 180.0 * wind_angle_deg;
+    SetWindSpeedAndAngle(wind_speed, wind_angle_rad);
   }
 }
 
 //////////////////////////////////////////////////
 std::string WaveParameters::Algorithm() const
 {
-  return this->dataPtr->algorithm;
+  return impl_->algorithm_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::TileSize() const
 {
-  return this->dataPtr->tileSize;
+  return impl_->tile_size_;
 }
 
 //////////////////////////////////////////////////
-size_t WaveParameters::CellCount() const
+Index WaveParameters::CellCount() const
 {
-  return this->dataPtr->cellCount;
+  return impl_->cell_count_;
 }
 
 //////////////////////////////////////////////////
-size_t WaveParameters::Number() const
+Index WaveParameters::Number() const
 {
-  return this->dataPtr->number;
+  return impl_->number_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::Angle() const
 {
-  return this->dataPtr->angle;
+  return impl_->angle_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::Scale() const
 {
-  return this->dataPtr->scale;
+  return impl_->scale_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::Steepness() const
 {
-  return this->dataPtr->steepness;
+  return impl_->steepness_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::AngularFrequency() const
 {
-  return this->dataPtr->angularFrequency;
+  return impl_->angular_frequency_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::Amplitude() const
 {
-  return this->dataPtr->amplitude;
+  return impl_->amplitude_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::Period() const
 {
-  return this->dataPtr->period;
+  return impl_->period_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::Phase() const
 {
-  return this->dataPtr->phase;
+  return impl_->phase_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::Wavelength() const
 {
-  return this->dataPtr->wavelength;
+  return impl_->wavelength_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::Wavenumber() const
 {
-  return this->dataPtr->wavenumber;
+  return impl_->wavenumber_;
 }    
 
 //////////////////////////////////////////////////
 gz::math::Vector2d WaveParameters::Direction() const
 {
-  return this->dataPtr->direction;
+  return impl_->direction_;
 }
 
 //////////////////////////////////////////////////
 gz::math::Vector2d WaveParameters::WindVelocity() const
 {
-  return this->dataPtr->windVelocity;
+  return impl_->wind_velocity_;
 }
 
 //////////////////////////////////////////////////
 double WaveParameters::WindSpeed() const
 {
-  double vx = this->dataPtr->windVelocity.X();
-  double vy = this->dataPtr->windVelocity.Y();
+  double vx = impl_->wind_velocity_.X();
+  double vy = impl_->wind_velocity_.Y();
   double u = sqrt(vx*vx + vy*vy);
   return u;
 }
@@ -393,157 +394,157 @@ double WaveParameters::WindSpeed() const
 //////////////////////////////////////////////////
 double WaveParameters::WindAngleRad() const
 {
-  double vx = this->dataPtr->windVelocity.X();
-  double vy = this->dataPtr->windVelocity.Y();
+  double vx = impl_->wind_velocity_.X();
+  double vy = impl_->wind_velocity_.Y();
   double phi_rad = atan2(vy, vx);
   return phi_rad;
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetAlgorithm(const std::string &_algorithm)
+void WaveParameters::SetAlgorithm(const std::string &value)
 {
-  this->dataPtr->algorithm = _algorithm;
-  this->dataPtr->Recalculate();
+  impl_->algorithm_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetTileSize(double _tileSize)
+void WaveParameters::SetTileSize(double value)
 {
-  this->dataPtr->tileSize = _tileSize;
-  this->dataPtr->Recalculate();
+  impl_->tile_size_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetCellCount(size_t _cellCount)
+void WaveParameters::SetCellCount(Index value)
 {
-  this->dataPtr->cellCount = _cellCount;
-  this->dataPtr->Recalculate();
+  impl_->cell_count_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetNumber(size_t _number)
+void WaveParameters::SetNumber(Index value)
 {
-  this->dataPtr->number = _number;
-  this->dataPtr->Recalculate();
+  impl_->number_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetAngle(double _angle)
+void WaveParameters::SetAngle(double value)
 {
-  this->dataPtr->angle = _angle;
-  this->dataPtr->Recalculate();
+  impl_->angle_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetScale(double _scale)
+void WaveParameters::SetScale(double value)
 {
-  this->dataPtr->scale = _scale;
-  this->dataPtr->Recalculate();
+  impl_->scale_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetSteepness(double _steepness)
+void WaveParameters::SetSteepness(double value)
 {
-  this->dataPtr->steepness = _steepness;
-  this->dataPtr->Recalculate();
+  impl_->steepness_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetAmplitude(double _amplitude)
+void WaveParameters::SetAmplitude(double value)
 {
-  this->dataPtr->amplitude = _amplitude;
-  this->dataPtr->Recalculate();
+  impl_->amplitude_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetPeriod(double _period)
+void WaveParameters::SetPeriod(double value)
 {
-  this->dataPtr->period = _period;
-  this->dataPtr->Recalculate();
+  impl_->period_ = value;
+  impl_->Recalculate();
 }
   
 //////////////////////////////////////////////////
-void WaveParameters::SetPhase(double _phase)
+void WaveParameters::SetPhase(double value)
 {
-  this->dataPtr->phase = _phase;
-  this->dataPtr->Recalculate();
+  impl_->phase_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetDirection(const gz::math::Vector2d& _direction)
+void WaveParameters::SetDirection(const gz::math::Vector2d &value)
 {
-  this->dataPtr->direction = _direction;
-  this->dataPtr->Recalculate();
+  impl_->direction_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetWindVelocity(const gz::math::Vector2d& _windVelocity)
+void WaveParameters::SetWindVelocity(const gz::math::Vector2d &value)
 {
-  this->dataPtr->windVelocity = _windVelocity;
-  this->dataPtr->Recalculate();
+  impl_->wind_velocity_ = value;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
-void WaveParameters::SetWindSpeedAndAngle(double _windSpeed, double _windAngleRad)
+void WaveParameters::SetWindSpeedAndAngle(double wind_speed, double wind_angle_rad)
 {
   // update wind velocity
-  double ux = _windSpeed * cos(_windAngleRad);
-  double uy = _windSpeed * sin(_windAngleRad);
-  this->dataPtr->windVelocity.X() = ux;
-  this->dataPtr->windVelocity.Y() = uy;
-  this->dataPtr->Recalculate();
+  double ux = wind_speed * cos(wind_angle_rad);
+  double uy = wind_speed * sin(wind_angle_rad);
+  impl_->wind_velocity_.X() = ux;
+  impl_->wind_velocity_.Y() = uy;
+  impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
 const std::vector<double>& WaveParameters::AngularFrequency_V() const
 {
-  return this->dataPtr->angularFrequencies;
+  return impl_->angular_frequencies_;
 }
 
 //////////////////////////////////////////////////
 const std::vector<double>& WaveParameters::Amplitude_V() const
 {
-  return this->dataPtr->amplitudes;
+  return impl_->amplitudes_;
 }
 
 //////////////////////////////////////////////////
 const std::vector<double>& WaveParameters::Phase_V() const
 {
-  return this->dataPtr->phases;
+  return impl_->phases_;
 }
 
 //////////////////////////////////////////////////
 const std::vector<double>& WaveParameters::Steepness_V() const
 {
-  return this->dataPtr->steepnesses;
+  return impl_->steepnesses_;
 }
 
 //////////////////////////////////////////////////
 const std::vector<double>& WaveParameters::Wavenumber_V() const
 {
-  return this->dataPtr->wavenumbers;
+  return impl_->wavenumbers_;
 }
 
 //////////////////////////////////////////////////
 const std::vector<gz::math::Vector2d>& WaveParameters::Direction_V() const
 {
-  return this->dataPtr->directions;
+  return impl_->directions_;
 }
 
 //////////////////////////////////////////////////
 void WaveParameters::DebugPrint() const
 {
   // todo(srmainwaring) add missing entries
-  gzmsg << "number:     " << this->dataPtr->number << std::endl;
-  gzmsg << "scale:      " << this->dataPtr->scale << std::endl;
-  gzmsg << "angle:      " << this->dataPtr->angle << std::endl;
-  gzmsg << "period:     " << this->dataPtr->period << std::endl;
-  gzmsg << "amplitude:  " << this->dataPtr->amplitudes << std::endl;
-  gzmsg << "wavenumber: " << this->dataPtr->wavenumbers << std::endl;
-  gzmsg << "omega:      " << this->dataPtr->angularFrequencies << std::endl;
-  gzmsg << "phase:      " << this->dataPtr->phases << std::endl;
-  gzmsg << "steepness:  " << this->dataPtr->steepnesses << std::endl;
-  for (auto&& d : this->dataPtr->directions)
+  gzmsg << "number:     " << impl_->number_ << std::endl;
+  gzmsg << "scale:      " << impl_->scale_ << std::endl;
+  gzmsg << "angle:      " << impl_->angle_ << std::endl;
+  gzmsg << "period:     " << impl_->period_ << std::endl;
+  gzmsg << "amplitude:  " << impl_->amplitudes_ << std::endl;
+  gzmsg << "wavenumber: " << impl_->wavenumbers_ << std::endl;
+  gzmsg << "omega:      " << impl_->angular_frequencies_ << std::endl;
+  gzmsg << "phase:      " << impl_->phases_ << std::endl;
+  gzmsg << "steepness:  " << impl_->steepnesses_ << std::endl;
+  for (auto&& d : impl_->directions_)
   {
     gzmsg << "direction:  " << d << std::endl;
   }

--- a/gz-waves/src/WaveSimulation.cc
+++ b/gz-waves/src/WaveSimulation.cc
@@ -26,5 +26,5 @@ namespace waves
   //////////////////////////////////////////////////
   IWaveSimulation::~IWaveSimulation() = default;
 
-}
-}
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/WaveSpectrum.cc
+++ b/gz-waves/src/WaveSpectrum.cc
@@ -18,8 +18,10 @@
 #include <algorithm>
 #include <cmath>
 
-using namespace gz;
-using namespace waves;
+namespace gz
+{
+namespace waves
+{
 
 //////////////////////////////////////////////////
 OmniDirectionalWaveSpectrum::~OmniDirectionalWaveSpectrum()
@@ -67,7 +69,7 @@ double PiersonMoskowitzWaveSpectrum::Evaluate(double k) const
 //////////////////////////////////////////////////
 void PiersonMoskowitzWaveSpectrum::Evaluate(
     Eigen::Ref<Eigen::ArrayXXd> spectrum,
-    const Eigen::Ref<const Eigen::ArrayXXd> &k) const
+    const Eigen::Ref<const Eigen::ArrayXXd>& k) const
 {
   /// \note Eigen asserts cbegin and cend are from the same expression.
   auto k_view = k.reshaped();
@@ -78,8 +80,7 @@ void PiersonMoskowitzWaveSpectrum::Evaluate(
     [this] (double k_i) -> double
     {
       return this->Evaluate(k_i);
-    }
-  );
+    });
 }
 
 //////////////////////////////////////////////////
@@ -142,27 +143,23 @@ double ECKVWaveSpectrum::Evaluate(double k) const
   // intermediates
   double u_star = std::sqrt(cd_10n) * u10_;
   // double am = 0.13 * u_star / cm;
-  
+
   double gamma = 1.7;
   if (cap_omega_c_ < 1.0)
   {
     gamma = 1.7;
-  }
-  else
-  {
+  } else {
     gamma = 1.7 + 6.0 * std::log10(cap_omega_c_);
   }
 
   double sigma = 0.08 * (1.0 + 4.0 * std::pow(cap_omega_c_, -3.0));
   double alpha_p = 0.006 * std::pow(cap_omega_c_, 0.55);
 
-  double alpha_m; 
+  double alpha_m;
   if (u_star <= cm)
   {
     alpha_m = 0.01 * (1.0 + std::log(u_star / cm));
-  }
-  else
-  {
+  } else {
     alpha_m = 0.01 * (1.0 + 3.0 * std::log(u_star / cm));
   }
 
@@ -173,35 +170,32 @@ double ECKVWaveSpectrum::Evaluate(double k) const
   double c  = std::sqrt((gravity_ / k) * (1.0 + std::pow(k / km, 2.0)));
 
   double l_pm = std::exp(-1.25 * std::pow(kp / k, 2.0));
-  
+
   double cap_gamma = std::exp(
       -1.0/(2.0 * std::pow(sigma, 2.0))
-      * std::pow(std::sqrt(k / kp) - 1.0, 2.0)
-  );
-  
+      * std::pow(std::sqrt(k / kp) - 1.0, 2.0));
+
   double j_p = std::pow(gamma, cap_gamma);
-  
+
   double f_p = l_pm * j_p * std::exp(
-      -0.3162 * cap_omega_c_ * (std::sqrt(k / kp) - 1.0)
-  );
+      -0.3162 * cap_omega_c_ * (std::sqrt(k / kp) - 1.0));
 
   double f_m = l_pm * j_p * std::exp(
-      -0.25 * std::pow(k / km - 1.0, 2.0)
-  );
+      -0.25 * std::pow(k / km - 1.0, 2.0));
 
   double b_l = 0.5 * alpha_p * (cp / c) * f_p;
   double b_h = 0.5 * alpha_m * (cm / c) * f_m;
-  
+
   double k3 = k * k * k;
   double cap_s = (b_l + b_h) / k3;
-  
+
   return cap_s;
 }
 
 //////////////////////////////////////////////////
 void ECKVWaveSpectrum::Evaluate(
     Eigen::Ref<Eigen::ArrayXXd> spectrum,
-    const Eigen::Ref<const Eigen::ArrayXXd> &k) const
+    const Eigen::Ref<const Eigen::ArrayXXd>& k) const
 {
   auto k_view = k.reshaped();
   std::transform(
@@ -211,8 +205,7 @@ void ECKVWaveSpectrum::Evaluate(
     [this] (double k_i) -> double
     {
       return this->Evaluate(k_i);
-    }
-  );
+    });
 }
 
 //////////////////////////////////////////////////
@@ -251,3 +244,5 @@ void ECKVWaveSpectrum::SetCapOmegaC(double value)
   cap_omega_c_ = value;
 }
 
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/WaveSpectrum_TEST.cc
+++ b/gz-waves/src/WaveSpectrum_TEST.cc
@@ -13,21 +13,22 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "gz/waves/Types.hh"
-#include "gz/waves/WaveSpectrum.hh"
-#include "LinearRandomFFTWaveSimulationRefImpl.hh"
+#include <gtest/gtest.h>
 
 #include <memory>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include "gz/waves/Types.hh"
+#include "gz/waves/WaveSpectrum.hh"
 
-using namespace gz;
-using namespace waves;
+#include "LinearRandomFFTWaveSimulationRefImpl.hh"
 
-///////////////////////////////////////////////////////////////////////////////
-// Define tests
+using gz::waves::ECKVWaveSpectrum;
+using gz::waves::Index;
+using gz::waves::LinearRandomFFTWaveSimulationRef;
+using gz::waves::PiersonMoskowitzWaveSpectrum;
 
+//////////////////////////////////////////////////
 TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
 {
   double k[] {
@@ -45,7 +46,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
       0., 0., 0., 0.
     };
 
-    for (Index i=0; i<8; ++i)
+    for (Index i=0; i < 8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -62,7 +63,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
       4.20064584e-02, 4.11734258e-02, 3.39059000e-02, 2.64125839e-02
     };
 
-    for (Index i=0; i<8; ++i)
+    for (Index i=0; i < 8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -79,7 +80,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
       0.22791438, 0.12152584, 0.07189522, 0.04588103
     };
 
-    for (Index i=0; i<8; ++i)
+    for (Index i=0; i < 8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -96,7 +97,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
       0.24949601,  0.12877022, 0.07484505,  0.04725667
     };
 
-    for (Index i=0; i<8; ++i)
+    for (Index i=0; i < 8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -104,6 +105,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpectrum, PiersonMoskowitzSpectrumArrayXXd)
 {
   { // Eigen array version
@@ -121,11 +123,11 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumArrayXXd)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (Index i=0; i<ny; ++i)
+    for (Index i=0; i < ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -133,7 +135,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumArrayXXd)
     // broadcast to matrices (aka meshgrid)
     Eigen::ArrayXXd kx = Eigen::ArrayXXd::Zero(nx, ny);
     kx.colwise() += kx_v;
-    
+
     Eigen::ArrayXXd ky = Eigen::ArrayXXd::Zero(nx, ny);
     ky.rowwise() += ky_v.transpose();
 
@@ -146,9 +148,9 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumArrayXXd)
     Eigen::ArrayXXd cap_s = Eigen::ArrayXXd::Zero(nx, ny);
     spectrum.Evaluate(cap_s, k);
 
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
-      for (Index j=0; j<ny; ++j)
+      for (Index j=0; j < ny; ++j)
       {
         double cap_s_test = spectrum.Evaluate(k(i, j));
         EXPECT_NEAR(cap_s(i, j), cap_s_test, tolerance);
@@ -157,6 +159,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumArrayXXd)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpectrum, ECKVSpectrumRegression)
 {
   double k[] {
@@ -174,7 +177,7 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
       0., 0., 0., 0.
     };
 
-    for (Index i=0; i<8; ++i)
+    for (Index i=0; i < 8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -191,7 +194,7 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
       6.43908578e-02, 6.17616606e-02, 5.05207166e-02, 3.91055100e-02
     };
 
-    for (Index i=0; i<8; ++i)
+    for (Index i=0; i < 8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -208,7 +211,7 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
       0.30549674, 0.15782445, 0.0924573,  0.05921628
     };
 
-    for (Index i=0; i<8; ++i)
+    for (Index i=0; i < 8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -225,7 +228,7 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
       0.32892719,  0.17409368,  0.10300532,  0.06576126
     };
 
-    for (Index i=0; i<8; ++i)
+    for (Index i=0; i < 8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -233,6 +236,7 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpectrum, ECKVSpectrumArrayXXd)
 {
   { // Eigen array version
@@ -250,11 +254,11 @@ TEST(WaveSpectrum, ECKVSpectrumArrayXXd)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (Index i=0; i<ny; ++i)
+    for (Index i=0; i < ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -262,7 +266,7 @@ TEST(WaveSpectrum, ECKVSpectrumArrayXXd)
     // broadcast to matrices (aka meshgrid)
     Eigen::ArrayXXd kx = Eigen::ArrayXXd::Zero(nx, ny);
     kx.colwise() += kx_v;
-    
+
     Eigen::ArrayXXd ky = Eigen::ArrayXXd::Zero(nx, ny);
     ky.rowwise() += ky_v.transpose();
 
@@ -275,9 +279,9 @@ TEST(WaveSpectrum, ECKVSpectrumArrayXXd)
     Eigen::ArrayXXd cap_s = Eigen::ArrayXXd::Zero(nx, ny);
     spectrum.Evaluate(cap_s, k);
 
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
-      for (Index j=0; j<ny; ++j)
+      for (Index j=0; j < ny; ++j)
       {
         double cap_s_test = spectrum.Evaluate(k(i, j));
         EXPECT_NEAR(cap_s(i, j), cap_s_test, tolerance);
@@ -286,6 +290,7 @@ TEST(WaveSpectrum, ECKVSpectrumArrayXXd)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
 {
   const double u10 = 5.0;
@@ -306,11 +311,11 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (Index i=0; i<ny; ++i)
+    for (Index i=0; i < ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -318,7 +323,7 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
     // broadcast to matrices (aka meshgrid)
     Eigen::ArrayXXd kx = Eigen::ArrayXXd::Zero(nx, ny);
     kx.colwise() += kx_v;
-    
+
     Eigen::ArrayXXd ky = Eigen::ArrayXXd::Zero(nx, ny);
     ky.rowwise() += ky_v.transpose();
 
@@ -331,9 +336,9 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
     Eigen::ArrayXXd cap_s = Eigen::ArrayXXd::Zero(nx, ny);
     spectrum.Evaluate(cap_s, k);
 
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
-      for (Index j=0; j<ny; ++j)
+      for (Index j=0; j < ny; ++j)
       {
         double cap_s_test =
             LinearRandomFFTWaveSimulationRef::Impl::ECKVOmniDirectionalSpectrum(
@@ -344,9 +349,7 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Run tests
-
+//////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/gz-waves/src/WaveSpectrum_TEST.cc
+++ b/gz-waves/src/WaveSpectrum_TEST.cc
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "gz/waves/Types.hh"
 #include "gz/waves/WaveSpectrum.hh"
 #include "LinearRandomFFTWaveSimulationRefImpl.hh"
 
@@ -44,7 +45,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
       0., 0., 0., 0.
     };
 
-    for (int i=0; i<8; ++i)
+    for (Index i=0; i<8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -61,7 +62,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
       4.20064584e-02, 4.11734258e-02, 3.39059000e-02, 2.64125839e-02
     };
 
-    for (int i=0; i<8; ++i)
+    for (Index i=0; i<8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -78,7 +79,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
       0.22791438, 0.12152584, 0.07189522, 0.04588103
     };
 
-    for (int i=0; i<8; ++i)
+    for (Index i=0; i<8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -95,7 +96,7 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumRegression)
       0.24949601,  0.12877022, 0.07484505,  0.04725667
     };
 
-    for (int i=0; i<8; ++i)
+    for (Index i=0; i<8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -110,8 +111,8 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumArrayXXd)
 
     double lx = 200.0;
     double ly = 100.0;
-    int nx = 32;
-    int ny = 16;
+    Index nx = 32;
+    Index ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -120,11 +121,11 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumArrayXXd)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (int i=0; i<ny; ++i)
+    for (Index i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -145,9 +146,9 @@ TEST(WaveSpectrum, PiersonMoskowitzSpectrumArrayXXd)
     Eigen::ArrayXXd cap_s = Eigen::ArrayXXd::Zero(nx, ny);
     spectrum.Evaluate(cap_s, k);
 
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
-      for (int j=0; j<ny; ++j)
+      for (Index j=0; j<ny; ++j)
       {
         double cap_s_test = spectrum.Evaluate(k(i, j));
         EXPECT_NEAR(cap_s(i, j), cap_s_test, tolerance);
@@ -173,7 +174,7 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
       0., 0., 0., 0.
     };
 
-    for (int i=0; i<8; ++i)
+    for (Index i=0; i<8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -190,7 +191,7 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
       6.43908578e-02, 6.17616606e-02, 5.05207166e-02, 3.91055100e-02
     };
 
-    for (int i=0; i<8; ++i)
+    for (Index i=0; i<8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -207,7 +208,7 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
       0.30549674, 0.15782445, 0.0924573,  0.05921628
     };
 
-    for (int i=0; i<8; ++i)
+    for (Index i=0; i<8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -224,7 +225,7 @@ TEST(WaveSpectrum, ECKVSpectrumRegression)
       0.32892719,  0.17409368,  0.10300532,  0.06576126
     };
 
-    for (int i=0; i<8; ++i)
+    for (Index i=0; i<8; ++i)
     {
       double cap_s_test = spectrum.Evaluate(k[i]);
       EXPECT_NEAR(cap_s[i], cap_s_test, tolerance);
@@ -239,8 +240,8 @@ TEST(WaveSpectrum, ECKVSpectrumArrayXXd)
 
     double lx = 200.0;
     double ly = 100.0;
-    int nx = 32;
-    int ny = 16;
+    Index nx = 32;
+    Index ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -249,11 +250,11 @@ TEST(WaveSpectrum, ECKVSpectrumArrayXXd)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (int i=0; i<ny; ++i)
+    for (Index i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -274,9 +275,9 @@ TEST(WaveSpectrum, ECKVSpectrumArrayXXd)
     Eigen::ArrayXXd cap_s = Eigen::ArrayXXd::Zero(nx, ny);
     spectrum.Evaluate(cap_s, k);
 
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
-      for (int j=0; j<ny; ++j)
+      for (Index j=0; j<ny; ++j)
       {
         double cap_s_test = spectrum.Evaluate(k(i, j));
         EXPECT_NEAR(cap_s(i, j), cap_s_test, tolerance);
@@ -295,8 +296,8 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
 
     double lx = 200.0;
     double ly = 100.0;
-    int nx = 32;
-    int ny = 16;
+    Index nx = 32;
+    Index ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -305,11 +306,11 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (int i=0; i<ny; ++i)
+    for (Index i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -330,9 +331,9 @@ TEST(WaveSpectrum, ECKVSpectrumFFT2ImplRegression)
     Eigen::ArrayXXd cap_s = Eigen::ArrayXXd::Zero(nx, ny);
     spectrum.Evaluate(cap_s, k);
 
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
-      for (int j=0; j<ny; ++j)
+      for (Index j=0; j<ny; ++j)
       {
         double cap_s_test =
             LinearRandomFFTWaveSimulationRef::Impl::ECKVOmniDirectionalSpectrum(

--- a/gz-waves/src/WaveSpreadingFunction.cc
+++ b/gz-waves/src/WaveSpreadingFunction.cc
@@ -18,8 +18,10 @@
 #include <algorithm>
 #include <cmath>
 
-using namespace gz; 
-using namespace waves; 
+namespace gz
+{
+namespace waves
+{
 
 //////////////////////////////////////////////////
 DirectionalSpreadingFunction::~DirectionalSpreadingFunction()
@@ -54,7 +56,7 @@ double Cos2sSpreadingFunction::Evaluate(
 //////////////////////////////////////////////////
 void Cos2sSpreadingFunction::Evaluate(
     Eigen::Ref<Eigen::ArrayXXd> phi,
-    const Eigen::Ref<const Eigen::ArrayXXd> &theta,
+    const Eigen::Ref<const Eigen::ArrayXXd>& theta,
     double theta_mean,
     const Eigen::Ref<const Eigen::ArrayXXd>& /*k*/) const
 {
@@ -66,8 +68,7 @@ void Cos2sSpreadingFunction::Evaluate(
     [&, this] (double theta_i) -> double
     {
       return this->Evaluate(theta_i, theta_mean);
-    }
-  );
+    });
 }
 
 //////////////////////////////////////////////////
@@ -137,9 +138,9 @@ double ECKVSpreadingFunction::Evaluate(
 //////////////////////////////////////////////////
 void ECKVSpreadingFunction::Evaluate(
     Eigen::Ref<Eigen::ArrayXXd> phi,
-    const Eigen::Ref<const Eigen::ArrayXXd> &theta,
+    const Eigen::Ref<const Eigen::ArrayXXd>& theta,
     double theta_mean,
-    const Eigen::Ref<const Eigen::ArrayXXd> &k) const
+    const Eigen::Ref<const Eigen::ArrayXXd>& k) const
 {
   auto theta_view = theta.reshaped();
   std::transform(
@@ -150,8 +151,7 @@ void ECKVSpreadingFunction::Evaluate(
     [&, this] (double theta_i, double k_i) -> double
     {
       return this->Evaluate(theta_i, theta_mean, k_i);
-    }
-  );
+    });
 }
 
 //////////////////////////////////////////////////
@@ -190,3 +190,5 @@ void ECKVSpreadingFunction::SetCapOmegaC(double value)
   cap_omega_c_ = value;
 }
 
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/WaveSpreadingFunction_TEST.cc
+++ b/gz-waves/src/WaveSpreadingFunction_TEST.cc
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "gz/waves/Types.hh"
 #include "gz/waves/WaveSpreadingFunction.hh"
 #include "LinearRandomFFTWaveSimulationRefImpl.hh"
 
@@ -51,7 +52,7 @@ TEST(WaveSpreadingFunction, Cos2sRegression)
       9.03278127e-01
     };
 
-    for (int i=0; i<21; ++i)
+    for (Index i=0; i<21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta[i], theta_mean);
       EXPECT_NEAR(phi[i], phi_test, tolerance);
@@ -77,7 +78,7 @@ TEST(WaveSpreadingFunction, Cos2sVectorXd)
     Eigen::ArrayXd phi(21);
     spreadingFn.Evaluate(phi, theta, theta_mean);
 
-    for (int i=0; i<21; ++i)
+    for (Index i=0; i<21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta(i), theta_mean);
       EXPECT_DOUBLE_EQ(phi(i), phi_test);
@@ -103,7 +104,7 @@ TEST(WaveSpreadingFunction, Cos2sNonZeroMeanVectorXd)
     Eigen::ArrayXd phi(21);
     spreadingFn.Evaluate(phi, theta, theta_mean);
 
-    for (int i=0; i<21; ++i)
+    for (Index i=0; i<21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta(i), theta_mean);
       EXPECT_DOUBLE_EQ(phi(i), phi_test);
@@ -144,7 +145,7 @@ TEST(WaveSpreadingFunction, Cos2sAccessors)
     spreadingFn1.Evaluate(phi1, theta, theta_mean);
     spreadingFn2.Evaluate(phi2, theta, theta_mean);
 
-    for (int i=0; i<21; ++i)
+    for (Index i=0; i<21; ++i)
     {
       EXPECT_DOUBLE_EQ(phi1(i), phi2(i));
     }
@@ -175,7 +176,7 @@ TEST(WaveSpreadingFunction, Cos2sVirtualVectorXd)
     EXPECT_EQ(phi.rows(), 21);
     EXPECT_EQ(phi.cols(), 1);
 
-    for (int i=0; i<21; ++i)
+    for (Index i=0; i<21; ++i)
     {
       double phi_test = spreadingFn->Evaluate(theta(i, 0), theta_mean);
       EXPECT_DOUBLE_EQ(phi(i, 0), phi_test);
@@ -207,7 +208,7 @@ TEST(WaveSpreadingFunction, Cos2sFFT2ImplRegression)
     Eigen::ArrayXd phi(21);
     spreadingFn.Evaluate(phi, theta, theta_mean);
 
-    for (int i=0; i<21; ++i)
+    for (Index i=0; i<21; ++i)
     {
       double dtheta = theta(i) - theta_mean;
       double phi_test =
@@ -223,8 +224,8 @@ TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
   { // componentwise operations
     double lx = 200.0;
     double ly = 100.0;
-    int nx = 32;
-    int ny = 16;
+    Index nx = 32;
+    Index ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -233,11 +234,11 @@ TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (int i=0; i<ny; ++i)
+    for (Index i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -280,9 +281,9 @@ TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
     EXPECT_EQ(ky.cols(), ny);
 
     // check contents
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
-      for (int j=0; j<ny; ++j)
+      for (Index j=0; j<ny; ++j)
       {
         EXPECT_DOUBLE_EQ(kx(i, j), kx_v(i));
         EXPECT_DOUBLE_EQ(ky(i, j), ky_v(j));
@@ -297,9 +298,9 @@ TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
     );
 
     // check the wave number matrix and angle matrices
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     { 
-      for (int j=0; j<ny; ++j)
+      for (Index j=0; j<ny; ++j)
       {
         double kxij = kx(i, j);
         double kx2ij = kxij * kxij;
@@ -343,7 +344,7 @@ TEST(WaveSpreadingFunction, ECKVRegression)
       0.19146613, 0.24374672, 0.26371613
     };
 
-    for (int i=0; i<21; ++i)
+    for (Index i=0; i<21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta[i], theta_mean, k);
       EXPECT_NEAR(phi[i], phi_test, tolerance);
@@ -375,7 +376,7 @@ TEST(WaveSpreadingFunction, ECKVVectorXd)
     EXPECT_EQ(phi.rows(), 21);
     EXPECT_EQ(phi.cols(), 1);
 
-    for (int i=0; i<21; ++i)
+    for (Index i=0; i<21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta(i, 0), theta_mean, k(i, 0));
       EXPECT_DOUBLE_EQ(phi(i, 0), phi_test);
@@ -388,8 +389,8 @@ TEST(WaveSpreadingFunction, ECKVArrayXXd)
   { // Eigen array version
     double lx = 200.0;
     double ly = 100.0;
-    int nx = 32;
-    int ny = 16;
+    Index nx = 32;
+    Index ny = 16;
 
     double kx_nyquist = M_PI * nx / lx;
     double ky_nyquist = M_PI * ny / ly;
@@ -398,11 +399,11 @@ TEST(WaveSpreadingFunction, ECKVArrayXXd)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (int i=0; i<ny; ++i)
+    for (Index i=0; i<ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -428,9 +429,9 @@ TEST(WaveSpreadingFunction, ECKVArrayXXd)
     Eigen::ArrayXXd phi(nx, ny);
     spreadingFn.Evaluate(phi, theta, theta_mean, k);
 
-    for (int i=0; i<nx; ++i)
+    for (Index i=0; i<nx; ++i)
     {
-      for (int j=0; j<ny; ++j)
+      for (Index j=0; j<ny; ++j)
       {
         double phi_test =
             spreadingFn.Evaluate(theta(i, j), theta_mean, k(i, j));
@@ -463,7 +464,7 @@ TEST(WaveSpreadingFunction, ECKVFFT2ImplRegression)
     Eigen::ArrayXd phi(21);
     spreadingFn.Evaluate(phi, theta, theta_mean, k);
 
-    for (int i=0; i<21; ++i)
+    for (Index i=0; i<21; ++i)
     {
       double dtheta = theta(i) - theta_mean;
       double phi_test =

--- a/gz-waves/src/WaveSpreadingFunction_TEST.cc
+++ b/gz-waves/src/WaveSpreadingFunction_TEST.cc
@@ -13,21 +13,22 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "gz/waves/Types.hh"
-#include "gz/waves/WaveSpreadingFunction.hh"
-#include "LinearRandomFFTWaveSimulationRefImpl.hh"
+#include <gtest/gtest.h>
 
 #include <memory>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include "gz/waves/Types.hh"
+#include "gz/waves/WaveSpreadingFunction.hh"
+#include "LinearRandomFFTWaveSimulationRefImpl.hh"
 
-using namespace gz;
-using namespace waves;
+using gz::waves::Cos2sSpreadingFunction;
+using gz::waves::DirectionalSpreadingFunction;
+using gz::waves::ECKVSpreadingFunction;
+using gz::waves::Index;
+using gz::waves::LinearRandomFFTWaveSimulationRef;
 
-///////////////////////////////////////////////////////////////////////////////
-// Define tests
-
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, Cos2sRegression)
 {
   { // Regress against values generate from Python reference version
@@ -52,7 +53,7 @@ TEST(WaveSpreadingFunction, Cos2sRegression)
       9.03278127e-01
     };
 
-    for (Index i=0; i<21; ++i)
+    for (Index i=0; i < 21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta[i], theta_mean);
       EXPECT_NEAR(phi[i], phi_test, tolerance);
@@ -60,6 +61,7 @@ TEST(WaveSpreadingFunction, Cos2sRegression)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, Cos2sVectorXd)
 {
   { // Eigen array version
@@ -78,7 +80,7 @@ TEST(WaveSpreadingFunction, Cos2sVectorXd)
     Eigen::ArrayXd phi(21);
     spreadingFn.Evaluate(phi, theta, theta_mean);
 
-    for (Index i=0; i<21; ++i)
+    for (Index i=0; i < 21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta(i), theta_mean);
       EXPECT_DOUBLE_EQ(phi(i), phi_test);
@@ -86,6 +88,7 @@ TEST(WaveSpreadingFunction, Cos2sVectorXd)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, Cos2sNonZeroMeanVectorXd)
 {
   { // Eigen array version - non-zero mean
@@ -104,7 +107,7 @@ TEST(WaveSpreadingFunction, Cos2sNonZeroMeanVectorXd)
     Eigen::ArrayXd phi(21);
     spreadingFn.Evaluate(phi, theta, theta_mean);
 
-    for (Index i=0; i<21; ++i)
+    for (Index i=0; i < 21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta(i), theta_mean);
       EXPECT_DOUBLE_EQ(phi(i), phi_test);
@@ -112,6 +115,7 @@ TEST(WaveSpreadingFunction, Cos2sNonZeroMeanVectorXd)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, Cos2sAccessors)
 {
   { // accessor returns set value
@@ -145,13 +149,14 @@ TEST(WaveSpreadingFunction, Cos2sAccessors)
     spreadingFn1.Evaluate(phi1, theta, theta_mean);
     spreadingFn2.Evaluate(phi2, theta, theta_mean);
 
-    for (Index i=0; i<21; ++i)
+    for (Index i=0; i < 21; ++i)
     {
       EXPECT_DOUBLE_EQ(phi1(i), phi2(i));
     }
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, Cos2sVirtualVectorXd)
 {
   { // Call virtually from base class ptr.
@@ -176,7 +181,7 @@ TEST(WaveSpreadingFunction, Cos2sVirtualVectorXd)
     EXPECT_EQ(phi.rows(), 21);
     EXPECT_EQ(phi.cols(), 1);
 
-    for (Index i=0; i<21; ++i)
+    for (Index i=0; i < 21; ++i)
     {
       double phi_test = spreadingFn->Evaluate(theta(i, 0), theta_mean);
       EXPECT_DOUBLE_EQ(phi(i, 0), phi_test);
@@ -184,6 +189,7 @@ TEST(WaveSpreadingFunction, Cos2sVirtualVectorXd)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, Cos2sFFT2ImplRegression)
 {
   const double spread = 10.0;
@@ -208,7 +214,7 @@ TEST(WaveSpreadingFunction, Cos2sFFT2ImplRegression)
     Eigen::ArrayXd phi(21);
     spreadingFn.Evaluate(phi, theta, theta_mean);
 
-    for (Index i=0; i<21; ++i)
+    for (Index i=0; i < 21; ++i)
     {
       double dtheta = theta(i) - theta_mean;
       double phi_test =
@@ -219,6 +225,7 @@ TEST(WaveSpreadingFunction, Cos2sFFT2ImplRegression)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
 {
   { // componentwise operations
@@ -234,11 +241,11 @@ TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (Index i=0; i<ny; ++i)
+    for (Index i=0; i < ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -270,7 +277,7 @@ TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
     // broadcast to matrices (aka meshgrid)
     Eigen::ArrayXXd kx = Eigen::ArrayXXd::Zero(nx, ny);
     kx.colwise() += kx_v;
-    
+
     Eigen::ArrayXXd ky = Eigen::ArrayXXd::Zero(nx, ny);
     ky.rowwise() += ky_v.transpose();
 
@@ -281,9 +288,9 @@ TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
     EXPECT_EQ(ky.cols(), ny);
 
     // check contents
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
-      for (Index j=0; j<ny; ++j)
+      for (Index j=0; j < ny; ++j)
       {
         EXPECT_DOUBLE_EQ(kx(i, j), kx_v(i));
         EXPECT_DOUBLE_EQ(ky(i, j), ky_v(j));
@@ -294,13 +301,12 @@ TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
     Eigen::ArrayXXd ky2 = Eigen::pow(ky, 2.0);
     Eigen::ArrayXXd k = Eigen::sqrt(kx2 + ky2);
     Eigen::ArrayXXd theta = ky.binaryExpr(
-        kx, [] (double y, double x) { return std::atan2(y, x);}
-    );
+        kx, [] (double y, double x) { return std::atan2(y, x);});
 
     // check the wave number matrix and angle matrices
-    for (Index i=0; i<nx; ++i)
-    { 
-      for (Index j=0; j<ny; ++j)
+    for (Index i=0; i < nx; ++i)
+    {
+      for (Index j=0; j < ny; ++j)
       {
         double kxij = kx(i, j);
         double kx2ij = kxij * kxij;
@@ -317,10 +323,10 @@ TEST(WaveSpreadingFunction, WaveNumberArrayXXd)
         EXPECT_DOUBLE_EQ(theta(i, j), thetaij);
       }
     }
-
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, ECKVRegression)
 {
   { // Regress against values generate from Python reference version
@@ -344,7 +350,7 @@ TEST(WaveSpreadingFunction, ECKVRegression)
       0.19146613, 0.24374672, 0.26371613
     };
 
-    for (Index i=0; i<21; ++i)
+    for (Index i=0; i < 21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta[i], theta_mean, k);
       EXPECT_NEAR(phi[i], phi_test, tolerance);
@@ -352,6 +358,7 @@ TEST(WaveSpreadingFunction, ECKVRegression)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, ECKVVectorXd)
 {
   { // Eigen array version
@@ -376,7 +383,7 @@ TEST(WaveSpreadingFunction, ECKVVectorXd)
     EXPECT_EQ(phi.rows(), 21);
     EXPECT_EQ(phi.cols(), 1);
 
-    for (Index i=0; i<21; ++i)
+    for (Index i=0; i < 21; ++i)
     {
       double phi_test = spreadingFn.Evaluate(theta(i, 0), theta_mean, k(i, 0));
       EXPECT_DOUBLE_EQ(phi(i, 0), phi_test);
@@ -384,6 +391,7 @@ TEST(WaveSpreadingFunction, ECKVVectorXd)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, ECKVArrayXXd)
 {
   { // Eigen array version
@@ -399,11 +407,11 @@ TEST(WaveSpreadingFunction, ECKVArrayXXd)
     Eigen::ArrayXd kx_v(nx);
     Eigen::ArrayXd ky_v(ny);
 
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
       kx_v(i) = (i * 2.0 / nx - 1.0) * kx_nyquist;
     }
-    for (Index i=0; i<ny; ++i)
+    for (Index i=0; i < ny; ++i)
     {
       ky_v(i) = (i * 2.0 / ny - 1.0) * ky_nyquist;
     }
@@ -411,7 +419,7 @@ TEST(WaveSpreadingFunction, ECKVArrayXXd)
     // broadcast to matrices (aka meshgrid)
     Eigen::ArrayXXd kx = Eigen::ArrayXXd::Zero(nx, ny);
     kx.colwise() += kx_v;
-    
+
     Eigen::ArrayXXd ky = Eigen::ArrayXXd::Zero(nx, ny);
     ky.rowwise() += ky_v.transpose();
 
@@ -419,8 +427,7 @@ TEST(WaveSpreadingFunction, ECKVArrayXXd)
     Eigen::ArrayXXd ky2 = Eigen::pow(ky, 2.0);
     Eigen::ArrayXXd k = Eigen::sqrt(kx2 + ky2);
     Eigen::ArrayXXd theta = ky.binaryExpr(
-        kx, [] (double y, double x) { return std::atan2(y, x);}
-    );
+        kx, [] (double y, double x) { return std::atan2(y, x);});
 
     ECKVSpreadingFunction spreadingFn;
 
@@ -429,9 +436,9 @@ TEST(WaveSpreadingFunction, ECKVArrayXXd)
     Eigen::ArrayXXd phi(nx, ny);
     spreadingFn.Evaluate(phi, theta, theta_mean, k);
 
-    for (Index i=0; i<nx; ++i)
+    for (Index i=0; i < nx; ++i)
     {
-      for (Index j=0; j<ny; ++j)
+      for (Index j=0; j < ny; ++j)
       {
         double phi_test =
             spreadingFn.Evaluate(theta(i, j), theta_mean, k(i, j));
@@ -441,6 +448,7 @@ TEST(WaveSpreadingFunction, ECKVArrayXXd)
   }
 }
 
+//////////////////////////////////////////////////
 TEST(WaveSpreadingFunction, ECKVFFT2ImplRegression)
 {
   // coefficients
@@ -464,7 +472,7 @@ TEST(WaveSpreadingFunction, ECKVFFT2ImplRegression)
     Eigen::ArrayXd phi(21);
     spreadingFn.Evaluate(phi, theta, theta_mean, k);
 
-    for (Index i=0; i<21; ++i)
+    for (Index i=0; i < 21; ++i)
     {
       double dtheta = theta(i) - theta_mean;
       double phi_test =
@@ -475,9 +483,7 @@ TEST(WaveSpreadingFunction, ECKVFFT2ImplRegression)
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Run tests
-
+//////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/gz-waves/src/Wavefield.cc
+++ b/gz-waves/src/Wavefield.cc
@@ -35,187 +35,185 @@ namespace gz
 {
 namespace waves
 {
-  /////////////////////////////////////////////////
-  /// \internal Private implementation.
-  class WavefieldPrivate
+//////////////////////////////////////////////////
+/// \internal Private implementation.
+class WavefieldPrivate
+{
+ public:
+  /// \brief Callback for topic "/world/<world>/waves".
+  ///
+  /// \param[in] msg Wave parameters message.
+  void OnWaveMsg(const gz::msgs::Param& msg);
+
+  /// \brief Wave parameters
+  std::shared_ptr<WaveParameters> params_;
+
+  /// \brief Ocean tile
+  std::unique_ptr<physics::OceanTile> ocean_tile_;
+
+  /// \brief The current position of the wave field.
+  std::unique_ptr<TriangulatedGrid> tri_grid_;
+
+  /// \brief Mutex to protect parameter updates.
+  std::recursive_mutex mutex_;
+
+  /// \brief Transport node
+  transport::Node node_;
+};
+
+//////////////////////////////////////////////////
+Wavefield::~Wavefield()
+{
+}
+
+//////////////////////////////////////////////////
+Wavefield::Wavefield(const std::string& world_name) :
+  impl_(new WavefieldPrivate())
+{
+  gzmsg << "Constructing Wavefield..." <<  std::endl;
+
+  // Subscribe to wave parameter updates
+  std::string topic("/world/" + world_name + "/waves");
+  impl_->node_.Subscribe(
+      topic, &WavefieldPrivate::OnWaveMsg, impl_.get());
+
+  // Wave parameters
+  gzmsg << "Creating WaveParameters." <<  std::endl;
+  auto params = std::make_shared<WaveParameters>();
+  SetParameters(params);
+
+  // Update
+  Update(0.0);
+
+  gzmsg << "Done constructing Wavefield." <<  std::endl;
+}
+
+//////////////////////////////////////////////////
+bool Wavefield::Height(const cgal::Point3& point, double& height) const
+{
+  /// \todo(srmainwaring) the calculation assumes that the tile origin
+  /// is at its center.
+  const double lx = impl_->ocean_tile_->TileSize();
+
+  auto pmod = [&](double x)
   {
-  public:
-    /// \brief Callback for topic "/world/<world>/waves".
-    ///
-    /// \param[in] msg Wave parameters message.
-    void OnWaveMsg(const gz::msgs::Param &msg);
-
-    /// \brief Wave parameters
-    std::shared_ptr<WaveParameters> params_;
-
-    /// \brief Ocean tile
-    std::unique_ptr<physics::OceanTile> ocean_tile_;
-
-    /// \brief The current position of the wave field.
-    std::unique_ptr<TriangulatedGrid> tri_grid_;
-
-    /// \brief Mutex to protect parameter updates.
-    std::recursive_mutex mutex_;
-
-    /// \brief Transport node
-    transport::Node node_;
+      if (x < 0.0)
+        return std::fmod(x - lx/2.0, lx) + lx/2.0;
+      else
+        return std::fmod(x + lx/2.0, lx) - lx/2.0;
   };
 
-  /////////////////////////////////////////////////
-  Wavefield::~Wavefield()
-  {
-  }
+  // Obtain the point modulo the tile dimensions
+  cgal::Point3 modulo_point(pmod(point.x()), pmod(point.y()), point.z());
 
-  /////////////////////////////////////////////////
-  Wavefield::Wavefield(const std::string &world_name) :
-    impl_(new WavefieldPrivate())
-  {
-    gzmsg << "Constructing Wavefield..." <<  std::endl;
-
-    // Subscribe to wave parameter updates
-    std::string topic("/world/" + world_name + "/waves");
-    impl_->node_.Subscribe(
-        topic, &WavefieldPrivate::OnWaveMsg, impl_.get());
-
-    // Wave parameters
-    gzmsg << "Creating WaveParameters." <<  std::endl;
-    auto params = std::make_shared<WaveParameters>();
-    SetParameters(params);
-
-    // Update
-    Update(0.0);
-
-    gzmsg << "Done constructing Wavefield." <<  std::endl;
-  }
-
-  /////////////////////////////////////////////////
-  bool Wavefield::Height(const cgal::Point3 &point, double &height) const
-  {
-    /// \todo(srmainwaring) the calculation assumes that the tile origin
-    /// is at its center.
-    const double lx = impl_->ocean_tile_->TileSize();
-
-    auto pmod = [&](double x)
-    {
-        if (x < 0.0)
-          return std::fmod(x - lx/2.0, lx) + lx/2.0;
-        else
-          return std::fmod(x + lx/2.0, lx) - lx/2.0;
-    };
-
-    // Obtain the point modulo the tile dimensions
-    cgal::Point3 modulo_point(pmod(point.x()), pmod(point.y()), point.z());
-
-    return impl_->tri_grid_->Height(modulo_point, height);
-  }
-
-  /////////////////////////////////////////////////
-  std::shared_ptr<const WaveParameters> Wavefield::GetParameters() const
-  {
-    return impl_->params_;
-  }
-
-  /////////////////////////////////////////////////
-  void Wavefield::SetParameters(std::shared_ptr<WaveParameters> params)
-  {
-    impl_->params_ = params;
-
-    // Force an update of the ocean tile and point locator
-    Index nx = impl_->params_->CellCount();
-    double lx = impl_->params_->TileSize();
-    double u = impl_->params_->WindVelocity().X();
-    double v = impl_->params_->WindVelocity().Y();
-
-    // OceanTile
-    gzmsg << "Creating OceanTile." <<  std::endl;
-    impl_->ocean_tile_.reset(new physics::OceanTile(
-        impl_->params_, false));
-    impl_->ocean_tile_->SetWindVelocity(u, v);
-    impl_->ocean_tile_->Create();
-
-    // Point Locator
-    gzmsg << "Creating triangulated grid." <<  std::endl;
-    auto grid = TriangulatedGrid::Create(nx, lx);
-    impl_->tri_grid_ = std::move(grid);
-  }
-
-  /////////////////////////////////////////////////
-  void Wavefield::Update(double time)
-  {
-    std::lock_guard<std::recursive_mutex> lock(impl_->mutex_);
-
-    // Update the tile.
-    impl_->ocean_tile_->Update(time);
-
-    // Update the point locator.
-    auto& vertices = impl_->ocean_tile_->Vertices();
-    impl_->tri_grid_->UpdatePoints(vertices);
-  }
-
-  /////////////////////////////////////////////////
-  //////////////////////////////////////////////////
-  void WavefieldPrivate::OnWaveMsg(const gz::msgs::Param &msg)
-  {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-
-    // gzmsg << msg.DebugString();
-
-    // // Get parameters from message
-    // double wind_angle = 0.0;
-    // double wind_speed = 0.0;
-    // wind_angle = Utilities::MsgParamDouble(*msg, "wind_angle", wind_angle);
-    // wind_speed = Utilities::MsgParamDouble(*msg, "wind_speed", wind_speed);
-
-    // current wind speed and angle
-    double wind_speed = params_->WindSpeed();
-    double wind_angle_rad = params_->WindAngleRad();
-    double steepness = params_->Steepness();
-
-    // extract parameters
-    {
-      auto it = msg.params().find("wind_speed");
-      if (it != msg.params().end())
-      {
-        /// \todo: assert the type is double
-        auto param = it->second;
-        // auto type = param.type();
-        auto value = param.double_value();
-        wind_speed = value;
-      }
-    }
-    {
-      auto it = msg.params().find("wind_angle");
-      if (it != msg.params().end())
-      {
-        /// \todo: assert the type is double
-        auto param = it->second;
-        // auto type = param.type();
-        auto value = param.double_value();
-        wind_angle_rad = M_PI/180.0*value;
-      }
-    }
-    {
-      auto it = msg.params().find("steepness");
-      if (it != msg.params().end())
-      {
-        /// \todo: assert the type is double
-        auto param = it->second;
-        // auto type = param.type();
-        auto value = param.double_value();
-        steepness = value;
-      }
-    }
-
-    // update parameters and wavefield
-    params_->SetWindSpeedAndAngle(wind_speed, wind_angle_rad);
-    params_->SetSteepness(steepness);
-
-    ocean_tile_->SetWindVelocity(
-        params_->WindVelocity().X(),
-        params_->WindVelocity().Y());
-  }
-
-  /////////////////////////////////////////////////
-
+  return impl_->tri_grid_->Height(modulo_point, height);
 }
+
+//////////////////////////////////////////////////
+std::shared_ptr<const WaveParameters> Wavefield::GetParameters() const
+{
+  return impl_->params_;
 }
+
+//////////////////////////////////////////////////
+void Wavefield::SetParameters(std::shared_ptr<WaveParameters> params)
+{
+  impl_->params_ = params;
+
+  // Force an update of the ocean tile and point locator
+  Index nx = impl_->params_->CellCount();
+  double lx = impl_->params_->TileSize();
+  double u = impl_->params_->WindVelocity().X();
+  double v = impl_->params_->WindVelocity().Y();
+
+  // OceanTile
+  gzmsg << "Creating OceanTile." <<  std::endl;
+  impl_->ocean_tile_.reset(new physics::OceanTile(
+      impl_->params_, false));
+  impl_->ocean_tile_->SetWindVelocity(u, v);
+  impl_->ocean_tile_->Create();
+
+  // Point Locator
+  gzmsg << "Creating triangulated grid." <<  std::endl;
+  auto grid = TriangulatedGrid::Create(nx, lx);
+  impl_->tri_grid_ = std::move(grid);
+}
+
+//////////////////////////////////////////////////
+void Wavefield::Update(double time)
+{
+  std::lock_guard<std::recursive_mutex> lock(impl_->mutex_);
+
+  // Update the tile.
+  impl_->ocean_tile_->Update(time);
+
+  // Update the point locator.
+  auto& vertices = impl_->ocean_tile_->Vertices();
+  impl_->tri_grid_->UpdatePoints(vertices);
+}
+
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+void WavefieldPrivate::OnWaveMsg(const gz::msgs::Param& msg)
+{
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+  // gzmsg << msg.DebugString();
+
+  // // Get parameters from message
+  // double wind_angle = 0.0;
+  // double wind_speed = 0.0;
+  // wind_angle = Utilities::MsgParamDouble(*msg, "wind_angle", wind_angle);
+  // wind_speed = Utilities::MsgParamDouble(*msg, "wind_speed", wind_speed);
+
+  // current wind speed and angle
+  double wind_speed = params_->WindSpeed();
+  double wind_angle_rad = params_->WindAngleRad();
+  double steepness = params_->Steepness();
+
+  // extract parameters
+  {
+    auto it = msg.params().find("wind_speed");
+    if (it != msg.params().end())
+    {
+      /// \todo: assert the type is double
+      auto param = it->second;
+      // auto type = param.type();
+      auto value = param.double_value();
+      wind_speed = value;
+    }
+  }
+  {
+    auto it = msg.params().find("wind_angle");
+    if (it != msg.params().end())
+    {
+      /// \todo: assert the type is double
+      auto param = it->second;
+      // auto type = param.type();
+      auto value = param.double_value();
+      wind_angle_rad = M_PI/180.0*value;
+    }
+  }
+  {
+    auto it = msg.params().find("steepness");
+    if (it != msg.params().end())
+    {
+      /// \todo: assert the type is double
+      auto param = it->second;
+      // auto type = param.type();
+      auto value = param.double_value();
+      steepness = value;
+    }
+  }
+
+  // update parameters and wavefield
+  params_->SetWindSpeedAndAngle(wind_speed, wind_angle_rad);
+  params_->SetSteepness(steepness);
+
+  ocean_tile_->SetWindVelocity(
+      params_->WindVelocity().X(),
+      params_->WindVelocity().Y());
+}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/Wavefield.cc
+++ b/gz-waves/src/Wavefield.cc
@@ -14,50 +14,51 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/Wavefield.hh"
-#include "gz/waves/CGALTypes.hh"
-#include "gz/waves/WaveParameters.hh"
-
-#include "gz/waves/OceanTile.hh"
-#include "gz/waves/TriangulatedGrid.hh"
-
-#include "gz/waves/Utilities.hh"
-#include <thread>
-
-#include <gz/transport.hh>
 
 #include <array>
 #include <cmath>
 #include <iostream>
 #include <string>
+#include <thread>
+
+#include <gz/transport.hh>
+
+#include "gz/waves/CGALTypes.hh"
+#include "gz/waves/OceanTile.hh"
+#include "gz/waves/TriangulatedGrid.hh"
+#include "gz/waves/Types.hh"
+#include "gz/waves/Utilities.hh"
+#include "gz/waves/WaveParameters.hh"
+
 
 namespace gz
 {
 namespace waves
 {
   /////////////////////////////////////////////////
-  /// \internal
-  /// \brief Private data for the Wavefield.
+  /// \internal Private implementation.
   class WavefieldPrivate
   {
+  public:
     /// \brief Callback for topic "/world/<world>/waves".
     ///
-    /// \param[in] _msg Wave parameters message.
-    public: void OnWaveMsg(const gz::msgs::Param &_msg);
+    /// \param[in] msg Wave parameters message.
+    void OnWaveMsg(const gz::msgs::Param &msg);
 
     /// \brief Wave parameters
-    public: std::shared_ptr<WaveParameters> params;
+    std::shared_ptr<WaveParameters> params_;
 
     /// \brief Ocean tile
-    public: std::unique_ptr<physics::OceanTile> oceanTile;
+    std::unique_ptr<physics::OceanTile> ocean_tile_;
 
     /// \brief The current position of the wave field.
-    public: std::unique_ptr<TriangulatedGrid> triangulatedGrid;
+    std::unique_ptr<TriangulatedGrid> tri_grid_;
 
     /// \brief Mutex to protect parameter updates.
-    public: std::recursive_mutex mutex;
+    std::recursive_mutex mutex_;
 
     /// \brief Transport node
-    public: transport::Node node;
+    transport::Node node_;
   };
 
   /////////////////////////////////////////////////
@@ -66,136 +67,136 @@ namespace waves
   }
 
   /////////////////////////////////////////////////
-  Wavefield::Wavefield(const std::string &_worldName) :
-    dataPtr(new WavefieldPrivate())
+  Wavefield::Wavefield(const std::string &world_name) :
+    impl_(new WavefieldPrivate())
   {
     gzmsg << "Constructing Wavefield..." <<  std::endl;
 
     // Subscribe to wave parameter updates
-    std::string topic("/world/" + _worldName + "/waves");
-    this->dataPtr->node.Subscribe(
-        topic, &WavefieldPrivate::OnWaveMsg, this->dataPtr.get());
+    std::string topic("/world/" + world_name + "/waves");
+    impl_->node_.Subscribe(
+        topic, &WavefieldPrivate::OnWaveMsg, impl_.get());
 
     // Wave parameters
     gzmsg << "Creating WaveParameters." <<  std::endl;
     auto params = std::make_shared<WaveParameters>();
-    this->SetParameters(params);
+    SetParameters(params);
 
     // Update
-    this->Update(0.0);
+    Update(0.0);
 
     gzmsg << "Done constructing Wavefield." <<  std::endl;
   }
 
   /////////////////////////////////////////////////
-  bool Wavefield::Height(const cgal::Point3& point, double& height) const
+  bool Wavefield::Height(const cgal::Point3 &point, double &height) const
   {
-    /// \todo(srmainwaring) the calculation assumes that the tile origin is at its center.
-    const double L = this->dataPtr->oceanTile->TileSize();
-    const double LOver2 = L/2.0;
+    /// \todo(srmainwaring) the calculation assumes that the tile origin
+    /// is at its center.
+    const double lx = impl_->ocean_tile_->TileSize();
 
     auto pmod = [&](double x)
     {
         if (x < 0.0)
-          return std::fmod(x - LOver2, L) + LOver2;
+          return std::fmod(x - lx/2.0, lx) + lx/2.0;
         else
-          return std::fmod(x + LOver2, L) - LOver2;
+          return std::fmod(x + lx/2.0, lx) - lx/2.0;
     };
 
     // Obtain the point modulo the tile dimensions
-    cgal::Point3 moduloPoint(pmod(point.x()), pmod(point.y()), point.z());
+    cgal::Point3 modulo_point(pmod(point.x()), pmod(point.y()), point.z());
 
-    return this->dataPtr->triangulatedGrid->Height(moduloPoint, height);
+    return impl_->tri_grid_->Height(modulo_point, height);
   }
 
   /////////////////////////////////////////////////
   std::shared_ptr<const WaveParameters> Wavefield::GetParameters() const
   {
-    return this->dataPtr->params;
+    return impl_->params_;
   }
 
   /////////////////////////////////////////////////
-  void Wavefield::SetParameters(std::shared_ptr<WaveParameters> _params)
+  void Wavefield::SetParameters(std::shared_ptr<WaveParameters> params)
   {
-    this->dataPtr->params = _params;
+    impl_->params_ = params;
 
     // Force an update of the ocean tile and point locator
-    size_t N = this->dataPtr->params->CellCount();
-    double L = this->dataPtr->params->TileSize();
-    double u = this->dataPtr->params->WindVelocity().X();
-    double v = this->dataPtr->params->WindVelocity().Y();
+    Index nx = impl_->params_->CellCount();
+    double lx = impl_->params_->TileSize();
+    double u = impl_->params_->WindVelocity().X();
+    double v = impl_->params_->WindVelocity().Y();
 
     // OceanTile
     gzmsg << "Creating OceanTile." <<  std::endl;
-    this->dataPtr->oceanTile.reset(new physics::OceanTile(
-        this->dataPtr->params, false));
-    this->dataPtr->oceanTile->SetWindVelocity(u, v);
-    this->dataPtr->oceanTile->Create();
+    impl_->ocean_tile_.reset(new physics::OceanTile(
+        impl_->params_, false));
+    impl_->ocean_tile_->SetWindVelocity(u, v);
+    impl_->ocean_tile_->Create();
 
     // Point Locator
     gzmsg << "Creating triangulated grid." <<  std::endl;
-    auto grid = TriangulatedGrid::Create(N, L);
-    this->dataPtr->triangulatedGrid = std::move(grid);
+    auto grid = TriangulatedGrid::Create(nx, lx);
+    impl_->tri_grid_ = std::move(grid);
   }
 
   /////////////////////////////////////////////////
-  void Wavefield::Update(double _time)
+  void Wavefield::Update(double time)
   {
-    std::lock_guard<std::recursive_mutex> lock(this->dataPtr->mutex);
+    std::lock_guard<std::recursive_mutex> lock(impl_->mutex_);
 
     // Update the tile.
-    this->dataPtr->oceanTile->Update(_time);
+    impl_->ocean_tile_->Update(time);
 
     // Update the point locator.
-    auto& vertices = this->dataPtr->oceanTile->Vertices();
-    this->dataPtr->triangulatedGrid->UpdatePoints(vertices);
+    auto& vertices = impl_->ocean_tile_->Vertices();
+    impl_->tri_grid_->UpdatePoints(vertices);
   }
 
   /////////////////////////////////////////////////
   //////////////////////////////////////////////////
-  void WavefieldPrivate::OnWaveMsg(const gz::msgs::Param &_msg)
+  void WavefieldPrivate::OnWaveMsg(const gz::msgs::Param &msg)
   {
-    std::lock_guard<std::recursive_mutex> lock(this->mutex);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
 
-    // gzmsg << _msg.DebugString();
+    // gzmsg << msg.DebugString();
 
     // // Get parameters from message
     // double wind_angle = 0.0;
     // double wind_speed = 0.0;
-    // wind_angle = Utilities::MsgParamDouble(*_msg, "wind_angle", wind_angle);
-    // wind_speed = Utilities::MsgParamDouble(*_msg, "wind_speed", wind_speed);
+    // wind_angle = Utilities::MsgParamDouble(*msg, "wind_angle", wind_angle);
+    // wind_speed = Utilities::MsgParamDouble(*msg, "wind_speed", wind_speed);
 
     // current wind speed and angle
-    double windSpeed = this->params->WindSpeed();
-    double windAngleRad = this->params->WindAngleRad();
-    double steepness = this->params->Steepness();
+    double wind_speed = params_->WindSpeed();
+    double wind_angle_rad = params_->WindAngleRad();
+    double steepness = params_->Steepness();
 
     // extract parameters
     {
-      auto it = _msg.params().find("wind_speed");
-      if (it != _msg.params().end())
+      auto it = msg.params().find("wind_speed");
+      if (it != msg.params().end())
       {
         /// \todo: assert the type is double
         auto param = it->second;
         // auto type = param.type();
         auto value = param.double_value();
-        windSpeed = value;
+        wind_speed = value;
       }
     }
     {
-      auto it = _msg.params().find("wind_angle");
-      if (it != _msg.params().end())
+      auto it = msg.params().find("wind_angle");
+      if (it != msg.params().end())
       {
         /// \todo: assert the type is double
         auto param = it->second;
         // auto type = param.type();
         auto value = param.double_value();
-        windAngleRad = M_PI/180.0*value;
+        wind_angle_rad = M_PI/180.0*value;
       }
     }
     {
-      auto it = _msg.params().find("steepness");
-      if (it != _msg.params().end())
+      auto it = msg.params().find("steepness");
+      if (it != msg.params().end())
       {
         /// \todo: assert the type is double
         auto param = it->second;
@@ -206,12 +207,12 @@ namespace waves
     }
 
     // update parameters and wavefield
-    this->params->SetWindSpeedAndAngle(windSpeed, windAngleRad);
-    this->params->SetSteepness(steepness);
+    params_->SetWindSpeedAndAngle(wind_speed, wind_angle_rad);
+    params_->SetSteepness(steepness);
 
-    this->oceanTile->SetWindVelocity(
-        this->params->WindVelocity().X(),
-        this->params->WindVelocity().Y());
+    ocean_tile_->SetWindVelocity(
+        params_->WindVelocity().X(),
+        params_->WindVelocity().Y());
   }
 
   /////////////////////////////////////////////////

--- a/gz-waves/src/WavefieldSampler.cc
+++ b/gz-waves/src/WavefieldSampler.cc
@@ -147,7 +147,7 @@ namespace waves
     // Calculate the depth
     cgal::Direction3 direction(0, 0, 1);
     cgal::Point3 wave_point = CGAL::ORIGIN;
-    std::array<size_t, 3> index;
+    std::array<Index, 3> index;
     bool is_found = GridTools::FindIntersectionIndex(
       patch, point.x(), point.y(), index);
     if (!is_found)
@@ -210,8 +210,8 @@ namespace waves
       J(0, 1) =  0;
       J(1, 0) =  0;
       J(1, 1) = -1;
-      size_t n = wp.a.size();
-      for (size_t i=0; i<n; ++i)
+      Index n = wp.a.size();
+      for (Index i=0; i<n; ++i)
       {
         const double dx = wp.dir[i].X();
         const double dy = wp.dir[i].Y();
@@ -243,7 +243,7 @@ namespace waves
     auto solver = [=](auto& fdfunc, auto x0, auto p, auto t,
         auto& wp, auto tol, auto nmax)
     {
-      int n = 0;
+      Index n = 0;
       double err = 1;
       double pz = 0;
       auto xn = x0;

--- a/gz-waves/src/WavefieldSampler.cc
+++ b/gz-waves/src/WavefieldSampler.cc
@@ -15,12 +15,12 @@
 
 #include "gz/waves/WavefieldSampler.hh"
 
+#include <Eigen/Dense>
+
 #include <array>
 #include <cmath>
 #include <iostream>
 #include <string>
-
-#include <Eigen/Dense>
 
 #include <gz/common.hh>
 #include <gz/math/Pose3.hh>
@@ -33,255 +33,252 @@
 #include "gz/waves/Wavefield.hh"
 #include "gz/waves/WaveParameters.hh"
 
-
 namespace gz
 {
 namespace waves
 {
-  /////////////////////////////////////////////////
-  /// \internal
-  /// \brief Private data for the WavefieldSampler.
-  class WavefieldSamplerPrivate
+//////////////////////////////////////////////////
+/// \internal
+/// \brief Private data for the WavefieldSampler.
+class WavefieldSamplerPrivate
+{
+ public:
+  /// \brief The wavefield grid.
+  std::shared_ptr<const Wavefield> wavefield_;
+
+  /// \brief A sample of the wavefield located at the initial pose.
+  std::shared_ptr<const Grid> init_patch_;
+
+  /// \brief A sample of the wavefield. This copy is updated.
+  std::shared_ptr<Grid> patch_;
+};
+
+//////////////////////////////////////////////////
+WavefieldSampler::~WavefieldSampler()
+{
+}
+
+//////////////////////////////////////////////////
+WavefieldSampler::WavefieldSampler(
+  std::shared_ptr<const Wavefield> wavefield,
+  std::shared_ptr<const Grid> patch
+) : impl_(new WavefieldSamplerPrivate())
+{
+  impl_->wavefield_ = wavefield;
+  impl_->init_patch_ = patch;
+  impl_->patch_.reset(new Grid(*patch));
+}
+
+//////////////////////////////////////////////////
+std::shared_ptr<const Grid> WavefieldSampler::GetWaterPatch() const
+{
+  return impl_->patch_;
+}
+
+//////////////////////////////////////////////////
+void WavefieldSampler::ApplyPose(const gz::math::Pose3d& pose)
+{
+  // @TODO_FRAGILE - Move to Grid as changing internal state
+  // Apply pose to center
+  const cgal::Point3& c0 = impl_->init_patch_->GetCenter();
+  cgal::Point3 c1(c0.x() + pose.Pos().X(), c0.y() + pose.Pos().Y(), c0.z());
+  impl_->patch_->SetCenter(c1);
+
+  // Iterate over vertices
+  auto& source = *impl_->init_patch_->GetMesh();
+  auto& target = *impl_->patch_->GetMesh();
+  for (
+    auto&& it = std::make_pair(std::begin(source.vertices()),
+        std::begin(target.vertices()));
+    it.first != std::end(source.vertices()) &&
+        it.second != std::end(target.vertices());
+    ++it.first, ++it.second)
   {
-  public:
-    /// \brief The wavefield grid.
-    std::shared_ptr<const Wavefield> wavefield_;
+    auto& v0 = *it.first;
+    auto& v1 = *it.second;
+    const cgal::Point3& p0 = source.point(v0);
 
-    /// \brief A sample of the wavefield located at the initial pose.
-    std::shared_ptr<const Grid> init_patch_;
+    // Transformation: slide the patch in the xy - plane only
+    cgal::Point3 p1(p0.x() + pose.Pos().X(), p0.y() + pose.Pos().Y(), p0.z());
+    target.point(v1) = p1;
+  }
+}
 
-    /// \brief A sample of the wavefield. This copy is updated.
-    std::shared_ptr<Grid> patch_;
+//////////////////////////////////////////////////
+void WavefieldSampler::UpdatePatch()
+{
+  // Update the water patch Mesh
+  // gzmsg << "Update water patch..." << std::endl;
+  const auto& target = impl_->patch_->GetMesh();
+  for (
+    auto&& vb = std::begin(target->vertices());
+    vb != std::end(target->vertices());
+    ++vb
+  )
+  {
+    const auto& vertex = *vb;
+    const auto& p0 = target->point(vertex);
+    double height = 0.0;
+    impl_->wavefield_->Height(p0, height);
+    cgal::Point3 p1(p0.x(), p0.y(), height);
+    target->point(vertex) = p1;
+    // gzmsg << target->point(vertex) << std::endl;
+  }
+}
+
+//////////////////////////////////////////////////
+double WavefieldSampler::ComputeDepth(const cgal::Point3& point) const
+{
+  auto& grid = *impl_->patch_;
+  return WavefieldSampler::ComputeDepth(grid, point);
+
+  // @TODO_EXPERIMENTAL - direct calculation (currently static only)
+  // auto& waveParams = *impl_->wavefield_->GetParameters();
+  // return WavefieldSampler::ComputeDepthDirectly(waveParams, point, 0.0);
+}
+
+//////////////////////////////////////////////////
+double WavefieldSampler::ComputeDepth(
+  const Grid& patch,
+  const cgal::Point3& point
+)
+{
+  // Calculate the depth
+  cgal::Direction3 direction(0, 0, 1);
+  cgal::Point3 wave_point = CGAL::ORIGIN;
+  std::array<Index, 3> index;
+  bool is_found = GridTools::FindIntersectionIndex(
+    patch, point.x(), point.y(), index);
+  if (!is_found)
+  {
+    // @DEBUG_INFO
+    gzerr << "point:  " << point << std::endl;
+    // patch.DebugPrint();
+    gzerr << "Water patch is too small" << std::endl;
+    return 0;
+  }
+  is_found = GridTools::FindIntersectionGrid(
+    patch, point, direction, index, wave_point);
+  if (!is_found)
+  {
+    // @DEBUG_INFO
+    gzerr << "point:  " << point << std::endl;
+    // patch.DebugPrint();
+    gzerr << "Water patch is too small" << std::endl;
+    return 0;
+  }
+  double h = wave_point.z() - point.z();
+  return h;
+}
+
+//////////////////////////////////////////////////
+double WavefieldSampler::ComputeDepthDirectly(
+  const WaveParameters& wave_params,
+  const cgal::Point3& point,
+  double time
+)
+{
+  // Struture for passing wave parameters to lambdas
+  struct WaveParams
+  {
+    WaveParams(
+      const std::vector<double>& _a,
+      const std::vector<double>& _k,
+      const std::vector<double>& _omega,
+      const std::vector<double>& _phi,
+      const std::vector<double>& _q,
+      const std::vector<gz::math::Vector2d>& _dir) :
+      a(_a), k(_k), omega(_omega), phi(_phi), q(_q), dir(_dir) {}
+
+    const std::vector<double>& a;
+    const std::vector<double>& k;
+    const std::vector<double>& omega;
+    const std::vector<double>& phi;
+    const std::vector<double>& q;
+    const std::vector<gz::math::Vector2d>& dir;
   };
 
-  /////////////////////////////////////////////////
-  WavefieldSampler::~WavefieldSampler()
+  // Compute the target function and Jacobian. Also calculate pz,
+  // the z-componen of the Gerstner wave, which we essentially get for free.
+  auto wave_fdf = [=](auto x, auto p, auto t, auto& wp, auto& F, auto& J)
   {
-  }
-
-  /////////////////////////////////////////////////
-  WavefieldSampler::WavefieldSampler(
-    std::shared_ptr<const Wavefield> wavefield,
-    std::shared_ptr<const Grid> patch
-  ) : impl_(new WavefieldSamplerPrivate())
-  {
-    impl_->wavefield_ = wavefield;
-    impl_->init_patch_ = patch;
-    impl_->patch_.reset(new Grid(*patch));
-  }
-
-  /////////////////////////////////////////////////
-  std::shared_ptr<const Grid> WavefieldSampler::GetWaterPatch() const
-  {
-    return impl_->patch_;
-  }
-
-  /////////////////////////////////////////////////
-  void WavefieldSampler::ApplyPose(const gz::math::Pose3d &pose)
-  {
-    // @TODO_FRAGILE - Move to Grid as changing internal state 
-    // Apply pose to center
-    const cgal::Point3& c0 = impl_->init_patch_->GetCenter();
-    cgal::Point3 c1(c0.x() + pose.Pos().X(), c0.y() + pose.Pos().Y(), c0.z());
-    impl_->patch_->SetCenter(c1);
-
-    // Iterate over vertices
-    auto& source = *impl_->init_patch_->GetMesh();
-    auto& target = *impl_->patch_->GetMesh();
-    for (
-      auto&& it = std::make_pair(std::begin(source.vertices()),
-          std::begin(target.vertices()));
-      it.first != std::end(source.vertices()) &&
-          it.second != std::end(target.vertices());
-      ++it.first, ++it.second)
+    double pz = 0;
+    F(0) = p.x() - x.x();
+    F(1) = p.y() - x.y();
+    J(0, 0) = -1;
+    J(0, 1) =  0;
+    J(1, 0) =  0;
+    J(1, 1) = -1;
+    Index n = wp.a.size();
+    for (Index i=0; i < n; ++i)
     {
-      auto& v0 = *it.first;
-      auto& v1 = *it.second;
-      const cgal::Point3& p0 = source.point(v0);
-
-      // Transformation: slide the patch in the xy - plane only
-      cgal::Point3 p1(p0.x() + pose.Pos().X(), p0.y() + pose.Pos().Y(), p0.z());
-      target.point(v1) = p1;
+      const double dx = wp.dir[i].X();
+      const double dy = wp.dir[i].Y();
+      const double q = wp.q[i];
+      const double a = wp.a[i];
+      const double k = wp.k[i];
+      const double dot = x.x() * dx + x.y() * dy;
+      const double theta = k * dot - wp.omega[i] * t;
+      const double s = std::sin(theta);
+      const double c = std::cos(theta);
+      const double qakc = q * a * k * c;
+      const double df1x = qakc * dx * dx;
+      const double df1y = qakc * dx * dy;
+      const double df2x = df1y;
+      const double df2y = qakc * dy * dy;
+      pz += a * c;
+      F(0) += a * dx * s;
+      F(1) += a * dy * s;
+      J(0, 0) += df1x;
+      J(0, 1) += df1y;
+      J(1, 0) += df2x;
+      J(1, 1) += df2y;
     }
-  }
+    return pz;
+  };
 
-  /////////////////////////////////////////////////
-  void WavefieldSampler::UpdatePatch()
+  // Simple multi-variate Newton solver - this version returns the
+  // z-component of the wave field at the desired point p.
+  auto solver = [=](auto& fdfunc, auto x0, auto p, auto t,
+      auto& wp, auto tol, auto nmax)
   {
-    // Update the water patch Mesh
-    // gzmsg << "Update water patch..." << std::endl;
-    const auto& target = impl_->patch_->GetMesh();
-    for (
-      auto&& vb = std::begin(target->vertices()); 
-      vb != std::end(target->vertices());
-      ++vb
-    )
+    Index n = 0;
+    double err = 1;
+    double pz = 0;
+    auto xn = x0;
+    Eigen::Vector2d F;
+    Eigen::Matrix2d J;
+    while (std::abs(err) > tol && n < nmax)
     {
-      const auto& vertex = *vb;
-      const auto& p0 = target->point(vertex);
-      double height = 0.0;
-      impl_->wavefield_->Height(p0, height);
-      cgal::Point3 p1(p0.x(), p0.y(), height);
-      target->point(vertex) = p1;
-      // gzmsg << target->point(vertex) << std::endl;
+      pz = fdfunc(x0, p, t, wp, F, J);
+      xn = x0 - J.inverse() * F;
+      x0 = xn;
+      err = F.norm();
+      n++;
     }
-  }
+    return pz;
+  };
 
-  /////////////////////////////////////////////////
-  double WavefieldSampler::ComputeDepth(const cgal::Point3 &point) const
-  {
-    auto& grid = *impl_->patch_;
-    return WavefieldSampler::ComputeDepth(grid, point);
+  // Set up parameter references
+  WaveParams wp(
+    wave_params.Amplitude_V(),
+    wave_params.Wavenumber_V(),
+    wave_params.AngularFrequency_V(),
+    wave_params.Phase_V(),
+    wave_params.Steepness_V(),
+    wave_params.Direction_V());
 
-    // @TODO_EXPERIMENTAL - direct calculation (currently static only)
-    // auto& waveParams = *impl_->wavefield_->GetParameters();
-    // return WavefieldSampler::ComputeDepthDirectly(waveParams, point, 0.0);
-  }
+  // Tolerances etc.
+  const double tol = 1.0E-10;
+  const double nmax = 30;
 
-  /////////////////////////////////////////////////
-  double WavefieldSampler::ComputeDepth(
-    const Grid &patch,
-    const cgal::Point3 &point
-  )
-  {
-    // Calculate the depth
-    cgal::Direction3 direction(0, 0, 1);
-    cgal::Point3 wave_point = CGAL::ORIGIN;
-    std::array<Index, 3> index;
-    bool is_found = GridTools::FindIntersectionIndex(
-      patch, point.x(), point.y(), index);
-    if (!is_found)
-    {
-      // @DEBUG_INFO
-      gzerr << "point:  " << point << std::endl;
-      // patch.DebugPrint();
-      gzerr << "Water patch is too small" << std::endl;
-      return 0;
-    }
-    is_found = GridTools::FindIntersectionGrid(
-      patch, point, direction, index, wave_point);
-    if (!is_found)
-    {
-      // @DEBUG_INFO
-      gzerr << "point:  " << point << std::endl;
-      // patch.DebugPrint();
-      gzerr << "Water patch is too small" << std::endl;
-      return 0;
-    }
-    double h = wave_point.z() - point.z();
-    return h;
-  }
-
-  /////////////////////////////////////////////////
-  double WavefieldSampler::ComputeDepthDirectly(
-    const WaveParameters &wave_params,
-    const cgal::Point3 &point,
-    double time
-  )
-  {
-    // Struture for passing wave parameters to lambdas
-    struct WaveParams
-    {
-      WaveParams(
-        const std::vector<double>& _a,
-        const std::vector<double>& _k,
-        const std::vector<double>& _omega,
-        const std::vector<double>& _phi,
-        const std::vector<double>& _q,
-        const std::vector<gz::math::Vector2d>& _dir) :
-        a(_a), k(_k), omega(_omega), phi(_phi), q(_q), dir(_dir) {}
-
-      const std::vector<double>& a;
-      const std::vector<double>& k;
-      const std::vector<double>& omega;
-      const std::vector<double>& phi;
-      const std::vector<double>& q;
-      const std::vector<gz::math::Vector2d>& dir;
-    };
-
-    // Compute the target function and Jacobian. Also calculate pz,
-    // the z-componen of the Gerstner wave, which we essentially get for free.
-    auto wave_fdf = [=](auto x, auto p, auto t, auto& wp, auto& F, auto& J)
-    {
-      double pz = 0;
-      F(0) = p.x() - x.x();
-      F(1) = p.y() - x.y();
-      J(0, 0) = -1;
-      J(0, 1) =  0;
-      J(1, 0) =  0;
-      J(1, 1) = -1;
-      Index n = wp.a.size();
-      for (Index i=0; i<n; ++i)
-      {
-        const double dx = wp.dir[i].X();
-        const double dy = wp.dir[i].Y();
-        const double q = wp.q[i];
-        const double a = wp.a[i];
-        const double k = wp.k[i];
-        const double dot = x.x() * dx + x.y() * dy;
-        const double theta = k * dot - wp.omega[i] * t;
-        const double s = std::sin(theta);
-        const double c = std::cos(theta);
-        const double qakc = q * a * k * c;
-        const double df1x = qakc * dx * dx;
-        const double df1y = qakc * dx * dy;
-        const double df2x = df1y;
-        const double df2y = qakc * dy * dy;
-        pz += a * c;
-        F(0) += a * dx * s;
-        F(1) += a * dy * s;
-        J(0, 0) += df1x;
-        J(0, 1) += df1y;
-        J(1, 0) += df2x;
-        J(1, 1) += df2y;
-      }
-      return pz;
-    };
-
-    // Simple multi-variate Newton solver - this version returns the
-    // z-component of the wave field at the desired point p.
-    auto solver = [=](auto& fdfunc, auto x0, auto p, auto t,
-        auto& wp, auto tol, auto nmax)
-    {
-      Index n = 0;
-      double err = 1;
-      double pz = 0;
-      auto xn = x0;
-      Eigen::Vector2d F;
-      Eigen::Matrix2d J;
-      while (std::abs(err) > tol && n < nmax)
-      {
-        pz = fdfunc(x0, p, t, wp, F, J);
-        xn = x0 - J.inverse() * F;
-        x0 = xn;
-        err = F.norm();
-        n++;
-      }
-      return pz;
-    };
-
-    // Set up parameter references
-    WaveParams wp(
-      wave_params.Amplitude_V(),
-      wave_params.Wavenumber_V(),
-      wave_params.AngularFrequency_V(),
-      wave_params.Phase_V(),
-      wave_params.Steepness_V(),
-      wave_params.Direction_V()
-    );
-
-    // Tolerances etc.
-    const double tol = 1.0E-10;
-    const double nmax = 30;
-
-    // Use the target point as the initial guess (this is within
-    // sum{amplitudes} of the solution)
-    Eigen::Vector2d p2(point.x(), point.y());
-    const double pz = solver(wave_fdf, p2, p2, time, wp, tol, nmax);
-    const double h = pz - point.z();
-    return h;
-  }
-
-  /////////////////////////////////////////////////
+  // Use the target point as the initial guess (this is within
+  // sum{amplitudes} of the solution)
+  Eigen::Vector2d p2(point.x(), point.y());
+  const double pz = solver(wave_fdf, p2, p2, time, wp, tol, nmax);
+  const double h = pz - point.z();
+  return h;
 }
-}
+
+}  // namespace waves
+}  // namespace gz

--- a/gz-waves/src/Wavefield_TEST.cc
+++ b/gz-waves/src/Wavefield_TEST.cc
@@ -13,10 +13,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "gz/waves/CGALTypes.hh"
-#include "gz/waves/Types.hh"
-#include "gz/waves/Wavefield.hh"
-
 #include <Eigen/Dense>
 
 #include <gtest/gtest.h>
@@ -25,27 +21,33 @@
 #include <memory>
 #include <string>
 
-using namespace gz;
-using namespace waves;
+#include "gz/waves/CGALTypes.hh"
+#include "gz/waves/Types.hh"
+#include "gz/waves/Wavefield.hh"
 
-///////////////////////////////////////////////////////////////////////////////
+using gz::waves::Index;
+
+//////////////////////////////////////////////////
 // Utilities
 
-std::ostream& operator<<(std::ostream& os, const std::vector<double>& _vec)
-{ 
-  for (auto&& v : _vec )
+std::ostream& operator<<(std::ostream& os,
+    const std::vector<double>& vec)
+{
+  for (auto& v : vec)
     os << v << ", ";
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const std::vector<Eigen::Vector2d>& _vec)
-{ 
-  for (auto&& v : _vec )
+//////////////////////////////////////////////////
+std::ostream& operator<<(std::ostream& os,
+    const std::vector<Eigen::Vector2d>& vec)
+{
+  for (auto& v : vec)
     os << v.transpose() << ", ";
   return os;
 }
 
-///////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////
 // Define tests
 
 // One dimension, one wave component
@@ -61,7 +63,7 @@ TEST(Wavefield, WaveSolver1D)
 
   auto dispersion = [=](auto omega)
   {
-    return omega * omega / 9.8; 
+    return omega * omega / 9.8;
   };
 
   auto wave = [=](auto x, auto t, auto& wp)
@@ -93,7 +95,8 @@ TEST(Wavefield, WaveSolver1D)
     return df;
   };
 
-  auto solver = [=](auto& func, auto& dfunc, auto x0, auto p, auto t, auto& wp, auto tol, auto nmax)
+  auto solver = [=](auto& func, auto& dfunc, auto x0, auto p, auto t,
+      auto& wp, auto tol, auto nmax)
   {
     Index n = 0;
     double err = 1;
@@ -126,8 +129,8 @@ TEST(Wavefield, WaveSolver1D)
 
   const double tol = 1E-8;
   const double nmax = 20;
-  double x = solver(wave_f, wave_df, p, p, t, wp, tol, nmax); 
-  
+  double x = solver(wave_f, wave_df, p, p, t, wp, tol, nmax);
+
   const double eps = 1E-8;
   EXPECT_NEAR(wp.a, 3.0, eps);
   EXPECT_NEAR(wp.k, 0.251775622, eps);
@@ -148,6 +151,7 @@ TEST(Wavefield, WaveSolver1D)
   // std::cout << "x:      " << x << std::endl;
 }
 
+//////////////////////////////////////////////////
 // Two dimensions, one wave component
 TEST(Wavefield, WaveSolver2D)
 {
@@ -162,7 +166,7 @@ TEST(Wavefield, WaveSolver2D)
 
   auto dispersion = [=](auto omega)
   {
-    return omega * omega / 9.8; 
+    return omega * omega / 9.8;
   };
 
   auto wave = [=](auto x, auto t, auto& wp)
@@ -175,8 +179,7 @@ TEST(Wavefield, WaveSolver2D)
     const Eigen::Vector3d p(
       x.x() - wp.a * dx * s,
       x.y() - wp.a * dy * s,
-      wp.a * c
-    );
+      wp.a * c);
     return p;
   };
 
@@ -188,8 +191,7 @@ TEST(Wavefield, WaveSolver2D)
     const double dy = wp.dir.y();
     const Eigen::Vector2d f(
       p.x() - x.x() + wp.a * dx * s,
-      p.y() - x.y() + wp.a * dy * s
-    );
+      p.y() - x.y() + wp.a * dy * s);
     return f;
   };
 
@@ -212,7 +214,8 @@ TEST(Wavefield, WaveSolver2D)
     return J;
   };
 
-  auto solver = [=](auto& func, auto& dfunc, auto x0, auto p, auto t, auto& wp, auto tol, auto nmax)
+  auto solver = [=](auto& func, auto& dfunc, auto x0, auto p, auto t,
+      auto& wp, auto tol, auto nmax)
   {
     Index n = 0;
     double err = 1;
@@ -246,8 +249,8 @@ TEST(Wavefield, WaveSolver2D)
 
   const double tol = 1E-8;
   const double nmax = 20;
-  auto x = solver(wave_f, wave_df, p, p, t, wp, tol, nmax); 
-  
+  auto x = solver(wave_f, wave_df, p, p, t, wp, tol, nmax);
+
   const double eps = 1E-8;
   EXPECT_NEAR(wp.a, 3.0, eps);
   EXPECT_NEAR(wp.k, 0.251775622, eps);
@@ -271,6 +274,7 @@ TEST(Wavefield, WaveSolver2D)
   // std::cout << "x:      " << x.transpose() << std::endl;
 }
 
+//////////////////////////////////////////////////
 // Two dimensions, many wave components
 TEST(Wavefield, NWaveSolver2D)
 {
@@ -285,14 +289,14 @@ TEST(Wavefield, NWaveSolver2D)
 
   auto dispersion = [=](auto omega)
   {
-    return omega * omega / 9.8; 
+    return omega * omega / 9.8;
   };
 
   auto wave = [=](auto x, auto t, auto& wp)
   {
     Eigen::Vector3d p(x.x(), x.y(), 0.0);
     Index n = wp.a.size();
-    for (Index i=0; i<n; ++i)
+    for (Index i=0; i < n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -303,8 +307,7 @@ TEST(Wavefield, NWaveSolver2D)
       p += Eigen::Vector3d(
         - a * dx * s,
         - a * dy * s,
-        a * c
-      );
+        a * c);
     }
     return p;
   };
@@ -313,7 +316,7 @@ TEST(Wavefield, NWaveSolver2D)
   {
     Eigen::Vector2d f(p.x() - x.x(), p.y() - x.y());
     Index n = wp.a.size();
-    for (Index i=0; i<n; ++i)
+    for (Index i=0; i < n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -322,8 +325,7 @@ TEST(Wavefield, NWaveSolver2D)
       const double a = wp.a[i];
       f += Eigen::Vector2d(
         a * dx * s,
-        a * dy * s
-      );
+        a * dy * s);
     }
     return f;
   };
@@ -336,7 +338,7 @@ TEST(Wavefield, NWaveSolver2D)
     J(1, 0) =  0;
     J(1, 1) = -1;
     Index n = wp.a.size();
-    for (Index i=0; i<n; ++i)
+    for (Index i=0; i < n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double c = std::cos(theta);
@@ -351,11 +353,12 @@ TEST(Wavefield, NWaveSolver2D)
       J(0, 1) += df1y;
       J(1, 0) += df2x;
       J(1, 1) += df2y;
-    }    
+    }
     return J;
   };
 
-  auto solver = [=](auto& func, auto& dfunc, auto x0, auto p, auto t, auto& wp, auto tol, auto nmax)
+  auto solver = [=](auto& func, auto& dfunc, auto x0, auto p, auto t,
+      auto& wp, auto tol, auto nmax)
   {
     Index n = 0;
     double err = 1;
@@ -377,9 +380,11 @@ TEST(Wavefield, NWaveSolver2D)
   // wp.omega = { 2*M_PI/4.0, 2*M_PI, 2*M_PI };
   wp.a = { 1.0, 2.0, 3.0 };
   wp.omega = { 2*M_PI/50.0, 2*M_PI/10.0, 2*M_PI/20.0 };
-  wp.k = { dispersion(wp.omega[0]), dispersion(wp.omega[1]), dispersion(wp.omega[2]) };
+  wp.k = { dispersion(wp.omega[0]), dispersion(wp.omega[1]),
+      dispersion(wp.omega[2]) };
   wp.phi = { 0.0, 0.0, 0.0 };
-  wp.dir = { Eigen::Vector2d(1, 0), Eigen::Vector2d(1, 0), Eigen::Vector2d(1, 0) };
+  wp.dir = { Eigen::Vector2d(1, 0), Eigen::Vector2d(1, 0),
+      Eigen::Vector2d(1, 0) };
 
   double t = 0;
   Eigen::Vector2d x0(2.0, 3.0);
@@ -391,8 +396,8 @@ TEST(Wavefield, NWaveSolver2D)
 
   const double tol = 1E-8;
   const double nmax = 20;
-  auto x = solver(wave_f, wave_df, p, p, t, wp, tol, nmax); 
-  
+  auto x = solver(wave_f, wave_df, p, p, t, wp, tol, nmax);
+
   const double eps = 1E-8;
   EXPECT_DOUBLE_EQ(x0.x(), 2.0);
   EXPECT_DOUBLE_EQ(x0.y(), 3.0);
@@ -412,7 +417,9 @@ TEST(Wavefield, NWaveSolver2D)
   // std::cout << "x:      " << x.transpose() << std::endl;
 }
 
-// Two dimensions, many wave components, combined function and jacobian calculation
+//////////////////////////////////////////////////
+// Two dimensions, many wave components, combined function
+/// and jacobian calculation
 TEST(Wavefield, NWaveFdFSolver2D)
 {
   struct WaveParams
@@ -426,14 +433,14 @@ TEST(Wavefield, NWaveFdFSolver2D)
 
   auto dispersion = [=](auto omega)
   {
-    return omega * omega / 9.8; 
+    return omega * omega / 9.8;
   };
 
   auto wave = [=](auto x, auto t, auto& wp)
   {
     Eigen::Vector3d p(x.x(), x.y(), 0.0);
     Index n = wp.a.size();
-    for (Index i=0; i<n; ++i)
+    for (Index i=0; i < n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -444,8 +451,7 @@ TEST(Wavefield, NWaveFdFSolver2D)
       p += Eigen::Vector3d(
         - a * dx * s,
         - a * dy * s,
-        a * c
-      );
+        a * c);
     }
     return p;
   };
@@ -459,7 +465,7 @@ TEST(Wavefield, NWaveFdFSolver2D)
     J(1, 0) =  0;
     J(1, 1) = -1;
     Index n = wp.a.size();
-    for (Index i=0; i<n; ++i)
+    for (Index i=0; i < n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -478,10 +484,11 @@ TEST(Wavefield, NWaveFdFSolver2D)
       J(0, 1) += df1y;
       J(1, 0) += df2x;
       J(1, 1) += df2y;
-    }    
+    }
   };
 
-  auto solver = [=](auto& fdfunc, auto x0, auto p, auto t, auto& wp, auto tol, auto nmax)
+  auto solver = [=](auto& fdfunc, auto x0, auto p, auto t,
+      auto& wp, auto tol, auto nmax)
   {
     Index n = 0;
     double err = 1;
@@ -502,9 +509,11 @@ TEST(Wavefield, NWaveFdFSolver2D)
   WaveParams wp;
   wp.a = { 1.0, 2.0, 3.0 };
   wp.omega = { 2*M_PI/50.0, 2*M_PI/10.0, 2*M_PI/20.0 };
-  wp.k = { dispersion(wp.omega[0]), dispersion(wp.omega[1]), dispersion(wp.omega[2]) };
+  wp.k = { dispersion(wp.omega[0]), dispersion(wp.omega[1]),
+      dispersion(wp.omega[2]) };
   wp.phi = { 0.0, 0.0, 0.0 };
-  wp.dir = { Eigen::Vector2d(1, 0), Eigen::Vector2d(1, 0), Eigen::Vector2d(1, 0) };
+  wp.dir = { Eigen::Vector2d(1, 0), Eigen::Vector2d(1, 0),
+      Eigen::Vector2d(1, 0) };
 
   double t = 0;
   Eigen::Vector2d x0(2.0, 3.0);
@@ -517,8 +526,8 @@ TEST(Wavefield, NWaveFdFSolver2D)
 
   const double tol = 1E-8;
   const double nmax = 20;
-  auto x = solver(wave_fdf, p, p, t, wp, tol, nmax); 
-  
+  auto x = solver(wave_fdf, p, p, t, wp, tol, nmax);
+
   const double eps = 1E-8;
   EXPECT_DOUBLE_EQ(x0.x(), 2.0);
   EXPECT_DOUBLE_EQ(x0.y(), 3.0);
@@ -527,7 +536,7 @@ TEST(Wavefield, NWaveFdFSolver2D)
   EXPECT_LE(F.norm(), eps);
 }
 
-///////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////
 // Run tests
 
 int main(int argc, char **argv)

--- a/gz-waves/src/Wavefield_TEST.cc
+++ b/gz-waves/src/Wavefield_TEST.cc
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gz/waves/CGALTypes.hh"
+#include "gz/waves/Types.hh"
 #include "gz/waves/Wavefield.hh"
 
 #include <Eigen/Dense>
@@ -94,7 +95,7 @@ TEST(Wavefield, WaveSolver1D)
 
   auto solver = [=](auto& func, auto& dfunc, auto x0, auto p, auto t, auto& wp, auto tol, auto nmax)
   {
-    int n = 0;
+    Index n = 0;
     double err = 1;
     double xn = x0;
     while (std::abs(err) > tol && n < nmax)
@@ -213,7 +214,7 @@ TEST(Wavefield, WaveSolver2D)
 
   auto solver = [=](auto& func, auto& dfunc, auto x0, auto p, auto t, auto& wp, auto tol, auto nmax)
   {
-    int n = 0;
+    Index n = 0;
     double err = 1;
     auto xn = x0;
     while (std::abs(err) > tol && n < nmax)
@@ -290,8 +291,8 @@ TEST(Wavefield, NWaveSolver2D)
   auto wave = [=](auto x, auto t, auto& wp)
   {
     Eigen::Vector3d p(x.x(), x.y(), 0.0);
-    size_t n = wp.a.size();
-    for (size_t i=0; i<n; ++i)
+    Index n = wp.a.size();
+    for (Index i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -311,8 +312,8 @@ TEST(Wavefield, NWaveSolver2D)
   auto wave_f = [=](auto x, auto p, auto t, auto& wp)
   {
     Eigen::Vector2d f(p.x() - x.x(), p.y() - x.y());
-    size_t n = wp.a.size();
-    for (size_t i=0; i<n; ++i)
+    Index n = wp.a.size();
+    for (Index i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -334,8 +335,8 @@ TEST(Wavefield, NWaveSolver2D)
     J(0, 1) =  0;
     J(1, 0) =  0;
     J(1, 1) = -1;
-    size_t n = wp.a.size();
-    for (size_t i=0; i<n; ++i)
+    Index n = wp.a.size();
+    for (Index i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double c = std::cos(theta);
@@ -356,7 +357,7 @@ TEST(Wavefield, NWaveSolver2D)
 
   auto solver = [=](auto& func, auto& dfunc, auto x0, auto p, auto t, auto& wp, auto tol, auto nmax)
   {
-    int n = 0;
+    Index n = 0;
     double err = 1;
     auto xn = x0;
     while (std::abs(err) > tol && n < nmax)
@@ -431,8 +432,8 @@ TEST(Wavefield, NWaveFdFSolver2D)
   auto wave = [=](auto x, auto t, auto& wp)
   {
     Eigen::Vector3d p(x.x(), x.y(), 0.0);
-    size_t n = wp.a.size();
-    for (size_t i=0; i<n; ++i)
+    Index n = wp.a.size();
+    for (Index i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -457,8 +458,8 @@ TEST(Wavefield, NWaveFdFSolver2D)
     J(0, 1) =  0;
     J(1, 0) =  0;
     J(1, 1) = -1;
-    size_t n = wp.a.size();
-    for (size_t i=0; i<n; ++i)
+    Index n = wp.a.size();
+    for (Index i=0; i<n; ++i)
     {
       const double theta = wp.k[i] * x.dot(wp.dir[i])  - wp.omega[i] * t;
       const double s = std::sin(theta);
@@ -482,7 +483,7 @@ TEST(Wavefield, NWaveFdFSolver2D)
 
   auto solver = [=](auto& fdfunc, auto x0, auto p, auto t, auto& wp, auto tol, auto nmax)
   {
-    int n = 0;
+    Index n = 0;
     double err = 1;
     auto xn = x0;
     Eigen::Vector2d F;

--- a/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -20,6 +20,7 @@
 #include "gz/waves/Grid.hh"
 #include "gz/waves/MeshTools.hh"
 #include "gz/waves/Physics.hh"
+#include "gz/waves/Types.hh"
 #include "gz/waves/Utilities.hh"
 #include "gz/waves/Wavefield.hh"
 #include "gz/waves/WavefieldSampler.hh"
@@ -531,10 +532,10 @@ bool HydrodynamicsPrivate::InitPhysics(EntityComponentManager &_ecm)
       << ", meshes: " << meshes.size()
       << ", collisions: " << collisions.size() << "\n";
 
-  for (size_t i=0; i<links.size(); ++i)
+  for (waves::Index i=0; i<links.size(); ++i)
   {
     // Create storage
-    size_t meshCount = meshes[i].size();
+    waves::Index meshCount = meshes[i].size();
     std::shared_ptr<HydrodynamicsLinkData> hd(new HydrodynamicsLinkData);
     this->hydroData.push_back(hd);
     hd->initLinkMeshes.resize(meshCount);
@@ -618,7 +619,7 @@ bool HydrodynamicsPrivate::InitPhysics(EntityComponentManager &_ecm)
     //     hd->link.WorldCoGLinearVelocity(_ecm).value());
     // cgal::Vector3 linVelocityCoM = linVelocity;
 
-    for (size_t j=0; j<meshCount; ++j)
+    for (waves::Index j=0; j<meshCount; ++j)
     {
       // Mesh (SurfaceMesh copy performs a deep copy of all properties)
       std::shared_ptr<cgal::Mesh> initLinkMesh = meshes[i][j];
@@ -718,8 +719,8 @@ void HydrodynamicsPrivate::UpdatePhysics(const UpdateInfo &/*_info*/,
     // cgal::Vector3 linVelocityCoM = linVelocity;
 
     // Meshes
-    // size_t nSubTri = 0;
-    for (size_t j=0; j<hd->linkMeshes.size(); ++j)
+    // waves::Index nSubTri = 0;
+    for (waves::Index j=0; j<hd->linkMeshes.size(); ++j)
     {
       // Update link mesh
       auto linkCollision = hd->linkCollisions[j];
@@ -1064,7 +1065,7 @@ void HydrodynamicsPrivate::InitWaterPatchMarkers(
     1.0E9/this->updateRate);
 
   std::string modelName(this->model.Name(_ecm));
-  int markerId = 0;
+  waves::Index markerId = 0;
   for (auto&& hd : this->hydroData)
   {
     hd->waterPatchMsg.set_ns(modelName + "/water_patch");
@@ -1097,10 +1098,10 @@ void HydrodynamicsPrivate::InitWaterlineMarkers(
     1.0E9/this->updateRate);
 
   std::string modelName(this->model.Name(_ecm));
-  int markerId = 0;
+  waves::Index markerId = 0;
   for (auto&& hd : this->hydroData)
   {
-    for (size_t j=0; j<hd->linkMeshes.size(); ++j)
+    for (waves::Index j=0; j<hd->linkMeshes.size(); ++j)
     {
       hd->waterlineMsgs[j].set_ns(modelName + "/waterline");
       hd->waterlineMsgs[j].set_id(markerId++);
@@ -1133,10 +1134,10 @@ void HydrodynamicsPrivate::InitUnderwaterSurfaceMarkers(
     1.0E9/this->updateRate);
 
   std::string modelName(this->model.Name(_ecm));
-  int markerId = 0;
+  waves::Index markerId = 0;
   for (auto&& hd : this->hydroData)
   {
-    for (size_t j=0; j<hd->linkMeshes.size(); ++j)
+    for (waves::Index j=0; j<hd->linkMeshes.size(); ++j)
     {
       hd->underwaterSurfaceMsgs[j].set_ns(modelName + "/underwater_surface");
       hd->underwaterSurfaceMsgs[j].set_id(markerId++);
@@ -1214,11 +1215,11 @@ void HydrodynamicsPrivate::UpdateWaterPatchMarkers(
 
     // clear and update
     hd->waterPatchMsg.mutable_point()->Clear();
-    for (size_t ix=0; ix<grid.GetCellCount()[0]; ++ix)
+    for (waves::Index ix=0; ix<grid.GetCellCount()[0]; ++ix)
     {
-      for (size_t iy=0; iy<grid.GetCellCount()[1]; ++iy)
+      for (waves::Index iy=0; iy<grid.GetCellCount()[1]; ++iy)
       {
-        for (size_t k=0; k<2; ++k)
+        for (waves::Index k=0; k<2; ++k)
         {
           cgal::Triangle tri = grid.GetTriangle(ix, iy, k);
           gz::msgs::Set(hd->waterPatchMsg.add_point(), waves::ToGz(tri[0]));
@@ -1240,7 +1241,7 @@ void HydrodynamicsPrivate::UpdateWaterlineMarkers(
 
   for (auto&& hd : this->hydroData)
   {
-    for (size_t j=0; j<hd->linkMeshes.size(); ++j)
+    for (waves::Index j=0; j<hd->linkMeshes.size(); ++j)
     {
       hd->waterlineMsgs[j].mutable_point()->Clear();
       if (hd->hydrodynamics[j]->GetWaterline().empty())
@@ -1268,7 +1269,7 @@ void HydrodynamicsPrivate::UpdateUnderwaterSurfaceMarkers(
 
   for (auto&& hd : this->hydroData)
   {
-    for (size_t j=0; j<hd->linkMeshes.size(); ++j)
+    for (waves::Index j=0; j<hd->linkMeshes.size(); ++j)
     {
       hd->underwaterSurfaceMsgs[j].mutable_point()->Clear();
       if (hd->hydrodynamics[j]->GetSubmergedTriangles().empty())

--- a/gz-waves/src/systems/waves/WavesVisual.cc
+++ b/gz-waves/src/systems/waves/WavesVisual.cc
@@ -37,18 +37,16 @@
 #include "WavesVisual.hh"
 
 #include "DisplacementMap.hh"
-
 #include "OceanGeometry.hh"
 #include "OceanVisual.hh"
-#include "SceneNodeFactory.hh"
-
 #include "RenderEngineExtension.hh"
 #include "RenderEngineExtensionManager.hh"
+#include "SceneNodeFactory.hh"
 
 #include "gz/waves/OceanTile.hh"
+#include "gz/waves/Types.hh"
 #include "gz/waves/Utilities.hh"
 #include "gz/waves/WaveParameters.hh"
-
 #include "gz/waves/WaveSimulation.hh"
 #include "gz/waves/LinearRandomFFTWaveSimulation.hh"
 
@@ -585,7 +583,7 @@ void WavesVisualPrivate::OnUpdate()
   double simTime = this->currentSimTimeSeconds;
 
   // ocean tile parameters
-  // size_t N = this->waveParams->CellCount();
+  // waves::Index N = this->waveParams->CellCount();
   double L = this->waveParams->TileSize();
   double ux = this->waveParams->WindVelocity().X();
   double uy = this->waveParams->WindVelocity().Y();
@@ -629,9 +627,9 @@ void WavesVisualPrivate::OnUpdate()
 
         unsigned int objId = 50000;
         auto position = this->visual->LocalPosition();
-        for (int iy=this->tiles_y[0]; iy<=this->tiles_y[1]; ++iy)
+        for (waves::Index iy=this->tiles_y[0]; iy<=this->tiles_y[1]; ++iy)
         {
-          for (int ix=this->tiles_x[0]; ix<=this->tiles_x[1]; ++ix)
+          for (waves::Index ix=this->tiles_x[0]; ix<=this->tiles_x[1]; ++ix)
           {
             // tile position 
             gz::math::Vector3d tilePosition(
@@ -738,9 +736,9 @@ void WavesVisualPrivate::OnUpdate()
 
         // Water tiles: tiles_x[0], tiles_x[0] + 1, ..., tiles_x[1], etc.
         auto position = this->visual->LocalPosition();
-        for (int iy=this->tiles_y[0]; iy<=this->tiles_y[1]; ++iy)
+        for (waves::Index iy=this->tiles_y[0]; iy<=this->tiles_y[1]; ++iy)
         {
-          for (int ix=this->tiles_x[0]; ix<=this->tiles_x[1]; ++ix)
+          for (waves::Index ix=this->tiles_x[0]; ix<=this->tiles_x[1]; ++ix)
           {
             // tile position 
             gz::math::Vector3d tilePosition(
@@ -891,7 +889,7 @@ void WavesVisualPrivate::CreateShaderMaterial()
 //////////////////////////////////////////////////
 void WavesVisualPrivate::InitWaveSim()
 {
-  int N      = this->waveParams->CellCount();
+  waves::Index N = this->waveParams->CellCount();
   double L   = this->waveParams->TileSize();
   double ux  = this->waveParams->WindVelocity().X();
   double uy  = this->waveParams->WindVelocity().Y();
@@ -905,7 +903,7 @@ void WavesVisualPrivate::InitWaveSim()
   waveSim->SetWindVelocity(ux, uy);
   waveSim->SetLambda(s);
 
-  int N2 = N * N;
+  waves::Index N2 = N * N;
   this->mHeights = Eigen::ArrayXd::Zero(N2);
   this->mDisplacementsX = Eigen::ArrayXd::Zero(N2);
   this->mDisplacementsY = Eigen::ArrayXd::Zero(N2);


### PR DESCRIPTION
This PR adds a cpplint workflow and includes changes needed for the code in the core library to run clean.

## Details

The cpplint workflow is: 

```bash
.github/workflows/cpplint.yml
``` 

with a configuration file:

```
./CPPLINT.cfg
```

We set the following filters:

```bash
filter=-whitespace/braces,-runtime/references,-build/c++11,+build/c++14,-build/include_subdir
```

- `-whitespace/braces`: allow opening curly braces on following line after classes, conditionals etc.
- `-runtime/references`: allow pass-by-reference modifications (Google insists on using pointers).
- `-build/c++11,+build/c++14`: allow #include <threads>
- `-build/include_subdir`: unclear how to address this for headers in the `src` folder we don't want to export.

The CI covers the core libraries - the remaining files will be added to the coverage in follow up PRs.

There are a lot of changes in many files, however it is mostly formatting to comply with the linter.

- Rearranging includes
- Adjusting indentation (i.e. no-indent inside namespace).
- Stripping the per-method public, private declarations (i.e. not Gazebo style)
- 80 char line limits
- Removing trailing whitespace
