### PR TITLE
Style: apply cpplint to tests and plugins

### DIFF
--- a/.github/workflows/ccplint.yml
+++ b/.github/workflows/ccplint.yml
@@ -1,21 +1,9 @@
-# GitHub Action to run cpplint recursively on all pushes and pull requests
-# https://github.com/cpplint/GitHub-Action-for-cpplint
-
+# GitHub Action to run cpplint
+# 
 # The cpplint configuration file is:
-#
+# 
 #   ./CPPLINT.cfg
 #
-# Equivalent command line check:
-# 
-# 1. core library headers
-# 
-#   cpplint ./gz-waves/include/gz/waves/*.hh
-# 
-# 2. core library source
-# 
-#   cpplint ./gz-waves/src/*.cc ./gz-waves/src/*.hh
-# 
-
 name: Cpplint
 
 on: [push, pull_request]
@@ -34,7 +22,23 @@ jobs:
       - name: Install Cpplint
         run: |
           pip install cpplint
-      - name: Cpplint
+      - name: Cpplint Core Library
         run: |
           cpplint ./gz-waves/include/gz/waves/*.hh
           cpplint ./gz-waves/src/*.cc ./gz-waves/src/*.hh
+      - name: Cpplint Tests
+        run: |
+          cpplint ./gz-waves/test/performance/*.cc
+          cpplint ./gz-waves/test/plots/*.cc
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent ./gz-waves/include/gz/common/*.hh
+      - name: Cpplint Hydrodynamics Plugin
+        run: |
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard ./gz-waves/src/systems/hydrodynamics/*
+      - name: Cpplint DynamicGeometry Plugin
+        run: |
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard ./gz-waves/src/systems/dynamic/*
+      - name: Cpplint Waves Plugin
+        run: |
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard ./gz-waves/src/systems/waves/*.hh
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard,-whitespace/newline ./gz-waves/src/systems/waves/*.cc
+

--- a/gz-waves/include/gz/common/SubMeshWithTangents.hh
+++ b/gz-waves/include/gz/common/SubMeshWithTangents.hh
@@ -19,90 +19,92 @@
 #ifndef GZ_COMMON_SUBMESHWITHTANGENTS_HH_
 #define GZ_COMMON_SUBMESHWITHTANGENTS_HH_
 
-#include <gz/common/SubMesh.hh>
-#include <gz/math/Vector3.hh>
-#include <gz/utils/ImplPtr.hh>
-
 #include <memory>
 #include <string>
 #include <vector>
 
+#include <gz/common/SubMesh.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/utils/ImplPtr.hh>
+
 namespace gz
 {
-  namespace common
-  {
-    /// \brief A child mesh
-    class GZ_COMMON_GRAPHICS_VISIBLE SubMeshWithTangents : public SubMesh
-    {
-      /// \brief Constructor
-      public: SubMeshWithTangents();
+namespace common
+{
+/// \brief A child mesh
+class GZ_COMMON_GRAPHICS_VISIBLE SubMeshWithTangents : public SubMesh
+{
+  /// \brief Constructor
+  public: SubMeshWithTangents();
 
-      /// \brief Constructor
-      /// \param _name Name of the submesh.
-      public: explicit SubMeshWithTangents(const std::string &_name);
+  /// \brief Constructor
+  /// \param _name Name of the submesh.
+  public: explicit SubMeshWithTangents(const std::string &_name);
 
-      /// \brief Copy constructor
-      /// \param[in] _submesh SubMeshWithTangents to copy.
-      public: SubMeshWithTangents(const SubMeshWithTangents &_submesh);
+  /// \brief Copy constructor
+  /// \param[in] _submesh SubMeshWithTangents to copy.
+  public: SubMeshWithTangents(const SubMeshWithTangents &_submesh);
 
-      /// \brief Move constructor
-      /// \param[in] _collision SubMeshWithTangents to move.
-      public: SubMeshWithTangents(SubMeshWithTangents &&_submesh) noexcept;
+  /// \brief Move constructor
+  /// \param[in] _collision SubMeshWithTangents to move.
+  public: SubMeshWithTangents(SubMeshWithTangents &&_submesh) noexcept;
 
-      /// \brief Copy assignment operator.
-      /// \param[in] _submesh SubMeshWithTangents to copy.
-      /// \return Reference to this.
-      public: SubMeshWithTangents &operator=(const SubMeshWithTangents &_submesh);
+  /// \brief Copy assignment operator.
+  /// \param[in] _submesh SubMeshWithTangents to copy.
+  /// \return Reference to this.
+  public: SubMeshWithTangents &operator=(const SubMeshWithTangents &_submesh);
 
-      /// \brief Move assignment operator.
-      /// \param[in] _collision Collision component to move.
-      /// \return Reference to this.
-      public: SubMeshWithTangents &operator=(SubMeshWithTangents &&_submesh) noexcept;
+  /// \brief Move assignment operator.
+  /// \param[in] _collision Collision component to move.
+  /// \return Reference to this.
+  public: SubMeshWithTangents &operator=(
+      SubMeshWithTangents &&_submesh) noexcept;
 
-      /// \brief Destructor
-      public: virtual ~SubMeshWithTangents();
+  /// \brief Destructor
+  public: virtual ~SubMeshWithTangents();
 
-      /// \brief Add a tangent to the mesh
-      /// \param[in] _n The tangent
-      public: void AddTangent(const gz::math::Vector3d &_tangent);
+  /// \brief Add a tangent to the mesh
+  /// \param[in] _n The tangent
+  public: void AddTangent(const gz::math::Vector3d &_tangent);
 
-      /// \brief Add a tangent to the mesh
-      /// \param[in] _x Position along x
-      /// \param[in] _y Position along y
-      /// \param[in] _z Position along z
-      public: void AddTangent(const double _x, const double _y, const double _z);
+  /// \brief Add a tangent to the mesh
+  /// \param[in] _x Position along x
+  /// \param[in] _y Position along y
+  /// \param[in] _z Position along z
+  public: void AddTangent(const double _x, const double _y, const double _z);
 
-      /// \brief Get a tangent
-      /// \param[in] _index The tangent index
-      /// \return The tangent direction or gz::math::Vector3d::Zero
-      ///  if index is out of bounds.
-      /// \sa bool HasTangent(const unsigned int _index);
-      public: gz::math::Vector3d Tangent(const unsigned int _index) const;
+  /// \brief Get a tangent
+  /// \param[in] _index The tangent index
+  /// \return The tangent direction or gz::math::Vector3d::Zero
+  ///  if index is out of bounds.
+  /// \sa bool HasTangent(const unsigned int _index);
+  public: gz::math::Vector3d Tangent(const unsigned int _index) const;
 
-      /// \brief Set a tangent
-      /// \param[in] _index Index of the tangent that will be set.
-      /// \param[in] _n The new tangent direction
-      public: void SetTangent(const unsigned int _index,
-                  const gz::math::Vector3d &_tangent);
+  /// \brief Set a tangent
+  /// \param[in] _index Index of the tangent that will be set.
+  /// \param[in] _n The new tangent direction
+  public: void SetTangent(const unsigned int _index,
+      const gz::math::Vector3d &_tangent);
 
-      /// \brief Return the number of tangents
-      /// \return The number of tangents.
-      public: unsigned int TangentCount() const;
+  /// \brief Return the number of tangents
+  /// \return The number of tangents.
+  public: unsigned int TangentCount() const;
 
-      /// \brief Return true if this submesh has the tangent with the given
-      /// index
-      /// \param[in] _index Tangent index
-      /// \return Return true if this submesh has the tangent with the given
-      /// _index.
-      public: bool HasTangent(const unsigned int _index) const;
+  /// \brief Return true if this submesh has the tangent with the given
+  /// index
+  /// \param[in] _index Tangent index
+  /// \return Return true if this submesh has the tangent with the given
+  /// _index.
+  public: bool HasTangent(const unsigned int _index) const;
 
-      /// \brief Recalculate all the tangents.
-      public: void RecalculateTangents();
+  /// \brief Recalculate all the tangents.
+  public: void RecalculateTangents();
 
-      /// \brief Private data pointer.
-      GZ_UTILS_IMPL_PTR(dataPtr)
-    };
-  }
-}
+  /// \brief Private data pointer.
+  GZ_UTILS_IMPL_PTR(dataPtr)
+};
 
-#endif
+}  // namespace common
+}  // namespace gz
+
+#endif  // GZ_COMMON_SUBMESHWITHTANGENTS_HH_

--- a/gz-waves/src/systems/dynamic/DynamicGeometry.cc
+++ b/gz-waves/src/systems/dynamic/DynamicGeometry.cc
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// The DynamicGeometry example is sourced from the Ogre2 Samples 
+// The DynamicGeometry example is sourced from the Ogre2 Samples
 
 // OGRE (www.ogre3d.org) is made available under the MIT License.
 //
@@ -39,6 +39,22 @@
 
 #include "DynamicGeometry.hh"
 
+// Ogre2
+#include <OgreItem.h>
+#include <OgreMesh2.h>
+#include <OgreMeshManager2.h>
+#include <OgreSceneManager.h>
+#include <OgreSubMesh2.h>
+#include <Vao/OgreVaoManager.h>
+// Ogre2
+
+#include <chrono>
+#include <list>
+#include <mutex>
+#include <utility>
+#include <vector>
+#include <string>
+
 #include <gz/common/Profiler.hh>
 #include <gz/plugin/Register.hh>
 #include <gz/rendering/Material.hh>
@@ -61,241 +77,231 @@
 
 #include <sdf/Element.hh>
 
-// Ogre2
-#include <OgreItem.h>
-#include <OgreMesh2.h>
-#include <OgreMeshManager2.h>
-#include <OgreSceneManager.h>
-#include <OgreSubMesh2.h>
-#include <Vao/OgreVaoManager.h>
-// Ogre2
-
-#include <chrono>
-#include <list>
-#include <mutex>
-#include <vector>
-#include <string>
-
 namespace gz
 {
 namespace rendering
 {
 inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-  //////////////////////////////////////////////////
+//////////////////////////////////////////////////
 
-  // Subclass from Ogre2Mesh and Ogre2MeshFactory to get
-  // indirect access to protected members and override any
-  // behaviour that tries to load a gz::common::Mesh which we
-  // are not using.
+// Subclass from Ogre2Mesh and Ogre2MeshFactory to get
+// indirect access to protected members and override any
+// behaviour that tries to load a gz::common::Mesh which we
+// are not using.
 
-  //////////////////////////////////////////////////
-  class GZ_RENDERING_OGRE2_VISIBLE Ogre2MeshExt :
-      public Ogre2Mesh
-  {
-    /// \brief Destructor
-    public: virtual ~Ogre2MeshExt() {}
-
-    /// \brief Constructor
-    protected: explicit Ogre2MeshExt() : Ogre2Mesh() {}
-
-    /// \brief Allow intercept of pre-render call for this mesh
-    public: virtual void PreRender() override
-    {
-      Ogre2Mesh::PreRender();
-    }
-
-    /// \brief Work-around the protected accessors and protected methods in Scene
-    public: void InitObject(Ogre2ScenePtr _scene, unsigned int _id, const std::string &_name)
-    {
-      this->id = _id;
-      this->name = _name;
-      this->scene = _scene;
-
-      // initialize object
-      this->Load();
-      this->Init();
-    }
-
-    /// \brief Used by friend class (Ogre2MeshFactoryExt)
-    protected: void SetOgreItem(Ogre::Item *_ogreItem)
-    {
-      this->ogreItem = _ogreItem;
-    }
-
-    private: friend class Ogre2MeshFactoryExt;
-  };
-
-  typedef std::shared_ptr<Ogre2MeshExt> Ogre2MeshExtPtr;
-
-  //////////////////////////////////////////////////
-  class GZ_RENDERING_OGRE2_VISIBLE Ogre2MeshFactoryExt :
-      public Ogre2MeshFactory
-  {
-    /// \brief Destructor
-    public: virtual ~Ogre2MeshFactoryExt() {}
-
-    /// \brief Constructor - construct from an Ogre2ScenePtr
-    public: explicit Ogre2MeshFactoryExt(Ogre2ScenePtr _scene) :
-        Ogre2MeshFactory(_scene), ogre2Scene(_scene) {}
-
-    /// \brief Override - use an extension of Ogre2Mesh
-    public: virtual Ogre2MeshPtr Create(const MeshDescriptor &_desc) override
-    {
-      // create ogre entity
-      Ogre2MeshExtPtr mesh(new Ogre2MeshExt);
-      MeshDescriptor normDesc = _desc;
-      // \todo do this? override MeshDescriptor behaviour as we're not using gz::common::Mesh
-      normDesc.Load();
-      mesh->SetOgreItem(this->OgreItem(normDesc));
-
-      // check if invalid mesh
-      if (!mesh->ogreItem)
-      {
-        gzerr << "Failed to get Ogre item for [" << _desc.meshName << "]"
-                << std::endl;
-        return nullptr;
-      }
-
-      // create sub-mesh store
-      Ogre2SubMeshStoreFactory subMeshFactory(this->scene, mesh->ogreItem);
-      mesh->subMeshes = subMeshFactory.Create();
-      for (unsigned int i = 0; i < mesh->subMeshes->Size(); i++)
-      {
-        Ogre2SubMeshPtr submesh =
-            std::dynamic_pointer_cast<Ogre2SubMesh>(mesh->subMeshes->GetById(i));
-        submesh->SetMeshName(this->MeshName(_desc));
-      }
-      return mesh;
-    }
-
-    /// \brief Override \todo: may be able to use base class implementation...
-    protected: virtual Ogre::Item * OgreItem(const MeshDescriptor &_desc) override
-    {
-      if (!this->Load(_desc))
-      {
-        return nullptr;
-      }
-
-      std::string name = this->MeshName(_desc);
-      gzmsg << "Get Ogre::SceneManager\n";
-      Ogre::SceneManager *sceneManager = this->scene->OgreSceneManager();
-
-      gzmsg << "Check for v2 mesh\n";
-      // check if a v2 mesh already exists
-      Ogre::MeshPtr mesh =
-          Ogre::MeshManager::getSingleton().getByName(name);
-
-      // if not, it probably has not been imported from v1 yet
-      if (!mesh)
-      {
-        gzmsg << "Check for v1 mesh\n";
-        Ogre::v1::MeshPtr v1Mesh =
-            Ogre::v1::MeshManager::getSingleton().getByName(name);
-        if (!v1Mesh)
-        {
-          gzerr << "Did not find v1 mesh [" << name << "]\n";
-          return nullptr;
-        }
-
-        // examine v1 mesh properties
-        v1Mesh->load();
-        gzmsg << "v1 mesh: isLoaded: " << v1Mesh->isLoaded() << "\n";
-
-        gzmsg << "Creating v2 mesh\n";
-        // create v2 mesh from v1
-        mesh = Ogre::MeshManager::getSingleton().createManual(
-            name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-
-        gzmsg << "Importing v2 mesh\n";
-        mesh->importV1(v1Mesh.get(), false, true, true);
-        this->ogreMeshes.push_back(name);
-      }
-      else
-      {
-        gzmsg << "Found v2 mesh\n";
-      }
-
-      return sceneManager->createItem(mesh, Ogre::SCENE_DYNAMIC);
-    }
-
-    /// \brief Override
-    protected: virtual bool LoadImpl(const MeshDescriptor &/*_desc*/) override
-    {
-      /// \todo: currently assume we've already loaded from the tile
-      /// but should handle better
-      return true;
-    }
-
-    /// \brief Override \todo: may be able to use base class implementation...
-    public: virtual bool Validate(const MeshDescriptor &_desc) override
-    {
-      if (!_desc.mesh && _desc.meshName.empty())
-      {
-        gzerr << "Invalid mesh-descriptor, no mesh specified" << std::endl;
-        return false;
-      }
-
-      if (!_desc.mesh)
-      {
-        gzerr << "Cannot load null mesh [" << _desc.meshName << "]" << std::endl;
-        return false;
-        // Override MeshDescriptor behaviour as we're not using gz::common::Mesh
-        // return true;
-      }
-
-      if (_desc.mesh->SubMeshCount() == 0)
-      {
-        gzerr << "Cannot load mesh with zero sub-meshes" << std::endl;
-        return false;
-      }
-
-      return true;
-    }
-
-    /// \brief Pointer to the derived Ogre2Scene
-    private: rendering::Ogre2ScenePtr ogre2Scene;
-
-  };
-
-  typedef std::shared_ptr<Ogre2MeshFactoryExt> Ogre2MeshFactoryExtPtr;
-}
-}
-}
-
-using namespace gz;
-using namespace sim;
-using namespace systems;
-
-// From ogre-next/Samples/2.0/ApiUsage/DynamicGeometry/DynamicGeometryGameState.h/cpp
-
-struct gz::sim::systems::CubeVertices
+//////////////////////////////////////////////////
+class GZ_RENDERING_OGRE2_VISIBLE Ogre2MeshExt :
+    public Ogre2Mesh
 {
-    float px, py, pz;   //Position
-    float nx, ny, nz;   //Normals
+  /// \brief Destructor
+  public: virtual ~Ogre2MeshExt() {}
+
+  /// \brief Constructor
+  protected: explicit Ogre2MeshExt() : Ogre2Mesh() {}
+
+  /// \brief Allow intercept of pre-render call for this mesh
+  public: virtual void PreRender() override
+  {
+    Ogre2Mesh::PreRender();
+  }
+
+  /// \brief Work-around the protected accessors and protected methods in Scene
+  public: void InitObject(Ogre2ScenePtr _scene, unsigned int _id,
+      const std::string &_name)
+  {
+    this->id = _id;
+    this->name = _name;
+    this->scene = _scene;
+
+    // initialize object
+    this->Load();
+    this->Init();
+  }
+
+  /// \brief Used by friend class (Ogre2MeshFactoryExt)
+  protected: void SetOgreItem(Ogre::Item *_ogreItem)
+  {
+    this->ogreItem = _ogreItem;
+  }
+
+  private: friend class Ogre2MeshFactoryExt;
+};
+
+typedef std::shared_ptr<Ogre2MeshExt> Ogre2MeshExtPtr;
+
+//////////////////////////////////////////////////
+class GZ_RENDERING_OGRE2_VISIBLE Ogre2MeshFactoryExt :
+    public Ogre2MeshFactory
+{
+  /// \brief Destructor
+  public: virtual ~Ogre2MeshFactoryExt() {}
+
+  /// \brief Constructor - construct from an Ogre2ScenePtr
+  public: explicit Ogre2MeshFactoryExt(Ogre2ScenePtr _scene) :
+      Ogre2MeshFactory(_scene), ogre2Scene(_scene) {}
+
+  /// \brief Override - use an extension of Ogre2Mesh
+  public: virtual Ogre2MeshPtr Create(const MeshDescriptor &_desc) override
+  {
+    // create ogre entity
+    Ogre2MeshExtPtr mesh(new Ogre2MeshExt);
+    MeshDescriptor normDesc = _desc;
+    /// \todo do this? override MeshDescriptor behaviour as we're
+    ///       not using gz::common::Mesh
+    normDesc.Load();
+    mesh->SetOgreItem(this->OgreItem(normDesc));
+
+    // check if invalid mesh
+    if (!mesh->ogreItem)
+    {
+      gzerr << "Failed to get Ogre item for [" << _desc.meshName << "]"
+              << std::endl;
+      return nullptr;
+    }
+
+    // create sub-mesh store
+    Ogre2SubMeshStoreFactory subMeshFactory(this->scene, mesh->ogreItem);
+    mesh->subMeshes = subMeshFactory.Create();
+    for (unsigned int i = 0; i < mesh->subMeshes->Size(); i++)
+    {
+      Ogre2SubMeshPtr submesh =
+          std::dynamic_pointer_cast<Ogre2SubMesh>(mesh->subMeshes->GetById(i));
+      submesh->SetMeshName(this->MeshName(_desc));
+    }
+    return mesh;
+  }
+
+  /// \brief Override \todo: may be able to use base class implementation...
+  protected: virtual Ogre::Item * OgreItem(const MeshDescriptor &_desc) override
+  {
+    if (!this->Load(_desc))
+    {
+      return nullptr;
+    }
+
+    std::string name = this->MeshName(_desc);
+    gzmsg << "Get Ogre::SceneManager\n";
+    Ogre::SceneManager *sceneManager = this->scene->OgreSceneManager();
+
+    gzmsg << "Check for v2 mesh\n";
+    // check if a v2 mesh already exists
+    Ogre::MeshPtr mesh =
+        Ogre::MeshManager::getSingleton().getByName(name);
+
+    // if not, it probably has not been imported from v1 yet
+    if (!mesh)
+    {
+      gzmsg << "Check for v1 mesh\n";
+      Ogre::v1::MeshPtr v1Mesh =
+          Ogre::v1::MeshManager::getSingleton().getByName(name);
+      if (!v1Mesh)
+      {
+        gzerr << "Did not find v1 mesh [" << name << "]\n";
+        return nullptr;
+      }
+
+      // examine v1 mesh properties
+      v1Mesh->load();
+      gzmsg << "v1 mesh: isLoaded: " << v1Mesh->isLoaded() << "\n";
+
+      gzmsg << "Creating v2 mesh\n";
+      // create v2 mesh from v1
+      mesh = Ogre::MeshManager::getSingleton().createManual(
+          name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+      gzmsg << "Importing v2 mesh\n";
+      mesh->importV1(v1Mesh.get(), false, true, true);
+      this->ogreMeshes.push_back(name);
+    } else {
+      gzmsg << "Found v2 mesh\n";
+    }
+
+    return sceneManager->createItem(mesh, Ogre::SCENE_DYNAMIC);
+  }
+
+  /// \brief Override
+  protected: virtual bool LoadImpl(const MeshDescriptor &/*_desc*/) override
+  {
+    /// \todo: currently assume we've already loaded from the tile
+    /// but should handle better
+    return true;
+  }
+
+  /// \brief Override \todo: may be able to use base class implementation...
+  public: virtual bool Validate(const MeshDescriptor &_desc) override
+  {
+    if (!_desc.mesh && _desc.meshName.empty())
+    {
+      gzerr << "Invalid mesh-descriptor, no mesh specified" << std::endl;
+      return false;
+    }
+
+    if (!_desc.mesh)
+    {
+      gzerr << "Cannot load null mesh [" << _desc.meshName << "]" << std::endl;
+      return false;
+      // Override MeshDescriptor behaviour as we're not using gz::common::Mesh
+      // return true;
+    }
+
+    if (_desc.mesh->SubMeshCount() == 0)
+    {
+      gzerr << "Cannot load mesh with zero sub-meshes" << std::endl;
+      return false;
+    }
+
+    return true;
+  }
+
+  /// \brief Pointer to the derived Ogre2Scene
+  private: rendering::Ogre2ScenePtr ogre2Scene;
+
+};
+
+typedef std::shared_ptr<Ogre2MeshFactoryExt> Ogre2MeshFactoryExtPtr;
+
+}
+}  // namespace rendering
+}  // namespace gz
+
+namespace gz
+{
+namespace sim
+{
+namespace systems
+{
+
+// From ogre-next:
+// Samples/2.0/ApiUsage/DynamicGeometry/DynamicGeometryGameState.h/cpp
+
+struct CubeVertices
+{
+    float px, py, pz;   // Position
+    float nx, ny, nz;   // Normals
 
     CubeVertices() {}
-    CubeVertices( float _px, float _py, float _pz,
-                  float _nx, float _ny, float _nz ) :
-        px( _px ), py( _py ), pz( _pz ),
-        nx( _nx ), ny( _ny ), nz( _nz )
+    CubeVertices(float _px, float _py, float _pz,
+                 float _nx, float _ny, float _nz) :
+        px(_px), py(_py), pz(_pz),
+        nx(_nx), ny(_ny), nz(_nz)
     {
     }
 };
 
 const CubeVertices c_originalVertices[8] =
 {
-    CubeVertices( -1, -1,  1, -0.57737, -0.57737,  0.57737 ),
-    CubeVertices(  1, -1,  1,  0.57737, -0.57737,  0.57737 ),
-    CubeVertices(  1,  1,  1,  0.57737,  0.57737,  0.57737 ),
-    CubeVertices( -1,  1,  1, -0.57737,  0.57737,  0.57737 ),
-    CubeVertices( -1, -1, -1, -0.57737, -0.57737, -0.57737 ),
-    CubeVertices(  1, -1, -1,  0.57737, -0.57737, -0.57737 ),
-    CubeVertices(  1,  1, -1,  0.57737,  0.57737, -0.57737 ),
-    CubeVertices( -1,  1, -1, -0.57737,  0.57737, -0.57737 )
+    CubeVertices(-1, -1,  1, -0.57737, -0.57737,  0.57737),
+    CubeVertices(1, -1,  1,  0.57737, -0.57737,  0.57737),
+    CubeVertices(1,  1,  1,  0.57737,  0.57737,  0.57737),
+    CubeVertices(-1,  1,  1, -0.57737,  0.57737,  0.57737),
+    CubeVertices(-1, -1, -1, -0.57737, -0.57737, -0.57737),
+    CubeVertices(1, -1, -1,  0.57737, -0.57737, -0.57737),
+    CubeVertices(1,  1, -1,  0.57737,  0.57737, -0.57737),
+    CubeVertices(-1,  1, -1, -0.57737,  0.57737, -0.57737)
 };
 
-class gz::sim::systems::DynamicGeometryPrivate
+class DynamicGeometryPrivate
 {
   /// \brief Path to the model
   public: std::string modelPath;
@@ -331,14 +337,15 @@ class gz::sim::systems::DynamicGeometryPrivate
   public: void OnUpdate();
 
   ///////////////// OGRE SAMPLE
-  // From ogre-next/Samples/2.0/ApiUsage/DynamicGeometry/DynamicGeometryGameState.h/cpp
+  // From ogre-next
+  // Samples/2.0/ApiUsage/DynamicGeometry/DynamicGeometryGameState.h/cpp
   Ogre::MeshPtr               mStaticMesh;
   Ogre::MeshPtr               mPartialMesh;
   Ogre::MeshPtr               mDynamicMesh[2];
   Ogre::VertexBufferPacked    *mDynamicVertexBuffer[2];
 
   float mRotationTime;
-  
+
   /// Helper function to retrieve the render system
   Ogre::RenderSystem * RenderSystem() const;
 
@@ -349,7 +356,8 @@ class gz::sim::systems::DynamicGeometryPrivate
   Ogre::MeshPtr CreateStaticMesh(bool partialMesh);
 
   /// Creates a dynamic buffer. The idx parameter is needed for the mesh' name
-  std::pair<Ogre::MeshPtr, Ogre::VertexBufferPacked*> CreateDynamicMesh(size_t idx);
+  std::pair<Ogre::MeshPtr, Ogre::VertexBufferPacked*>
+  CreateDynamicMesh(size_t idx);
 
   /// Helper function to fill the 2nd dynamic vertex buffer
   void UpdateDynamicBuffer01(float *cubeVertices,
@@ -359,7 +367,7 @@ class gz::sim::systems::DynamicGeometryPrivate
   void Update(float simTime);
 
   void CreateScene01(void);
-  
+
   void DestroyScene();
   ///////////////// OGRE SAMPLE
 };
@@ -389,7 +397,7 @@ void DynamicGeometry::Configure(const Entity &_entity,
   // function and _sdf is a const shared pointer to a const sdf::Element.
   // auto sdf = const_cast<sdf::Element *>(_sdf.get());
 
-  // capture entity 
+  // capture entity
   this->dataPtr->entity = _entity;
   auto nameComp = _ecm.Component<components::Name>(_entity);
   this->dataPtr->visualName = nameComp->Data();
@@ -478,14 +486,14 @@ Ogre::IndexBufferPacked* DynamicGeometryPrivate::CreateIndexBuffer(void)
 
   const Ogre::uint16 c_indexData[3 * 2 * 6] =
   {
-      0, 1, 2, 2, 3, 0, //Front face
-      6, 5, 4, 4, 7, 6, //Back face
+      0, 1, 2, 2, 3, 0,  // Front face
+      6, 5, 4, 4, 7, 6,  // Back face
 
-      3, 2, 6, 6, 7, 3, //Top face
-      5, 1, 0, 0, 4, 5, //Bottom face
+      3, 2, 6, 6, 7, 3,  // Top face
+      5, 1, 0, 0, 4, 5,  // Bottom face
 
-      4, 0, 3, 3, 7, 4, //Left face
-      6, 2, 1, 1, 5, 6, //Right face
+      4, 0, 3, 3, 7, 4,  // Left face
+      6, 2, 1, 1, 5, 6,  // Right face
   };
 
   Ogre::uint16 *cubeIndices = reinterpret_cast<Ogre::uint16*>(
@@ -510,13 +518,15 @@ Ogre::IndexBufferPacked* DynamicGeometryPrivate::CreateIndexBuffer(void)
   }
   catch(Ogre::Exception &e)
   {
-      // When keepAsShadow = true, the memory will be freed when the index buffer is destroyed.
-      // However if for some weird reason there is an exception raised, the memory will
-      // not be freed, so it is up to us to do so.
-      // The reasons for exceptions are very rare. But we're doing this for correctness.
-      // Important: Please note that we passed keepAsShadow = true to createIndexBuffer,
-      // thus Ogre will free the pointer. However had we passed keepAsShadow = false,
-      // it would be YOUR responsability to free the pointer, not Ogre's
+      // When keepAsShadow = true, the memory will be freed when the
+      // index buffer is destroyed.  However if for some weird reason there
+      // is an exception raised, the memory will not be freed, so it is up
+      // to us to do so. The reasons for exceptions are very rare. But we're
+      // doing this for correctness.
+      // Important: Please note that we passed keepAsShadow = true to
+      // createIndexBuffer, thus Ogre will free the pointer. However had we
+      // passed keepAsShadow = false, it would be YOUR responsability to free
+      // the pointer, not Ogre's
       OGRE_FREE_SIMD(indexBuffer, Ogre::MEMCATEGORY_GEOMETRY);
       indexBuffer = 0;
       throw e;
@@ -533,67 +543,76 @@ Ogre::MeshPtr DynamicGeometryPrivate::CreateStaticMesh(bool partialMesh)
   Ogre::RenderSystem *renderSystem = this->RenderSystem();
   Ogre::VaoManager *vaoManager = renderSystem->getVaoManager();
 
-  //Create the mesh
+  // Create the mesh
   Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(
               partialMesh ? "My PartialMesh" : "My StaticMesh",
-              Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+              Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 
-  //Create one submesh
+  // Create one submesh
   Ogre::SubMesh *subMesh = mesh->createSubMesh();
 
-  //Vertex declaration
+  // Vertex declaration
   Ogre::VertexElement2Vec vertexElements;
-  vertexElements.push_back( Ogre::VertexElement2( Ogre::VET_FLOAT3, Ogre::VES_POSITION ) );
-  vertexElements.push_back( Ogre::VertexElement2( Ogre::VET_FLOAT3, Ogre::VES_NORMAL ) );
+  vertexElements.push_back(Ogre::VertexElement2(
+      Ogre::VET_FLOAT3, Ogre::VES_POSITION));
+  vertexElements.push_back(Ogre::VertexElement2(
+      Ogre::VET_FLOAT3, Ogre::VES_NORMAL));
 
-  //For immutable buffers, it is mandatory that cubeVertices is not a null pointer.
-  CubeVertices *cubeVertices = reinterpret_cast<CubeVertices*>( OGRE_MALLOC_SIMD(
-                                                                    sizeof(CubeVertices) * 8,
-                                                                    Ogre::MEMCATEGORY_GEOMETRY ) );
-  //Fill the data.
-  memcpy( cubeVertices, c_originalVertices, sizeof(CubeVertices) * 8 );
+  // For immutable buffers, it is mandatory that cubeVertices
+  // is not a null pointer.
+  CubeVertices *cubeVertices = reinterpret_cast<CubeVertices*>(
+      OGRE_MALLOC_SIMD(sizeof(CubeVertices) * 8, Ogre::MEMCATEGORY_GEOMETRY));
+  // Fill the data.
+  memcpy(cubeVertices, c_originalVertices, sizeof(CubeVertices) * 8);
 
   Ogre::VertexBufferPacked *vertexBuffer = 0;
   try
   {
-      //Create the actual vertex buffer.
-      vertexBuffer = vaoManager->createVertexBuffer( vertexElements, 8,
-                                                      partialMesh ? Ogre::BT_DEFAULT :
-                                                                    Ogre::BT_IMMUTABLE,
-                                                      cubeVertices, true );
+      // Create the actual vertex buffer.
+      vertexBuffer = vaoManager->createVertexBuffer(
+          vertexElements, 8,
+          partialMesh ? Ogre::BT_DEFAULT :
+              Ogre::BT_IMMUTABLE,
+          cubeVertices, true);
   }
-  catch( Ogre::Exception &e )
+  catch(Ogre::Exception &e)
   {
-      // Important: Please note that we passed keepAsShadow = true to createVertexBuffer,
-      // thus Ogre will free the pointer. However had we passed keepAsShadow = false,
-      // it would be YOUR responsability to free the pointer, not Ogre's
-      OGRE_FREE_SIMD( vertexBuffer, Ogre::MEMCATEGORY_GEOMETRY );
+      // Important: Please note that we passed keepAsShadow = true
+      // to createVertexBuffer, thus Ogre will free the pointer.
+      // However had we passed keepAsShadow = false, it would be YOUR
+      // responsability to free the pointer, not Ogre's
+      OGRE_FREE_SIMD(vertexBuffer, Ogre::MEMCATEGORY_GEOMETRY);
       vertexBuffer = 0;
       throw e;
   }
 
-  //Now the Vao. We'll just use one vertex buffer source (multi-source not working yet)
+  // Now the Vao. We'll just use one vertex buffer source
+  // (multi-source not working yet)
   Ogre::VertexBufferPackedVec vertexBuffers;
-  vertexBuffers.push_back( vertexBuffer );
-  Ogre::IndexBufferPacked *indexBuffer = this->CreateIndexBuffer(); //Create the actual index buffer
+  vertexBuffers.push_back(vertexBuffer);
+  // Create the actual index buffer
+  Ogre::IndexBufferPacked *indexBuffer = this->CreateIndexBuffer();
   Ogre::VertexArrayObject *vao = vaoManager->createVertexArrayObject(
-              vertexBuffers, indexBuffer, Ogre::OT_TRIANGLE_LIST );
+      vertexBuffers, indexBuffer, Ogre::OT_TRIANGLE_LIST);
 
-  //Each Vao pushed to the vector refers to an LOD level.
-  //Must be in sync with mesh->mLodValues & mesh->mNumLods if you use more than one level
-  subMesh->mVao[Ogre::VpNormal].push_back( vao );
-  //Use the same geometry for shadow casting.
-  subMesh->mVao[Ogre::VpShadow].push_back( vao );
+  // Each Vao pushed to the vector refers to an LOD level.
+  // Must be in sync with mesh->mLodValues & mesh->mNumLods
+  // if you use more than one level
+  subMesh->mVao[Ogre::VpNormal].push_back(vao);
+  // Use the same geometry for shadow casting.
+  subMesh->mVao[Ogre::VpShadow].push_back(vao);
 
-  //Set the bounds to get frustum culling and LOD to work correctly.
-  mesh->_setBounds( Ogre::Aabb( Ogre::Vector3::ZERO, Ogre::Vector3::UNIT_SCALE ), false );
-  mesh->_setBoundingSphereRadius( 1.732f );
+  // Set the bounds to get frustum culling and LOD to work correctly.
+  mesh->_setBounds(Ogre::Aabb(Ogre::Vector3::ZERO,
+      Ogre::Vector3::UNIT_SCALE), false);
+  mesh->_setBoundingSphereRadius(1.732f);
 
   return mesh;
 }
 
 //////////////////////////////////////////////////
-std::pair<Ogre::MeshPtr, Ogre::VertexBufferPacked*> DynamicGeometryPrivate::CreateDynamicMesh(size_t idx)
+std::pair<Ogre::MeshPtr, Ogre::VertexBufferPacked*>
+DynamicGeometryPrivate::CreateDynamicMesh(size_t idx)
 {
   // Ogre::Root *root = mGraphicsSystem->getRoot();
   // Ogre::RenderSystem *renderSystem = root->getRenderSystem();
@@ -602,39 +621,45 @@ std::pair<Ogre::MeshPtr, Ogre::VertexBufferPacked*> DynamicGeometryPrivate::Crea
 
   Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(
               "My DynamicMesh_" + Ogre::StringConverter::toString(idx),
-              Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+              Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 
   Ogre::SubMesh *subMesh = mesh->createSubMesh();
 
   Ogre::VertexElement2Vec vertexElements;
-  vertexElements.push_back( Ogre::VertexElement2( Ogre::VET_FLOAT3, Ogre::VES_POSITION ) );
-  vertexElements.push_back( Ogre::VertexElement2( Ogre::VET_FLOAT3, Ogre::VES_NORMAL ) );
+  vertexElements.push_back(Ogre::VertexElement2(
+      Ogre::VET_FLOAT3, Ogre::VES_POSITION));
+  vertexElements.push_back(Ogre::VertexElement2(
+      Ogre::VET_FLOAT3, Ogre::VES_NORMAL));
 
-  //Pass cubeVertices to have initialized values. However you can safely use a null pointer.
+  // Pass cubeVertices to have initialized values.
+  // However you can safely use a null pointer.
   CubeVertices cubeVertices[8];
-  memcpy( cubeVertices, c_originalVertices, sizeof(CubeVertices) * 8 );
+  memcpy( cubeVertices, c_originalVertices, sizeof(CubeVertices) * 8);
 
   Ogre::VertexBufferPacked *vertexBuffer = 0;
-  vertexBuffer = vaoManager->createVertexBuffer( vertexElements, 8,
-                                                  Ogre::BT_DYNAMIC_PERSISTENT,
-                                                  cubeVertices, false );
+  vertexBuffer = vaoManager->createVertexBuffer(
+      vertexElements, 8,
+      Ogre::BT_DYNAMIC_PERSISTENT,
+      cubeVertices, false);
 
-  //Now the Vao
+  // Now the Vao
   Ogre::VertexBufferPackedVec vertexBuffers;
-  vertexBuffers.push_back( vertexBuffer );
+  vertexBuffers.push_back(vertexBuffer);
   Ogre::IndexBufferPacked *indexBuffer = this->CreateIndexBuffer();
   Ogre::VertexArrayObject *vao = vaoManager->createVertexArrayObject(
-              vertexBuffers, indexBuffer, Ogre::OT_TRIANGLE_LIST );
+              vertexBuffers, indexBuffer, Ogre::OT_TRIANGLE_LIST);
 
-  subMesh->mVao[Ogre::VpNormal].push_back( vao );
-  //Use the same geometry for shadow casting.
-  subMesh->mVao[Ogre::VpShadow].push_back( vao );
+  subMesh->mVao[Ogre::VpNormal].push_back(vao);
+  // Use the same geometry for shadow casting.
+  subMesh->mVao[Ogre::VpShadow].push_back(vao);
 
-  //Set the bounds to get frustum culling and LOD to work correctly.
-  mesh->_setBounds( Ogre::Aabb( Ogre::Vector3::ZERO, Ogre::Vector3::UNIT_SCALE ), false );
-  mesh->_setBoundingSphereRadius( 1.732f );
+  // Set the bounds to get frustum culling and LOD to work correctly.
+  mesh->_setBounds(Ogre::Aabb(Ogre::Vector3::ZERO,
+      Ogre::Vector3::UNIT_SCALE), false);
+  mesh->_setBoundingSphereRadius(1.732f);
 
-  return std::pair<Ogre::MeshPtr, Ogre::VertexBufferPacked*>( mesh, vertexBuffer );
+  return std::pair<Ogre::MeshPtr, Ogre::VertexBufferPacked*>(
+      mesh, vertexBuffer);
 }
 
 //////////////////////////////////////////////////
@@ -642,18 +667,22 @@ void DynamicGeometryPrivate::UpdateDynamicBuffer01(float *cubeVertices,
     const CubeVertices originalVerts[8],
     size_t start, size_t end) const
 {
-  const float cosAlpha = cosf( mRotationTime );
-  const float sinAlpha = sinf( mRotationTime );
+  const float cosAlpha = cosf(mRotationTime);
+  const float sinAlpha = sinf(mRotationTime);
 
-  for( size_t i=start; i<end; ++i )
+  for (size_t i=start; i < end; ++i)
   {
-    cubeVertices[0] = originalVerts[i].px * cosAlpha - originalVerts[i].pz * sinAlpha;
+    cubeVertices[0] = originalVerts[i].px * cosAlpha
+        - originalVerts[i].pz * sinAlpha;
     cubeVertices[1] = originalVerts[i].py;
-    cubeVertices[2] = originalVerts[i].px * sinAlpha + originalVerts[i].pz * cosAlpha;
+    cubeVertices[2] = originalVerts[i].px * sinAlpha
+        + originalVerts[i].pz * cosAlpha;
 
-    cubeVertices[3] = originalVerts[i].nx * cosAlpha - originalVerts[i].nz * sinAlpha;
+    cubeVertices[3] = originalVerts[i].nx * cosAlpha
+        - originalVerts[i].nz * sinAlpha;
     cubeVertices[4] = originalVerts[i].ny;
-    cubeVertices[5] = originalVerts[i].nx * sinAlpha + originalVerts[i].nz * cosAlpha;
+    cubeVertices[5] = originalVerts[i].nx * sinAlpha
+        + originalVerts[i].nz * cosAlpha;
 
     cubeVertices += 6;
   }
@@ -664,99 +693,112 @@ void DynamicGeometryPrivate::Update(float simTime)
 {
   mRotationTime = simTime;
   // mRotationTime += timeSinceLast;
-  mRotationTime = fmod( mRotationTime, Ogre::Math::PI * 2.0f );
+  mRotationTime = fmod(mRotationTime, Ogre::Math::PI * 2.0f);
 
-  const float cosAlpha = cosf( mRotationTime );
-  const float sinAlpha = sinf( mRotationTime );
+  const float cosAlpha = cosf(mRotationTime);
+  const float sinAlpha = sinf(mRotationTime);
 
   {
-      //Partial update the buffer's 2nd vertex.
-      Ogre::VertexBufferPacked *partialVertexBuffer = mPartialMesh->getSubMesh( 0 )->
+      // Partial update the buffer's 2nd vertex.
+      Ogre::VertexBufferPacked *partialVertexBuffer =
+          mPartialMesh->getSubMesh(0)->
               mVao[Ogre::VpNormal][0]->getVertexBuffers()[0];
-      CubeVertices newVertex( c_originalVertices[2] );
+      CubeVertices newVertex(c_originalVertices[2]);
       newVertex.px += cosAlpha;
-      partialVertexBuffer->upload( &newVertex, 2, 1 );
+      partialVertexBuffer->upload(&newVertex, 2, 1);
   }
 
 
   //----------------------------------------------------------------
-  //First dynamic buffer example.
+  // First dynamic buffer example.
 
-  //Dynamic buffers assume you will be fully uploading the entire buffer's contents
-  //every time you map them.
-  //"Partially" mapping or filling the buffer will not result in desired results
-  //(data uploaded in previous frames will get mixed with with the
-  //new data you're uploading)
+  // Dynamic buffers assume you will be fully uploading the entire buffer's
+  // contents every time you map them.
+  // "Partially" mapping or filling the buffer will not result in desired
+  // results (data uploaded in previous frames will get mixed with with the
+  // new data you're uploading)
 
-  //You should NEVER read from cubeVertices pointer. Beware that something as innocent as
-  //++(*cubeVertices) or cubeVertices[0] += 1; or cubesVertices[1] = cubesVertices[0];
-  //implies reading from the mapped memory.
+  // You should NEVER read from cubeVertices pointer. Beware that something
+  // as innocent as ++(*cubeVertices) or cubeVertices[0] += 1;
+  // or cubesVertices[1] = cubesVertices[0]; implies reading from the
+  // mapped memory.
   //
-  //Reading from this memory may return garbage, may return old data (from previous frames)
-  //and will probably be *very* slow since the memory region is often write combined.
-  //Sometimes you need to check the assembly to see the compiler isn't reading from
-  //that memory even though the C++ code doesn't.
+  // Reading from this memory may return garbage, may return old data
+  // (from previous frames) and will probably be *very* slow since the memory
+  // region is often write combined.
+  // Sometimes you need to check the assembly to see the compiler isn't
+  // reading from that memory even though the C++ code doesn't.
   float * RESTRICT_ALIAS cubeVertices = reinterpret_cast<float*RESTRICT_ALIAS>(
-              mDynamicVertexBuffer[0]->map( 0, mDynamicVertexBuffer[0]->getNumElements() ) );
+              mDynamicVertexBuffer[0]->map(0, mDynamicVertexBuffer[0]->
+                  getNumElements()));
 
-  for( size_t i=0; i<8; ++i )
+  for (size_t i=0; i < 8; ++i)
   {
-      cubeVertices[0] = c_originalVertices[i].px * cosAlpha - c_originalVertices[i].py * sinAlpha;
-      cubeVertices[1] = c_originalVertices[i].px * sinAlpha + c_originalVertices[i].py * cosAlpha;
+      cubeVertices[0] = c_originalVertices[i].px * cosAlpha
+          - c_originalVertices[i].py * sinAlpha;
+      cubeVertices[1] = c_originalVertices[i].px * sinAlpha
+          + c_originalVertices[i].py * cosAlpha;
       cubeVertices[2] = c_originalVertices[i].pz;
 
-      cubeVertices[3] = c_originalVertices[i].nx * cosAlpha - c_originalVertices[i].ny * sinAlpha;
-      cubeVertices[4] = c_originalVertices[i].nx * sinAlpha + c_originalVertices[i].ny * cosAlpha;
+      cubeVertices[3] = c_originalVertices[i].nx * cosAlpha
+          - c_originalVertices[i].ny * sinAlpha;
+      cubeVertices[4] = c_originalVertices[i].nx * sinAlpha
+          + c_originalVertices[i].ny * cosAlpha;
       cubeVertices[5] = c_originalVertices[i].nz;
 
       cubeVertices += 6;
   }
 
-  mDynamicVertexBuffer[0]->unmap( Ogre::UO_KEEP_PERSISTENT );
+  mDynamicVertexBuffer[0]->unmap(Ogre::UO_KEEP_PERSISTENT);
 
   //----------------------------------------------------------------
-  //Second dynamic buffer example.
+  // Second dynamic buffer example.
   //  Update the cube mapping multiple times per frame.
   //  Every time you map, you 'advance' the buffer for the next frame.
   //  If you want to map it again within the same frame, you first
   //  need to 'regress' the buffer back to its original state,
   //  while being carefull that:
-  //      1. Once you're done with all your maps, and by the time rendering starts,
+  //      1. Once you're done with all your maps, and by the time
+  //         rendering starts,
   //         the buffer has advanced ONLY once.
-  //      2. You do not write to a memory region that you have already written to,
-  //         unless you know you haven't issued draw calls that are using this region yet.
+  //      2. You do not write to a memory region that you have already
+  //         written to, unless you know you haven't issued draw calls
+  //         that are using this region yet.
 
-  //The last 'false' indicates the buffer not to advance forward.
+  // The last 'false' indicates the buffer not to advance forward.
   cubeVertices = reinterpret_cast<float*RESTRICT_ALIAS>(
-              mDynamicVertexBuffer[1]->map( 0, 2, false ) );
-  this->UpdateDynamicBuffer01( cubeVertices, c_originalVertices, 0, 2 );
-  mDynamicVertexBuffer[1]->unmap( Ogre::UO_KEEP_PERSISTENT );
+      mDynamicVertexBuffer[1]->map(0, 2, false));
+  this->UpdateDynamicBuffer01(cubeVertices, c_originalVertices, 0, 2);
+  mDynamicVertexBuffer[1]->unmap(Ogre::UO_KEEP_PERSISTENT);
 
-  //We do not regress the frame, because we haven't advanced yet.
+  // We do not regress the frame, because we haven't advanced yet.
   cubeVertices = reinterpret_cast<float*RESTRICT_ALIAS>(
-              mDynamicVertexBuffer[1]->map( 2, 2, true ) );
-  this->UpdateDynamicBuffer01( cubeVertices, c_originalVertices, 2, 4 );
-  mDynamicVertexBuffer[1]->unmap( Ogre::UO_KEEP_PERSISTENT );
+      mDynamicVertexBuffer[1]->map(2, 2, true));
+  this->UpdateDynamicBuffer01(cubeVertices, c_originalVertices, 2, 4);
+  mDynamicVertexBuffer[1]->unmap(Ogre::UO_KEEP_PERSISTENT);
 
-  //We regress the frame, because the previous map had advanced automatically by passing 'true'.
+  // We regress the frame, because the previous map had advanced
+  // automatically by passing 'true'.
   mDynamicVertexBuffer[1]->regressFrame();
   cubeVertices = reinterpret_cast<float*RESTRICT_ALIAS>(
-              mDynamicVertexBuffer[1]->map( 4, 2, false ) );
-  this->UpdateDynamicBuffer01( cubeVertices, c_originalVertices, 4, 6 );
-  mDynamicVertexBuffer[1]->unmap( Ogre::UO_KEEP_PERSISTENT );
-  mDynamicVertexBuffer[1]->advanceFrame();    //Make sure we advance when we're done and
-                                              //draw calls may start afterwards.
+      mDynamicVertexBuffer[1]->map(4, 2, false));
+  this->UpdateDynamicBuffer01(cubeVertices, c_originalVertices, 4, 6);
+  mDynamicVertexBuffer[1]->unmap(Ogre::UO_KEEP_PERSISTENT);
+  // Make sure we advance when we're done and draw calls may start afterwards.
+  mDynamicVertexBuffer[1]->advanceFrame();
 
   // ... hypothetical draw calls issued ...
 
-  //We regress the frame, because the previous map had advanced it; and the frame isn't over yet.
+  // We regress the frame, because the previous map had advanced it;
+  // and the frame isn't over yet.
   mDynamicVertexBuffer[1]->regressFrame();
   cubeVertices = reinterpret_cast<float*RESTRICT_ALIAS>(
-              mDynamicVertexBuffer[1]->map( 6, 2, false ) );
-  this->UpdateDynamicBuffer01( cubeVertices, c_originalVertices, 6, 8 );
-  mDynamicVertexBuffer[1]->unmap( Ogre::UO_KEEP_PERSISTENT );
-  mDynamicVertexBuffer[1]->advanceFrame();    //Make sure we advance when we're done and
-                                              //draw calls may start afterwards.
+      mDynamicVertexBuffer[1]->map(6, 2, false));
+  this->UpdateDynamicBuffer01(cubeVertices, c_originalVertices, 6, 8);
+  mDynamicVertexBuffer[1]->unmap(Ogre::UO_KEEP_PERSISTENT);
+
+  // Make sure we advance when we're done and draw calls may start afterwards.
+  mDynamicVertexBuffer[1]->advanceFrame();
 
   // TutorialGameState::update( timeSinceLast );
 }
@@ -764,52 +806,56 @@ void DynamicGeometryPrivate::Update(float simTime)
 //////////////////////////////////////////////////
 void DynamicGeometryPrivate::CreateScene01(void)
 {
-  //Create all four types of meshes.
-  mStaticMesh  = CreateStaticMesh( false );
-  mPartialMesh = CreateStaticMesh( true );
+  // Create all four types of meshes.
+  mStaticMesh  = CreateStaticMesh(false);
+  mPartialMesh = CreateStaticMesh(true);
 
-  for( size_t i=0; i<2; ++i )
+  for (size_t i = 0; i < 2; ++i)
   {
       std::pair<Ogre::MeshPtr, Ogre::VertexBufferPacked*> dynamicMesh;
-      dynamicMesh = CreateDynamicMesh( i );
+      dynamicMesh = CreateDynamicMesh(i);
       mDynamicMesh[i]         = dynamicMesh.first;
       mDynamicVertexBuffer[i] = dynamicMesh.second;
   }
 
-  //Initialize the scene (items)
+  // Initialize the scene (items)
   rendering::Ogre2ScenePtr ogreScene =
       std::dynamic_pointer_cast<rendering::Ogre2Scene>(this->scene);
   Ogre::SceneManager *sceneManager = ogreScene->OgreSceneManager();
   // Ogre::SceneManager *sceneManager = mGraphicsSystem->getSceneManager();
 
-  Ogre::Item *item = sceneManager->createItem( mStaticMesh, Ogre::SCENE_DYNAMIC );
-  Ogre::SceneNode *sceneNode = sceneManager->getRootSceneNode( Ogre::SCENE_DYNAMIC )->
-          createChildSceneNode( Ogre::SCENE_DYNAMIC );
-  sceneNode->attachObject( item );
-  sceneNode->setPosition( -6, 0, 0 );
+  Ogre::Item *item = sceneManager->createItem(
+      mStaticMesh, Ogre::SCENE_DYNAMIC);
+  Ogre::SceneNode *sceneNode = sceneManager->
+      getRootSceneNode(Ogre::SCENE_DYNAMIC)->
+          createChildSceneNode(Ogre::SCENE_DYNAMIC);
+  sceneNode->attachObject(item);
+  sceneNode->setPosition(-6, 0, 0);
 
-  item = sceneManager->createItem( mPartialMesh, Ogre::SCENE_DYNAMIC );
-  sceneNode = sceneManager->getRootSceneNode( Ogre::SCENE_DYNAMIC )->
-          createChildSceneNode( Ogre::SCENE_DYNAMIC );
-  sceneNode->attachObject( item );
-  sceneNode->setPosition( -2, 0, 0 );
+  item = sceneManager->createItem(mPartialMesh, Ogre::SCENE_DYNAMIC);
+  sceneNode = sceneManager->getRootSceneNode(Ogre::SCENE_DYNAMIC)->
+      createChildSceneNode(Ogre::SCENE_DYNAMIC);
+  sceneNode->attachObject(item);
+  sceneNode->setPosition(-2, 0, 0);
 
-  item = sceneManager->createItem( mDynamicMesh[0], Ogre::SCENE_DYNAMIC );
-  sceneNode = sceneManager->getRootSceneNode( Ogre::SCENE_DYNAMIC )->
-          createChildSceneNode( Ogre::SCENE_DYNAMIC );
-  sceneNode->attachObject( item );
-  sceneNode->setPosition( 2, 0, 0 );
+  item = sceneManager->createItem(mDynamicMesh[0], Ogre::SCENE_DYNAMIC);
+  sceneNode = sceneManager->getRootSceneNode(Ogre::SCENE_DYNAMIC)->
+          createChildSceneNode(Ogre::SCENE_DYNAMIC);
+  sceneNode->attachObject(item);
+  sceneNode->setPosition(2, 0, 0);
 
-  item = sceneManager->createItem( mDynamicMesh[1], Ogre::SCENE_DYNAMIC );
-  sceneNode = sceneManager->getRootSceneNode( Ogre::SCENE_DYNAMIC )->
-          createChildSceneNode( Ogre::SCENE_DYNAMIC );
-  sceneNode->attachObject( item );
-  sceneNode->setPosition( 6, 0, 0 );
+  item = sceneManager->createItem(mDynamicMesh[1], Ogre::SCENE_DYNAMIC);
+  sceneNode = sceneManager->getRootSceneNode(Ogre::SCENE_DYNAMIC)->
+      createChildSceneNode(Ogre::SCENE_DYNAMIC);
+  sceneNode->attachObject(item);
+  sceneNode->setPosition(6, 0, 0);
 
   // Ogre::Light *light = sceneManager->createLight();
-  // Ogre::SceneNode *lightNode = sceneManager->getRootSceneNode()->createChildSceneNode();
+  // Ogre::SceneNode *lightNode = sceneManager->getRootSceneNode()->
+  //    createChildSceneNode();
   // lightNode->attachObject( light );
-  // light->setPowerScale( Ogre::Math::PI ); //Since we don't do HDR, counter the PBS' division by PI
+  // Since we don't do HDR, counter the PBS' division by PI
+  // light->setPowerScale( Ogre::Math::PI );
   // light->setType( Ogre::Light::LT_DIRECTIONAL );
   // light->setDirection( Ogre::Vector3( -1, -1, -1 ).normalisedCopy() );
 
@@ -819,29 +865,33 @@ void DynamicGeometryPrivate::CreateScene01(void)
 //////////////////////////////////////////////////
 void DynamicGeometryPrivate::DestroyScene()
 {
-  for(size_t i=0; i<2; ++i)
+  for (size_t i = 0; i < 2; ++i)
   {
-    //Permanently unmap persistent mapped buffers
-    if( mDynamicVertexBuffer[i] &&
-        mDynamicVertexBuffer[i]->getMappingState() != Ogre::MS_UNMAPPED )
+    // Permanently unmap persistent mapped buffers
+    if (mDynamicVertexBuffer[i] &&
+        mDynamicVertexBuffer[i]->getMappingState() != Ogre::MS_UNMAPPED)
     {
-        mDynamicVertexBuffer[i]->unmap( Ogre::UO_UNMAP_ALL );
+        mDynamicVertexBuffer[i]->unmap(Ogre::UO_UNMAP_ALL);
     }
   }
 
-  //If we don't do this, the smart pointers will try to
-  //delete memory after Ogre has shutdown (and crash)
+  // If we don't do this, the smart pointers will try to
+  // delete memory after Ogre has shutdown (and crash)
   mStaticMesh.setNull();
   mPartialMesh.setNull();
-  for( size_t i=0; i<2; ++i )
+  for (size_t i = 0; i < 2; ++i)
     mDynamicMesh[i].setNull();
 }
 
-//////////////////////////////////////////////////
-GZ_ADD_PLUGIN(DynamicGeometry,
-              gz::sim::System,
-              DynamicGeometry::ISystemConfigure,
-              DynamicGeometry::ISystemPreUpdate)
+}  // namespace systems
+}  // namespace sim
+}  // namespace gz
 
-GZ_ADD_PLUGIN_ALIAS(DynamicGeometry,
-    "gz::sim::systems::DynamicGeometry")
+//////////////////////////////////////////////////
+GZ_ADD_PLUGIN(gz::sim::systems::DynamicGeometry,
+              gz::sim::System,
+              gz::sim::systems::DynamicGeometry::ISystemConfigure,
+              gz::sim::systems::DynamicGeometry::ISystemPreUpdate)
+
+GZ_ADD_PLUGIN_ALIAS(gz::sim::systems::DynamicGeometry,
+                   "gz::sim::systems::DynamicGeometry")

--- a/gz-waves/src/systems/dynamic/DynamicGeometry.hh
+++ b/gz-waves/src/systems/dynamic/DynamicGeometry.hh
@@ -1,4 +1,19 @@
 
+// Copyright (C) 2022  Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #ifndef GZ_SIM_SYSTEMS_DYNAMICGEOMETRY_HH_
 #define GZ_SIM_SYSTEMS_DYNAMICGEOMETRY_HH_
 
@@ -14,39 +29,40 @@ namespace sim
 inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace systems
 {
-  // Forward declaration
-  struct CubeVertices;
-  class DynamicGeometryPrivate;
+// Forward declaration
+struct CubeVertices;
+class DynamicGeometryPrivate;
 
-  /// \brief A plugin to demonstrate using Ogre2 for dynamic geometry
-  class DynamicGeometry
-      : public System,
-        public ISystemConfigure,
-        public ISystemPreUpdate
-  {
-    /// \brief Constructor
-    public: DynamicGeometry();
+/// \brief A plugin to demonstrate using Ogre2 for dynamic geometry
+class DynamicGeometry :
+    public System,
+    public ISystemConfigure,
+    public ISystemPreUpdate
+{
+  /// \brief Constructor
+  public: DynamicGeometry();
 
-    /// \brief Destructor
-    public: ~DynamicGeometry() override;
+  /// \brief Destructor
+  public: ~DynamicGeometry() override;
 
-    // Documentation inherited
-    public: void Configure(const Entity &_entity,
-                           const std::shared_ptr<const sdf::Element> &_sdf,
-                           EntityComponentManager &_ecm,
-                           EventManager &_eventMgr) final;
+  // Documentation inherited
+  public: void Configure(const Entity &_entity,
+                          const std::shared_ptr<const sdf::Element> &_sdf,
+                          EntityComponentManager &_ecm,
+                          EventManager &_eventMgr) final;
 
-    /// Documentation inherited
-    public: void PreUpdate(
-                const gz::sim::UpdateInfo &_info,
-                gz::sim::EntityComponentManager &_ecm) override;
+  /// Documentation inherited
+  public: void PreUpdate(
+              const gz::sim::UpdateInfo &_info,
+              gz::sim::EntityComponentManager &_ecm) override;
 
-    /// \brief Private data pointer
-    private: std::unique_ptr<DynamicGeometryPrivate> dataPtr;
-  };
-  }
+  /// \brief Private data pointer
+  private: std::unique_ptr<DynamicGeometryPrivate> dataPtr;
+};
+
+}  // namespace systems
 }
-}
-}
+}  // namespace sim
+}  // namespace gz
 
-#endif
+#endif  // GZ_SIM_SYSTEMS_DYNAMICGEOMETRY_HH_

--- a/gz-waves/src/systems/hydrodynamics/Collision.cc
+++ b/gz-waves/src/systems/hydrodynamics/Collision.cc
@@ -26,8 +26,10 @@ class gz::sim::CollisionPrivate
   public: Entity id{kNullEntity};
 };
 
-using namespace gz;
-using namespace sim;
+namespace gz
+{
+namespace sim
+{
 
 //////////////////////////////////////////////////
 Collision::~Collision() = default;
@@ -90,3 +92,5 @@ std::optional<Model> Collision::ParentLink(
   return std::optional<Model>(parent->Data());
 }
 
+}  // namespace sim
+}  // namespace gz

--- a/gz-waves/src/systems/hydrodynamics/Collision.hh
+++ b/gz-waves/src/systems/hydrodynamics/Collision.hh
@@ -16,15 +16,16 @@
 #ifndef GZ_SIM_COLLISION_HH_
 #define GZ_SIM_COLLISION_HH_
 
+#include <memory>
+#include <optional>
+#include <string>
+
 #include <gz/sim/config.hh>
 #include <gz/sim/EntityComponentManager.hh>
 #include <gz/sim/Export.hh>
 #include <gz/sim/Model.hh>
 #include <gz/sim/System.hh>
 #include <gz/sim/Types.hh>
-
-#include <memory>
-#include <optional>
 
 namespace gz
 {
@@ -91,7 +92,7 @@ inline namespace GZ_SIM_VERSION_NAMESPACE {
     private: std::unique_ptr<CollisionPrivate> dataPtr;
   };
 }
-}
-}
+}  // namespace sim
+}  // namespace gz
 
-#endif
+#endif  // GZ_SIM_COLLISION_HH_

--- a/gz-waves/src/systems/hydrodynamics/Hydrodynamics.hh
+++ b/gz-waves/src/systems/hydrodynamics/Hydrodynamics.hh
@@ -28,91 +28,92 @@ namespace sim
 inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace systems
 {
-  // Forward declaration
-  class HydrodynamicsPrivate;
+// Forward declaration
+class HydrodynamicsPrivate;
 
-  /// \brief A plugin to manage buoyancy and hydrodynamic force calculations
-  ///
-  /// # Usage
-  /// 
-  /// Add the SDF for the plugin to the <model> element of your model. 
-  /// 
-  /// /code
-  /// <plugin name="gz::sim::systems::Hydrodynamics"
-  ///         filename="gz-waves1-hydrodynamics-system">
-  ///
-  ///   <!-- Apply hydrodynamics to the entire model (default) -->
-  ///   <enable>model_name</enable>
-  ///
-  ///   <!-- Or apply hydrodynamics to named links -->
-  ///   <enable>model_name::link1</enable>
-  ///   <enable>model_name::link2</enable>
-  ///
-  ///   <!-- Or apply hydrodynamics to named collisions -->
-  ///   <enable>model_name::link1::collision1</enable>
-  ///   <enable>model_name::link1::collision2</enable>
-  ///
-  ///   <!-- Hydrodynamics -->
-  ///   <hydrodynamics>
-  ///     <damping_on>1</damping_on>
-  ///     <viscous_drag_on>1</viscous_drag_on>
-  ///     <pressure_drag_on>1</pressure_drag_on>
-  ///
-  ///     <!-- Linear and Angular Damping -->
-  ///     <cDampL1>1.0E-6</cDampL1>
-  ///     <cDampL2>1.0E-6</cDampL2>
-  ///     <cDampR1>1.0E-6</cDampR1>
-  ///     <cDampR2>1.0E-6</cDampR2>
-  ///
-  ///     <!-- 'Pressure' Drag -->
-  ///     <cPDrag1>1.0E+2</cPDrag1>
-  ///     <cPDrag2>1.0E+2</cPDrag2>
-  ///     <fPDrag>0.4</fPDrag>
-  ///     <cSDrag1>1.0E+2</cSDrag1>
-  ///     <cSDrag2>1.0E+2</cSDrag2>
-  ///     <fSDrag>0.4</fSDrag>
-  ///     <vRDrag>1.0</vRDrag>
-  ///   </hydrodynamics>
-  ///
-  ///   <!-- Control visibility of markers -->
-  ///   <markers>
-  ///     <update_rate>10</update_rate>
-  ///     <water_patch>1</water_patch>
-  ///     <waterline>1</waterline>
-  ///     <underwater_surface>1</underwater_surface>
-  ///   </markers>
-  ///
-  /// </plugin>
-  /// \endcode
-  ///
-  class Hydrodynamics
-      : public System,
-        public ISystemConfigure,
-        public ISystemPreUpdate
-  {
-    /// \brief Constructor
-    public: Hydrodynamics();
+/// \brief A plugin to manage buoyancy and hydrodynamic force calculations
+///
+/// # Usage
+///
+/// Add the SDF for the plugin to the <model> element of your model.
+///
+/// /code
+/// <plugin name="gz::sim::systems::Hydrodynamics"
+///         filename="gz-waves1-hydrodynamics-system">
+///
+///   <!-- Apply hydrodynamics to the entire model (default) -->
+///   <enable>model_name</enable>
+///
+///   <!-- Or apply hydrodynamics to named links -->
+///   <enable>model_name::link1</enable>
+///   <enable>model_name::link2</enable>
+///
+///   <!-- Or apply hydrodynamics to named collisions -->
+///   <enable>model_name::link1::collision1</enable>
+///   <enable>model_name::link1::collision2</enable>
+///
+///   <!-- Hydrodynamics -->
+///   <hydrodynamics>
+///     <damping_on>1</damping_on>
+///     <viscous_drag_on>1</viscous_drag_on>
+///     <pressure_drag_on>1</pressure_drag_on>
+///
+///     <!-- Linear and Angular Damping -->
+///     <cDampL1>1.0E-6</cDampL1>
+///     <cDampL2>1.0E-6</cDampL2>
+///     <cDampR1>1.0E-6</cDampR1>
+///     <cDampR2>1.0E-6</cDampR2>
+///
+///     <!-- 'Pressure' Drag -->
+///     <cPDrag1>1.0E+2</cPDrag1>
+///     <cPDrag2>1.0E+2</cPDrag2>
+///     <fPDrag>0.4</fPDrag>
+///     <cSDrag1>1.0E+2</cSDrag1>
+///     <cSDrag2>1.0E+2</cSDrag2>
+///     <fSDrag>0.4</fSDrag>
+///     <vRDrag>1.0</vRDrag>
+///   </hydrodynamics>
+///
+///   <!-- Control visibility of markers -->
+///   <markers>
+///     <update_rate>10</update_rate>
+///     <water_patch>1</water_patch>
+///     <waterline>1</waterline>
+///     <underwater_surface>1</underwater_surface>
+///   </markers>
+///
+/// </plugin>
+/// \endcode
+///
+class Hydrodynamics
+    : public System,
+      public ISystemConfigure,
+      public ISystemPreUpdate
+{
+  /// \brief Constructor
+  public: Hydrodynamics();
 
-    /// \brief Destructor
-    public: ~Hydrodynamics() override;
+  /// \brief Destructor
+  public: ~Hydrodynamics() override;
 
-    // Documentation inherited
-    public: void Configure(const Entity &_entity,
-                           const std::shared_ptr<const sdf::Element> &_sdf,
-                           EntityComponentManager &_ecm,
-                           EventManager &_eventMgr) final;
+  // Documentation inherited
+  public: void Configure(const Entity &_entity,
+                          const std::shared_ptr<const sdf::Element> &_sdf,
+                          EntityComponentManager &_ecm,
+                          EventManager &_eventMgr) final;
 
-    /// Documentation inherited
-    public: void PreUpdate(
-                const UpdateInfo &_info,
-                EntityComponentManager &_ecm) override;
+  /// Documentation inherited
+  public: void PreUpdate(
+              const UpdateInfo &_info,
+              EntityComponentManager &_ecm) override;
 
-    /// \brief Private data pointer
-    private: std::unique_ptr<HydrodynamicsPrivate> dataPtr;
-  };
-  }
+  /// \brief Private data pointer
+  private: std::unique_ptr<HydrodynamicsPrivate> dataPtr;
+};
+
+}  // namespace systems
 }
-}
-}
+}  // namespace sim
+}  // namespace gz
 
-#endif
+#endif  // GZ_SIM_SYSTEMS_HYDRODYNAMICS_HH_

--- a/gz-waves/src/systems/waves/BaseOceanGeometry.hh
+++ b/gz-waves/src/systems/waves/BaseOceanGeometry.hh
@@ -16,75 +16,77 @@
 #ifndef GZ_RENDERING_BASE_BASEOCEANGEOMETRY_HH_
 #define GZ_RENDERING_BASE_BASEOCEANGEOMETRY_HH_
 
+#include <string>
+
 #include "OceanGeometry.hh"
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    /// \brief Base implementation of an Ocean geometry
-    template <class T>
-    class BaseOceanGeometry :
-        public virtual OceanGeometry,
-        public virtual T
-    {
-      /// \brief Constructor
-      public: BaseOceanGeometry();
+/// \brief Base implementation of an Ocean geometry
+template <class T>
+class BaseOceanGeometry :
+    public virtual OceanGeometry,
+    public virtual T
+{
+  /// \brief Constructor
+  public: BaseOceanGeometry();
 
-      /// \brief Destructor
-      public: virtual ~BaseOceanGeometry();
+  /// \brief Destructor
+  public: virtual ~BaseOceanGeometry();
 
-      /// \brief Load from a mesh
-      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
+  /// \brief Load from a mesh
+  public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
 
-      /// \brief Update from a mesh
-      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
+  /// \brief Update from a mesh
+  public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
 
-      /// \brief Work-around the protected accessors and methods in Scene
-      public: virtual void InitObject(ScenePtr _scene,
-          unsigned int _id, const std::string &_name) override;
+  /// \brief Work-around the protected accessors and methods in Scene
+  public: virtual void InitObject(ScenePtr _scene,
+      unsigned int _id, const std::string &_name) override;
+};
 
-    };
-
-    /////////////////////////////////////////////////
-    // BaseOceanGeometry
-    /////////////////////////////////////////////////
-    template <class T>
-    BaseOceanGeometry<T>::BaseOceanGeometry()
-    {
-    }
-
-    /////////////////////////////////////////////////
-    template <class T>
-    BaseOceanGeometry<T>::~BaseOceanGeometry()
-    {
-    }
-
-    /////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanGeometry<T>::LoadMesh(gz::common::MeshPtr /*_mesh*/)
-    {
-      // no default implementation
-    }
-
-    /////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanGeometry<T>::UpdateMesh(gz::common::MeshPtr /*_mesh*/)
-    {
-      // no default implementation
-    }
-
-    /////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanGeometry<T>::InitObject(ScenePtr /*_scene*/,
-        unsigned int /*_id*/, const std::string &/*_name*/)
-    {
-      // no default implementation
-    }
-
-    }
-  }
+/////////////////////////////////////////////////
+// BaseOceanGeometry
+/////////////////////////////////////////////////
+template <class T>
+BaseOceanGeometry<T>::BaseOceanGeometry()
+{
 }
-#endif
+
+/////////////////////////////////////////////////
+template <class T>
+BaseOceanGeometry<T>::~BaseOceanGeometry()
+{
+}
+
+/////////////////////////////////////////////////
+template <class T>
+void BaseOceanGeometry<T>::LoadMesh(gz::common::MeshPtr /*_mesh*/)
+{
+  // no default implementation
+}
+
+/////////////////////////////////////////////////
+template <class T>
+void BaseOceanGeometry<T>::UpdateMesh(gz::common::MeshPtr /*_mesh*/)
+{
+  // no default implementation
+}
+
+/////////////////////////////////////////////////
+template <class T>
+void BaseOceanGeometry<T>::InitObject(ScenePtr /*_scene*/,
+    unsigned int /*_id*/, const std::string &/*_name*/)
+{
+  // no default implementation
+}
+
+}
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_BASE_BASEOCEANGEOMETRY_HH_

--- a/gz-waves/src/systems/waves/BaseOceanVisual.hh
+++ b/gz-waves/src/systems/waves/BaseOceanVisual.hh
@@ -16,163 +16,166 @@
 #ifndef GZ_RENDERING_BASE_BASEOCEANVISUAL_HH_
 #define GZ_RENDERING_BASE_BASEOCEANVISUAL_HH_
 
-#include "OceanVisual.hh"
+#include <string>
 
 #include <gz/rendering/base/BaseObject.hh>
 #include <gz/rendering/base/BaseRenderTypes.hh>
 #include <gz/rendering/Scene.hh>
 
+#include "OceanVisual.hh"
+
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    /// \brief Base implementation of an Ocean visual
-    template <class T>
-    class BaseOceanVisual :
-      public virtual OceanVisual,
-      public virtual T
-    {
-      /// \brief Constructor
-      public: BaseOceanVisual();
+/// \brief Base implementation of an Ocean visual
+template <class T>
+class BaseOceanVisual :
+  public virtual OceanVisual,
+  public virtual T
+{
+  /// \brief Constructor
+  public: BaseOceanVisual();
 
-      /// \brief Destructor
-      public: virtual ~BaseOceanVisual();
+  /// \brief Destructor
+  public: virtual ~BaseOceanVisual();
 
-      // Documentation inherited.
-      public: virtual void Init() override;
+  // Documentation inherited.
+  public: virtual void Init() override;
 
-      // Documentation inherited.
-      public: virtual void PreRender() override;
+  // Documentation inherited.
+  public: virtual void PreRender() override;
 
-      // Documentation inherited.
-      protected: virtual void Destroy() override;
+  // Documentation inherited.
+  protected: virtual void Destroy() override;
 
-      // Documentation inherited.
-      public: virtual MaterialPtr Material() const override;
+  // Documentation inherited.
+  public: virtual MaterialPtr Material() const override;
 
-      // Documentation inherited.
-      public: virtual void SetMaterial(
-        MaterialPtr _material, bool _unique) override;
+  // Documentation inherited.
+  public: virtual void SetMaterial(
+    MaterialPtr _material, bool _unique) override;
 
-      /// \brief Load a dynamic cube (example)
-      public: virtual void LoadCube() override;
+  /// \brief Load a dynamic cube (example)
+  public: virtual void LoadCube() override;
 
-      /// \brief Load from an ocean tile
-      public: virtual void LoadOceanTile(
-          waves::visual::OceanTilePtr _oceanTile) override;
+  /// \brief Load from an ocean tile
+  public: virtual void LoadOceanTile(
+      waves::visual::OceanTilePtr _oceanTile) override;
 
-      /// \brief Update from an ocean tile
-      public: virtual void UpdateOceanTile(
-          waves::visual::OceanTilePtr _oceanTile) override;
+  /// \brief Update from an ocean tile
+  public: virtual void UpdateOceanTile(
+      waves::visual::OceanTilePtr _oceanTile) override;
 
-      /// \brief Load from a mesh
-      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
+  /// \brief Load from a mesh
+  public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
 
-      /// \brief Update from a mesh
-      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
+  /// \brief Update from a mesh
+  public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
 
-      /// \brief Work-around the protected accessors and protected methods in Scene
-      public: virtual void InitObject(ScenePtr _scene,
-          unsigned int _id, const std::string &_name) override;
+  /// \brief Work-around the protected accessors and protected methods in Scene
+  public: virtual void InitObject(ScenePtr _scene,
+      unsigned int _id, const std::string &_name) override;
 
-    };
+};
 
-    //////////////////////////////////////////////////
-    template <class T>
-    BaseOceanVisual<T>::BaseOceanVisual()
-    {
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    BaseOceanVisual<T>::~BaseOceanVisual()
-    {
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::PreRender()
-    {
-      T::PreRender();
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::Init()
-    {
-      T::Init();
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::Destroy()
-    {
-      T::Destroy();
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    MaterialPtr BaseOceanVisual<T>::Material() const
-    {
-      return T::Material();
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::SetMaterial(
-      MaterialPtr _material, bool _unique)
-    {
-      T::SetMaterial(_material, _unique);
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::LoadCube( )
-    {
-      // no default implementation
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::LoadOceanTile(
-      waves::visual::OceanTilePtr /*_oceanTile*/)
-    {
-      // no default implementation
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::UpdateOceanTile(
-      waves::visual::OceanTilePtr /*_oceanTile*/)
-    {
-      // no default implementation
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::LoadMesh(gz::common::MeshPtr /*_mesh*/)
-    {
-      // no default implementation
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::UpdateMesh(gz::common::MeshPtr /*_mesh*/)
-    {
-      // no default implementation
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseOceanVisual<T>::InitObject(ScenePtr /*_scene*/,
-        unsigned int /*_id*/, const std::string &/*_name*/)
-    {
-      // no default implementation
-    }
-
-    }
-  }
+//////////////////////////////////////////////////
+template <class T>
+BaseOceanVisual<T>::BaseOceanVisual()
+{
 }
-#endif
+
+//////////////////////////////////////////////////
+template <class T>
+BaseOceanVisual<T>::~BaseOceanVisual()
+{
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::PreRender()
+{
+  T::PreRender();
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::Init()
+{
+  T::Init();
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::Destroy()
+{
+  T::Destroy();
+}
+
+//////////////////////////////////////////////////
+template <class T>
+MaterialPtr BaseOceanVisual<T>::Material() const
+{
+  return T::Material();
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::SetMaterial(
+  MaterialPtr _material, bool _unique)
+{
+  T::SetMaterial(_material, _unique);
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::LoadCube()
+{
+  // no default implementation
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::LoadOceanTile(
+  waves::visual::OceanTilePtr /*_oceanTile*/)
+{
+  // no default implementation
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::UpdateOceanTile(
+  waves::visual::OceanTilePtr /*_oceanTile*/)
+{
+  // no default implementation
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::LoadMesh(gz::common::MeshPtr /*_mesh*/)
+{
+  // no default implementation
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::UpdateMesh(gz::common::MeshPtr /*_mesh*/)
+{
+  // no default implementation
+}
+
+//////////////////////////////////////////////////
+template <class T>
+void BaseOceanVisual<T>::InitObject(ScenePtr /*_scene*/,
+    unsigned int /*_id*/, const std::string &/*_name*/)
+{
+  // no default implementation
+}
+
+}
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_BASE_BASEOCEANVISUAL_HH_

--- a/gz-waves/src/systems/waves/BaseRenderEngineExtension.cc
+++ b/gz-waves/src/systems/waves/BaseRenderEngineExtension.cc
@@ -17,8 +17,11 @@
 
 #include <gz/common/Console.hh>
 
-using namespace gz;
-using namespace rendering;
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
 //////////////////////////////////////////////////
 BaseRenderEngineExtension::BaseRenderEngineExtension()
@@ -75,3 +78,7 @@ bool BaseRenderEngineExtension::IsInitialized() const
 void BaseRenderEngineExtension::Destroy()
 {
 }
+
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/BaseRenderEngineExtension.hh
+++ b/gz-waves/src/systems/waves/BaseRenderEngineExtension.hh
@@ -16,46 +16,50 @@
 #ifndef GZ_RENDERING_BASE_RENDERENGINEEXTENSION_HH_
 #define GZ_RENDERING_BASE_RENDERENGINEEXTENSION_HH_
 
-#include "RenderEngineExtension.hh"
-
 #include <map>
 #include <string>
+
 #include <gz/rendering/config.hh>
 #include <gz/rendering/GraphicsAPI.hh>
 #include <gz/rendering/RenderTypes.hh>
 #include <gz/rendering/Export.hh>
 
+#include "RenderEngineExtension.hh"
+
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-    class GZ_RENDERING_VISIBLE BaseRenderEngineExtension :
-        public virtual RenderEngineExtension
-    {
-      protected: BaseRenderEngineExtension();
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-      public: virtual ~BaseRenderEngineExtension();
+class GZ_RENDERING_VISIBLE BaseRenderEngineExtension :
+    public virtual RenderEngineExtension
+{
+  protected: BaseRenderEngineExtension();
 
-      public: virtual bool Load(
-          const std::map<std::string, std::string> &_params = {}) override;
+  public: virtual ~BaseRenderEngineExtension();
 
-      public: virtual bool Init() override;
+  public: virtual bool Load(
+      const std::map<std::string, std::string> &_params = {}) override;
 
-      public: virtual void Destroy() override;
+  public: virtual bool Init() override;
 
-      public: virtual bool IsInitialized() const override;
+  public: virtual void Destroy() override;
 
-      protected: virtual bool LoadImpl(
-          const std::map<std::string, std::string> &_params) = 0;
+  public: virtual bool IsInitialized() const override;
 
-      protected: virtual bool InitImpl() = 0;
+  protected: virtual bool LoadImpl(
+      const std::map<std::string, std::string> &_params) = 0;
 
-      protected: bool loaded = false;
+  protected: virtual bool InitImpl() = 0;
 
-      protected: bool initialized = false;
-    };
-    }
-  }
+  protected: bool loaded = false;
+
+  protected: bool initialized = false;
+};
+
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_BASE_RENDERENGINEEXTENSION_HH_

--- a/gz-waves/src/systems/waves/DisplacementMap.cc
+++ b/gz-waves/src/systems/waves/DisplacementMap.cc
@@ -15,9 +15,14 @@
 
 #include "DisplacementMap.hh"
 
-using namespace gz;
-using namespace rendering;
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-//////////////////////////////////////////////////
 DisplacementMap::~DisplacementMap() = default;
 
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/DisplacementMap.hh
+++ b/gz-waves/src/systems/waves/DisplacementMap.hh
@@ -16,41 +16,42 @@
 #ifndef GZ_RENDERING_DISPLACEMENTMAP_HH_
 #define GZ_RENDERING_DISPLACEMENTMAP_HH_
 
-#include <gz/rendering/config.hh>
-#include <gz/rendering/Export.hh>
-
 #include <Eigen/Dense>
 
 #include <memory>
+
+#include <gz/rendering/config.hh>
+#include <gz/rendering/Export.hh>
 
 using Eigen::ArrayXXd;
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    class GZ_RENDERING_VISIBLE DisplacementMap
-    {
-      public: virtual ~DisplacementMap();
+class GZ_RENDERING_VISIBLE DisplacementMap
+{
+  public: virtual ~DisplacementMap();
 
-      public: virtual void InitTextures() = 0;
+  public: virtual void InitTextures() = 0;
 
-      public: virtual void UpdateTextures(
-        const Eigen::Ref<const Eigen::ArrayXXd> &mHeights,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDhdx,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDhdy,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDisplacementsX,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDisplacementsY,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDxdx,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDydy,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDxdy) = 0;
-    };
+  public: virtual void UpdateTextures(
+    const Eigen::Ref<const Eigen::ArrayXXd> &mHeights,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDhdx,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDhdy,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDisplacementsX,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDisplacementsY,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDxdx,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDydy,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDxdy) = 0;
+};
 
-    typedef std::shared_ptr<DisplacementMap> DisplacementMapPtr;
+typedef std::shared_ptr<DisplacementMap> DisplacementMapPtr;
 
-    }
-  }
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_DISPLACEMENTMAP_HH_

--- a/gz-waves/src/systems/waves/OceanGeometry.cc
+++ b/gz-waves/src/systems/waves/OceanGeometry.cc
@@ -15,8 +15,14 @@
 
 #include "OceanGeometry.hh"
 
-using namespace gz;
-using namespace rendering;
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-//////////////////////////////////////////////////
 OceanGeometry::~OceanGeometry() = default;
+
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/OceanGeometry.hh
+++ b/gz-waves/src/systems/waves/OceanGeometry.hh
@@ -16,6 +16,9 @@
 #ifndef GZ_RENDERING_OCEANGEOMETRY_HH_
 #define GZ_RENDERING_OCEANGEOMETRY_HH_
 
+#include <memory>
+#include <string>
+
 #include <gz/common/graphics/Types.hh>
 
 #include <gz/rendering/config.hh>
@@ -25,32 +28,33 @@
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    /// \brief Ocean geometry class based on a dynamic mesh
-    class GZ_RENDERING_VISIBLE OceanGeometry :
-        public virtual Geometry
-    {
-      /// \brief Destructor
-      public: virtual ~OceanGeometry();
+/// \brief Ocean geometry class based on a dynamic mesh
+class GZ_RENDERING_VISIBLE OceanGeometry :
+    public virtual Geometry
+{
+  /// \brief Destructor
+  public: virtual ~OceanGeometry();
 
-      /// \brief Load from a mesh
-      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) = 0;
+  /// \brief Load from a mesh
+  public: virtual void LoadMesh(gz::common::MeshPtr _mesh) = 0;
 
-      /// \brief Update from a mesh
-      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) = 0;
+  /// \brief Update from a mesh
+  public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) = 0;
 
-      /// \brief Work-around the protected accessors and methods in Scene
-      public: virtual void InitObject(ScenePtr _scene,
-          unsigned int _id, const std::string &_name) = 0;
+  /// \brief Work-around the protected accessors and methods in Scene
+  public: virtual void InitObject(ScenePtr _scene,
+      unsigned int _id, const std::string &_name) = 0;
 
-    };
+};
 
-    typedef std::shared_ptr<OceanGeometry> OceanGeometryPtr;
+typedef std::shared_ptr<OceanGeometry> OceanGeometryPtr;
 
-    }
-  }
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_OCEANGEOMETRY_HH_

--- a/gz-waves/src/systems/waves/OceanVisual.cc
+++ b/gz-waves/src/systems/waves/OceanVisual.cc
@@ -15,8 +15,14 @@
 
 #include "OceanVisual.hh"
 
-using namespace gz;
-using namespace rendering;
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-//////////////////////////////////////////////////
 OceanVisual::~OceanVisual() = default;
+
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/OceanVisual.hh
+++ b/gz-waves/src/systems/waves/OceanVisual.hh
@@ -16,7 +16,8 @@
 #ifndef GZ_RENDERING_OCEANVISUAL_HH_
 #define GZ_RENDERING_OCEANVISUAL_HH_
 
-#include "gz/waves/OceanTile.hh"
+#include <memory>
+#include <string>
 
 #include <gz/common/graphics/Types.hh>
 
@@ -25,45 +26,48 @@
 #include <gz/rendering/RenderTypes.hh>
 #include <gz/rendering/Visual.hh>
 
+#include "gz/waves/OceanTile.hh"
+
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    /// \brief Ocean visual using a dynamic mesh
-    class GZ_RENDERING_VISIBLE OceanVisual :
-      public virtual Visual
-    {
-      /// \brief Destructor
-      public: virtual ~OceanVisual();
+/// \brief Ocean visual using a dynamic mesh
+class GZ_RENDERING_VISIBLE OceanVisual :
+  public virtual Visual
+{
+  /// \brief Destructor
+  public: virtual ~OceanVisual();
 
-      /// \brief Load a dynamic cube (example)
-      public: virtual void LoadCube() = 0;
+  /// \brief Load a dynamic cube (example)
+  public: virtual void LoadCube() = 0;
 
-      /// \brief Load from an ocean tile
-      public: virtual void LoadOceanTile(
-          waves::visual::OceanTilePtr _oceanTile) = 0;
+  /// \brief Load from an ocean tile
+  public: virtual void LoadOceanTile(
+      waves::visual::OceanTilePtr _oceanTile) = 0;
 
-      /// \brief Update from an ocean tile
-      public: virtual void UpdateOceanTile(
-          waves::visual::OceanTilePtr _oceanTile) = 0;
+  /// \brief Update from an ocean tile
+  public: virtual void UpdateOceanTile(
+      waves::visual::OceanTilePtr _oceanTile) = 0;
 
-      /// \brief Load from a mesh
-      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) = 0;
+  /// \brief Load from a mesh
+  public: virtual void LoadMesh(gz::common::MeshPtr _mesh) = 0;
 
-      /// \brief Update from a mesh
-      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) = 0;
+  /// \brief Update from a mesh
+  public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) = 0;
 
-      /// \brief Work-around the protected accessors and methods in Scene
-      public: virtual void InitObject(ScenePtr _scene,
-          unsigned int _id, const std::string &_name) = 0;
+  /// \brief Work-around the protected accessors and methods in Scene
+  public: virtual void InitObject(ScenePtr _scene,
+      unsigned int _id, const std::string &_name) = 0;
 
-    };
+};
 
-    typedef std::shared_ptr<OceanVisual> OceanVisualPtr;
+typedef std::shared_ptr<OceanVisual> OceanVisualPtr;
 
-    }
-  }
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_OCEANVISUAL_HH_

--- a/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
+++ b/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
@@ -17,8 +17,11 @@
 
 #include <gz/rendering/RenderingIface.hh>
 
-using namespace gz;
-using namespace rendering;
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
 //////////////////////////////////////////////////
 Ogre2DisplacementMap::Ogre2DisplacementMap(
@@ -45,7 +48,7 @@ Ogre2DisplacementMap::~Ogre2DisplacementMap()
     std::dynamic_pointer_cast<gz::rendering::Ogre2Scene>(
         this->scene);
 
-  if(ogre2Scene != nullptr)
+  if (ogre2Scene != nullptr)
   {
     Ogre::SceneManager *ogre2SceneManager = ogre2Scene->OgreSceneManager();
 
@@ -57,7 +60,7 @@ Ogre2DisplacementMap::~Ogre2DisplacementMap()
 
       if (ogre2TextureManager != nullptr)
       {
-        for (uint8_t i=0; i<3; ++i)   {
+        for (uint8_t i=0; i < 3; ++i)   {
           if (mHeightMapStagingTextures[i]) {
               ogre2TextureManager->removeStagingTexture(
                   mHeightMapStagingTextures[i]);
@@ -140,7 +143,7 @@ void Ogre2DisplacementMap::InitTextures()
       "HeightMapTex(" + std::to_string(this->entity) + ")",
       Ogre::GpuPageOutStrategy::SaveToSystemRam,
       Ogre::TextureFlags::ManualTexture,
-      Ogre::TextureTypes::Type2D );
+      Ogre::TextureTypes::Type2D);
 
   mHeightMapTex->setResolution(mHeightMapImage->getWidth(),
       mHeightMapImage->getHeight());
@@ -154,7 +157,7 @@ void Ogre2DisplacementMap::InitTextures()
       "NormalMapTex(" + std::to_string(this->entity) + ")",
       Ogre::GpuPageOutStrategy::SaveToSystemRam,
       Ogre::TextureFlags::ManualTexture,
-      Ogre::TextureTypes::Type2D );
+      Ogre::TextureTypes::Type2D);
 
   mNormalMapTex->setResolution(mNormalMapImage->getWidth(),
       mNormalMapImage->getHeight());
@@ -168,7 +171,7 @@ void Ogre2DisplacementMap::InitTextures()
       "TangentMapTex(" + std::to_string(this->entity) + ")",
       Ogre::GpuPageOutStrategy::SaveToSystemRam,
       Ogre::TextureFlags::ManualTexture,
-      Ogre::TextureTypes::Type2D );
+      Ogre::TextureTypes::Type2D);
 
   mTangentMapTex->setResolution(mTangentMapImage->getWidth(),
       mTangentMapImage->getHeight());
@@ -332,11 +335,11 @@ void Ogre2DisplacementMap::UpdateTextures(
           double h  = mHeights(idx, 0);
           double sx = mDisplacementsX(idx, 0);
           double sy = mDisplacementsY(idx, 0);
-          double dhdx  = mDhdx(idx, 0); 
-          double dhdy  = mDhdy(idx, 0); 
-          double dsxdx = mDxdx(idx, 0); 
-          double dsydy = mDydy(idx, 0); 
-          double dsxdy = mDxdy(idx, 0); 
+          double dhdx  = mDhdx(idx, 0);
+          double dhdy  = mDhdy(idx, 0);
+          double dsxdx = mDxdx(idx, 0);
+          double dsydy = mDydy(idx, 0);
+          double dsxdy = mDxdy(idx, 0);
 
           // vertex displacements
           Dx += sy;
@@ -415,7 +418,7 @@ void Ogre2DisplacementMap::UpdateTextures(
     Ogre::StagingTexture *stagingTexture =
       mNormalMapStagingTextures[mNormalMapFrameIdx];
     mNormalMapFrameIdx = (mNormalMapFrameIdx + 1) % 3;
-    
+
     stagingTexture->startMapRegion();
     Ogre::TextureBox texBox = stagingTexture->mapRegion(
         mNormalMapImage->getWidth(), mNormalMapImage->getHeight(), 1u, 1u,
@@ -457,3 +460,7 @@ void Ogre2DisplacementMap::UpdateTextures(
     }
   }
 }
+
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/Ogre2DisplacementMap.hh
+++ b/gz-waves/src/systems/waves/Ogre2DisplacementMap.hh
@@ -16,84 +16,83 @@
 #ifndef GZ_RENDERING_OGRE2_OGRE2DISPLACEMENTMAP_HH_
 #define GZ_RENDERING_OGRE2_OGRE2DISPLACEMENTMAP_HH_
 
-#include "DisplacementMap.hh"
+#include <Eigen/Dense>
+
+#include <memory>
 
 #include <gz/rendering/config.hh>
 #include <gz/rendering/Material.hh>
 #include <gz/rendering/Scene.hh>
-#include "gz/rendering/Export.hh"
+#include <gz/rendering/Export.hh>
 
 #include <gz/rendering/ogre2.hh>
 #include <gz/rendering/ogre2/Export.hh>
 
-#include <Eigen/Dense>
-
-#include <memory>
+#include "DisplacementMap.hh"
 
 using Eigen::ArrayXXd;
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    class GZ_RENDERING_OGRE2_VISIBLE Ogre2DisplacementMap :
-        public DisplacementMap
-    {
-      public: Ogre2DisplacementMap(
-        ScenePtr _scene,
-        MaterialPtr _material,
-        uint64_t _entity,
-        uint32_t _width,
-        uint32_t _height);
+class GZ_RENDERING_OGRE2_VISIBLE Ogre2DisplacementMap :
+    public DisplacementMap
+{
+  public: Ogre2DisplacementMap(
+    ScenePtr _scene,
+    MaterialPtr _material,
+    uint64_t _entity,
+    uint32_t _width,
+    uint32_t _height);
 
-      public: virtual ~Ogre2DisplacementMap();
+  public: virtual ~Ogre2DisplacementMap();
 
-      public: virtual void InitTextures() override;
+  public: virtual void InitTextures() override;
 
-      public: virtual void UpdateTextures(
-        const Eigen::Ref<const Eigen::ArrayXXd> &mHeights,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDhdx,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDhdy,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDisplacementsX,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDisplacementsY,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDxdx,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDydy,
-        const Eigen::Ref<const Eigen::ArrayXXd> &mDxdy
-      ) override;
+  public: virtual void UpdateTextures(
+    const Eigen::Ref<const Eigen::ArrayXXd> &mHeights,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDhdx,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDhdy,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDisplacementsX,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDisplacementsY,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDxdx,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDydy,
+    const Eigen::Ref<const Eigen::ArrayXXd> &mDxdy) override;
 
-      private: ScenePtr scene;
-      private: MaterialPtr material;
-      private: uint64_t entity{0};
-      private: uint32_t width{0};
-      private: uint32_t height{0};
+  private: ScenePtr scene;
+  private: MaterialPtr material;
+  private: uint64_t entity{0};
+  private: uint32_t width{0};
+  private: uint32_t height{0};
 
-      private:
-      /// \note: new code adapted from ogre ocean materials sample
-      // textures for displacement, normal and tangent maps
-      Ogre::Image2       *mHeightMapImage{nullptr};
-      Ogre::Image2       *mNormalMapImage{nullptr};
-      Ogre::Image2       *mTangentMapImage{nullptr};
-      Ogre::TextureGpu   *mHeightMapTex{nullptr};
-      Ogre::TextureGpu   *mNormalMapTex{nullptr};
-      Ogre::TextureGpu   *mTangentMapTex{nullptr};
+  private:
+  /// \note: new code adapted from ogre ocean materials sample
+  // textures for displacement, normal and tangent maps
+  Ogre::Image2       *mHeightMapImage{nullptr};
+  Ogre::Image2       *mNormalMapImage{nullptr};
+  Ogre::Image2       *mTangentMapImage{nullptr};
+  Ogre::TextureGpu   *mHeightMapTex{nullptr};
+  Ogre::TextureGpu   *mNormalMapTex{nullptr};
+  Ogre::TextureGpu   *mTangentMapTex{nullptr};
 
-      /// \note Triple buffer staging textures
-      Ogre::StagingTexture* mHeightMapStagingTextures[3] =
-          {nullptr, nullptr, nullptr};
-      Ogre::StagingTexture* mNormalMapStagingTextures[3] =
-          {nullptr, nullptr, nullptr};
-      Ogre::StagingTexture* mTangentMapStagingTextures[3] =
-          {nullptr, nullptr, nullptr};
+  /// \note Triple buffer staging textures
+  Ogre::StagingTexture* mHeightMapStagingTextures[3] =
+      {nullptr, nullptr, nullptr};
+  Ogre::StagingTexture* mNormalMapStagingTextures[3] =
+      {nullptr, nullptr, nullptr};
+  Ogre::StagingTexture* mTangentMapStagingTextures[3] =
+      {nullptr, nullptr, nullptr};
 
-      uint8_t mHeightMapFrameIdx{0};
-      uint8_t mNormalMapFrameIdx{0};
-      uint8_t mTangentMapFrameIdx{0};
-    };
+  uint8_t mHeightMapFrameIdx{0};
+  uint8_t mNormalMapFrameIdx{0};
+  uint8_t mTangentMapFrameIdx{0};
+};
 
-    }
-  }
 }
+}  // namespace rendering
+}  // namespace gz
 
-#endif
+#endif  // GZ_RENDERING_OGRE2_OGRE2DISPLACEMENTMAP_HH_

--- a/gz-waves/src/systems/waves/Ogre2DynamicMesh.cc
+++ b/gz-waves/src/systems/waves/Ogre2DynamicMesh.cc
@@ -63,8 +63,14 @@
   #pragma warning(pop)
 #endif
 
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
 /// \brief Private implementation
-class gz::rendering::Ogre2DynamicMeshPrivate
+class Ogre2DynamicMeshPrivate
 {
   /// \brief list of colors at each point
   public: std::vector<gz::math::Color> colors;
@@ -105,11 +111,18 @@ class gz::rendering::Ogre2DynamicMeshPrivate
   /// \brief Ogre item created from the dynamic geometry
   public: Ogre::Item *ogreItem {nullptr};
 
-  /// \todo if we use binormals then update teh stride and ensure they are set elsewhere
-  /// \brief vertex buffer stride = vertex.xyz + normal.xyz + tangent.xyz + binormal.xyz + uv0.xy
+  /// \todo if we use binormals then update teh stride and ensure
+  ///       they are set elsewhere
+  /// \brief vertex buffer stride =
+  ///             vertex.xyz
+  ///             + normal.xyz + tangent.xyz + binormal.xyz
+  ///             + uv0.xy
   // public: unsigned int stride {3 + 3 + 3 + 3 + 2};
 
-  /// \brief vertex buffer stride = vertex.xyz + normal.xyz + tangent.xyz + uv0.xy
+  /// \brief vertex buffer stride =
+  ///             vertex.xyz
+  ///             + normal.xyz + tangent.xyz
+  ///             + uv0.xy
   public: unsigned int stride {3 + 3 + 3 + 2};
 
   /// \brief raw vertex buffer
@@ -131,10 +144,6 @@ class gz::rendering::Ogre2DynamicMeshPrivate
   /// \brief Pointer to the ogre scene manager
   public: Ogre::SceneManager *sceneManager = nullptr;
 };
-
-
-using namespace gz;
-using namespace rendering;
 
 //////////////////////////////////////////////////
 Ogre2DynamicMesh::Ogre2DynamicMesh(ScenePtr _scene)
@@ -457,11 +466,12 @@ void Ogre2DynamicMesh::UpdateBuffer()
     }
   }
 
-  // \todo add condition to check if normals are to be set or generated, ditto colors
+  /// \todo add condition to check if normals are to be set or generated,
+  ///       ditto colors
 
   // fill normals
-  // this->GenerateNormals(this->dataPtr->operationType, this->dataPtr->vertices,
-  //     vertices);
+  // this->GenerateNormals(this->dataPtr->operationType,
+  //    this->dataPtr->vertices, vertices);
 
   // fill colors for points
   // this->GenerateColors(this->dataPtr->operationType, this->dataPtr->vertices,
@@ -903,9 +913,9 @@ void Ogre2DynamicMesh::GenerateColors(Ogre::OperationType _opType,
 
   unsigned int stride = this->dataPtr->stride;
 
-  // Each vertex occupies 3 + 3 + 2 elements in the vbuffer float array. Normally,
-  // the last 3 are reserved for normals. But for types that don't use normals,
-  // we use them for per-vertex coloring.
+  // Each vertex occupies 3 + 3 + 2 elements in the vbuffer float array.
+  // Normally, the last 3 are reserved for normals. But for types that
+  // don't use normals, we use them for per-vertex coloring.
   // vbuffer[i]   : position x
   // vbuffer[i+1] : position y
   // vbuffer[i+2] : position z
@@ -934,3 +944,7 @@ void Ogre2DynamicMesh::GenerateColors(Ogre::OperationType _opType,
       break;
   }
 }
+
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/Ogre2DynamicMesh.hh
+++ b/gz-waves/src/systems/waves/Ogre2DynamicMesh.hh
@@ -56,149 +56,151 @@
 
 namespace Ogre
 {
-  class MovableObject;
-}
+class MovableObject;
+}  // namespace Ogre
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-    //
-    // forward declarations
-    class Ogre2DynamicMeshPrivate;
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    /*  \class Ogre2DynamicMesh Ogre2DynamicMesh.hh \
-     *  gz/rendering/ogre2/Ogre2DynamicMesh.hh
-     */
-    /// \brief Dynamic mesh class that manages hardware buffers for
-    /// a dynamic mesh
-    class GZ_RENDERING_OGRE2_VISIBLE Ogre2DynamicMesh :
-        public Ogre2Geometry
-    {
-      /// \brief Constructor
-      /// \param[in] _scene Pointer to scene
-      public: explicit Ogre2DynamicMesh(ScenePtr _scene);
+// forward declarations
+class Ogre2DynamicMeshPrivate;
 
-      /// \brief Virtual destructor
-      public: virtual ~Ogre2DynamicMesh();
+/*  \class Ogre2DynamicMesh Ogre2DynamicMesh.hh \
+  *  gz/rendering/ogre2/Ogre2DynamicMesh.hh
+  */
+/// \brief Dynamic mesh class that manages hardware buffers for
+/// a dynamic mesh
+class GZ_RENDERING_OGRE2_VISIBLE Ogre2DynamicMesh :
+    public Ogre2Geometry
+{
+  /// \brief Constructor
+  /// \param[in] _scene Pointer to scene
+  public: explicit Ogre2DynamicMesh(ScenePtr _scene);
 
-      // Documentation inherited.
-      public: virtual void Destroy() override;
+  /// \brief Virtual destructor
+  public: virtual ~Ogre2DynamicMesh();
 
-      // Documentation inherited.
-      public: virtual Ogre::MovableObject *OgreObject() const override;
+  // Documentation inherited.
+  public: virtual void Destroy() override;
 
-      // Documentation inherited.
-      public: virtual MaterialPtr Material() const override;
+  // Documentation inherited.
+  public: virtual Ogre::MovableObject *OgreObject() const override;
 
-      // Documentation inherited.
-      public: virtual void
-          SetMaterial(MaterialPtr _material, bool _unique) override;
+  // Documentation inherited.
+  public: virtual MaterialPtr Material() const override;
 
-      /////////// FROM DYNAMIC RENDERABLE
+  // Documentation inherited.
+  public: virtual void
+      SetMaterial(MaterialPtr _material, bool _unique) override;
 
-      /// \brief Set the render operation type
-      /// \param[in] _opType The type of render operation to perform.
-      public: void SetOperationType(MarkerType _opType);
+  /////////// FROM DYNAMIC RENDERABLE
 
-      /// \brief Get the render operation type
-      /// \return The render operation type.
-      public: MarkerType OperationType() const;
+  /// \brief Set the render operation type
+  /// \param[in] _opType The type of render operation to perform.
+  public: void SetOperationType(MarkerType _opType);
 
-      /// \brief Update the dynamic renderable
-      public: void Update();
+  /// \brief Get the render operation type
+  /// \return The render operation type.
+  public: MarkerType OperationType() const;
 
-      /// \brief Add a point to the point list
-      /// \param[in] _pt gz::math::Vector3d point
-      /// \param[in] _color gz::math::Color Point color
-      public: void AddPoint(const gz::math::Vector3d &_pt,
-            const gz::math::Color &_color = gz::math::Color::White);
+  /// \brief Update the dynamic renderable
+  public: void Update();
 
-      /// \brief Add a point to the point list.
-      /// \param[in] _x X position
-      /// \param[in] _y Y position
-      /// \param[in] _z Z position
-      /// \param[in] _color Point color
-      public: void AddPoint(const double _x, const double _y, const double _z,
-            const gz::math::Color &_color = gz::math::Color::White);
+  /// \brief Add a point to the point list
+  /// \param[in] _pt gz::math::Vector3d point
+  /// \param[in] _color gz::math::Color Point color
+  public: void AddPoint(const gz::math::Vector3d &_pt,
+        const gz::math::Color &_color = gz::math::Color::White);
 
-      /// \brief Change the location of an existing point in the point list
-      /// \param[in] _index Index of the point to set
-      /// \param[in] _value Position of the point
-      public: void SetPoint(unsigned int _index,
-                            const gz::math::Vector3d &_value);
+  /// \brief Add a point to the point list.
+  /// \param[in] _x X position
+  /// \param[in] _y Y position
+  /// \param[in] _z Z position
+  /// \param[in] _color Point color
+  public: void AddPoint(const double _x, const double _y, const double _z,
+        const gz::math::Color &_color = gz::math::Color::White);
 
-      /// \brief Change the color of an existing point in the point list
-      /// \param[in] _index Index of the point to set
-      /// \param[in] _color color to set the point to
-      public: void SetColor(unsigned int _index,
-                            const gz::math::Color &_color);
+  /// \brief Change the location of an existing point in the point list
+  /// \param[in] _index Index of the point to set
+  /// \param[in] _value Position of the point
+  public: void SetPoint(unsigned int _index,
+                        const gz::math::Vector3d &_value);
 
-      /// \brief Change the normal vector of an existing point in the point list
-      /// \param[in] _index Index of the point to set
-      /// \param[in] _normal Normal of the point
-      public: void SetNormal(unsigned int _index,
-                            const gz::math::Vector3d &_normal);
+  /// \brief Change the color of an existing point in the point list
+  /// \param[in] _index Index of the point to set
+  /// \param[in] _color color to set the point to
+  public: void SetColor(unsigned int _index,
+                        const gz::math::Color &_color);
 
-      /// \brief Change the tangent vector of an existing point in the point list
-      /// \param[in] _index Index of the point to set
-      /// \param[in] _normal Tangent of the point
-      public: void SetTangent(unsigned int _index,
-                            const gz::math::Vector3d &_tangent);
+  /// \brief Change the normal vector of an existing point in the point list
+  /// \param[in] _index Index of the point to set
+  /// \param[in] _normal Normal of the point
+  public: void SetNormal(unsigned int _index,
+                        const gz::math::Vector3d &_normal);
 
-      /// \brief Change the texture coordinate of an existing point in the point list
-      /// \param[in] _index Index of the point to set
-      /// \param[in] _uv0 Texture coordinate of the point
-      public: void SetUV0(unsigned int _index,
-                            const gz::math::Vector2d &_uv0);
+  /// \brief Change the tangent vector of an existing point in the point list
+  /// \param[in] _index Index of the point to set
+  /// \param[in] _normal Tangent of the point
+  public: void SetTangent(unsigned int _index,
+                        const gz::math::Vector3d &_tangent);
 
-      /// \brief Return the position of an existing point in the point list
-      /// \param[in] _index Get the point at this index
-      /// \return position of point. A vector of
-      /// [gz::math::INF_D, gz::math::INF_D, gz::math::INF_D]
-      /// is returned when then the _index is out of bounds.
-      /// gz::math::INF_D==std::numeric_limits<double>::infinity()
-      public: gz::math::Vector3d Point(unsigned int _index) const;
+  /// \brief Change the texture coordinate of an existing point
+  ///        in the point list
+  /// \param[in] _index Index of the point to set
+  /// \param[in] _uv0 Texture coordinate of the point
+  public: void SetUV0(unsigned int _index,
+                        const gz::math::Vector2d &_uv0);
 
-      /// \brief Return the total number of points in the point list
-      /// \return Number of points
-      public: unsigned int PointCount() const;
+  /// \brief Return the position of an existing point in the point list
+  /// \param[in] _index Get the point at this index
+  /// \return position of point. A vector of
+  /// [gz::math::INF_D, gz::math::INF_D, gz::math::INF_D]
+  /// is returned when then the _index is out of bounds.
+  /// gz::math::INF_D==std::numeric_limits<double>::infinity()
+  public: gz::math::Vector3d Point(unsigned int _index) const;
 
-      /// \brief Remove all points from the point list
-      public: void Clear();
+  /// \brief Return the total number of points in the point list
+  /// \return Number of points
+  public: unsigned int PointCount() const;
 
-      /// \brief Create the dynamic mesh
-      private: void CreateDynamicMesh();
+  /// \brief Remove all points from the point list
+  public: void Clear();
 
-      /// \brief Update vertex buffer if vertices have changes
-      private: void UpdateBuffer();
+  /// \brief Create the dynamic mesh
+  private: void CreateDynamicMesh();
 
-      /// \brief Helper function to generate normals
-      /// \param[in] _opType Ogre render operation type
-      /// \param[in] _vertices a list of vertices
-      /// \param[in,out] _vbuffer vertex buffer to be filled
-      private: void GenerateNormals(Ogre::OperationType _opType,
-          const std::vector<gz::math::Vector3d> &_vertices, float *_vbuffer);
+  /// \brief Update vertex buffer if vertices have changes
+  private: void UpdateBuffer();
 
-      /// \brief Helper function to generate colors per-vertex. Only applies
-      /// to points. The colors fill the normal slots on the vertex buffer.
-      /// \param[in] _opType Ogre render operation type
-      /// \param[in] _vertices a list of vertices
-      /// \param[in,out] _vbuffer vertex buffer to be filled
-      private: void GenerateColors(Ogre::OperationType _opType,
-          const std::vector<gz::math::Vector3d> &_vertices, float *_vbuffer);
+  /// \brief Helper function to generate normals
+  /// \param[in] _opType Ogre render operation type
+  /// \param[in] _vertices a list of vertices
+  /// \param[in,out] _vbuffer vertex buffer to be filled
+  private: void GenerateNormals(Ogre::OperationType _opType,
+      const std::vector<gz::math::Vector3d> &_vertices, float *_vbuffer);
 
-      /// \brief Destroy the vertex buffer
-      private: void DestroyBuffer();
+  /// \brief Helper function to generate colors per-vertex. Only applies
+  /// to points. The colors fill the normal slots on the vertex buffer.
+  /// \param[in] _opType Ogre render operation type
+  /// \param[in] _vertices a list of vertices
+  /// \param[in,out] _vbuffer vertex buffer to be filled
+  private: void GenerateColors(Ogre::OperationType _opType,
+      const std::vector<gz::math::Vector3d> &_vertices, float *_vbuffer);
 
-      /// \brief Pointer to private data
-      private: std::unique_ptr<Ogre2DynamicMeshPrivate> dataPtr;
-    };
+  /// \brief Destroy the vertex buffer
+  private: void DestroyBuffer();
 
-    typedef std::shared_ptr<Ogre2DynamicMesh> Ogre2DynamicMeshPtr;
+  /// \brief Pointer to private data
+  private: std::unique_ptr<Ogre2DynamicMeshPrivate> dataPtr;
+};
 
-    }
-  }
+typedef std::shared_ptr<Ogre2DynamicMesh> Ogre2DynamicMeshPtr;
+
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_OGRE2_OGRE2DYNAMICMESH_HH_

--- a/gz-waves/src/systems/waves/Ogre2OceanGeometry.cc
+++ b/gz-waves/src/systems/waves/Ogre2OceanGeometry.cc
@@ -14,16 +14,23 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "Ogre2OceanGeometry.hh"
-#include "Ogre2DynamicMesh.hh"
-
-#include "gz/common/SubMeshWithTangents.hh"
 
 #include <gz/common.hh>
 #include <gz/rendering/ogre2/Ogre2Material.hh>
 #include <gz/rendering/ogre2/Ogre2Scene.hh>
 
+#include "gz/common/SubMeshWithTangents.hh"
+
+#include "Ogre2DynamicMesh.hh"
+
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
 /// \brief Private implementation
-class gz::rendering::Ogre2OceanGeometryPrivate
+class Ogre2OceanGeometryPrivate
 {
   /// \brief OceanGeometry materal
   public: Ogre2MaterialPtr material{nullptr};
@@ -34,9 +41,6 @@ class gz::rendering::Ogre2OceanGeometryPrivate
   /// \brief Lazy evaluation flag
   // public: bool dirty{true};
 };
-
-using namespace gz;
-using namespace rendering;
 
 //////////////////////////////////////////////////
 Ogre2OceanGeometry::Ogre2OceanGeometry() :
@@ -219,3 +223,7 @@ void Ogre2OceanGeometry::InitObject(ScenePtr _scene,
   this->Load();
   this->Init();
 }
+
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/Ogre2OceanGeometry.hh
+++ b/gz-waves/src/systems/waves/Ogre2OceanGeometry.hh
@@ -16,76 +16,79 @@
 #ifndef GZ_RENDERING_OGRE2_OGRE2OCEANGEOMETRY_HH_
 #define GZ_RENDERING_OGRE2_OGRE2OCEANGEOMETRY_HH_
 
-#include "BaseOceanGeometry.hh"
+#include <memory>
+#include <string>
 
 #include <gz/rendering/ogre2/Export.hh>
 #include <gz/rendering/ogre2/Ogre2Geometry.hh>
 #include <gz/rendering/RenderTypes.hh>
 
-#include <memory>
+#include "BaseOceanGeometry.hh"
 
 namespace Ogre
 {
-  class MovableObject;
-}
+class MovableObject;
+}  // namespace Ogre
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-    // Forward declarations
-    class Ogre2OceanGeometryPrivate;
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    /// \brief Ocean geometry class based on a dynamic mesh
-    class GZ_RENDERING_OGRE2_VISIBLE Ogre2OceanGeometry :
-        public BaseOceanGeometry<Ogre2Geometry>
-    {
-      /// \brief Constructor
-      public: explicit Ogre2OceanGeometry();
+// Forward declarations
+class Ogre2OceanGeometryPrivate;
 
-      /// \brief Destructor
-      public: virtual ~Ogre2OceanGeometry();
+/// \brief Ocean geometry class based on a dynamic mesh
+class GZ_RENDERING_OGRE2_VISIBLE Ogre2OceanGeometry :
+    public BaseOceanGeometry<Ogre2Geometry>
+{
+  /// \brief Constructor
+  public: explicit Ogre2OceanGeometry();
 
-      // Documentation inherited.
-      public: virtual void Init() override;
+  /// \brief Destructor
+  public: virtual ~Ogre2OceanGeometry();
 
-      // Documentation inherited.
-      public: virtual void Destroy() override;
+  // Documentation inherited.
+  public: virtual void Init() override;
 
-      // Documentation inherited.
-      public: virtual Ogre::MovableObject *OgreObject() const override;
+  // Documentation inherited.
+  public: virtual void Destroy() override;
 
-      // Documentation inherited.
-      public: virtual void PreRender() override;
+  // Documentation inherited.
+  public: virtual Ogre::MovableObject *OgreObject() const override;
 
-      // Documentation inherited.
-      public: virtual MaterialPtr Material() const override;
+  // Documentation inherited.
+  public: virtual void PreRender() override;
 
-      // Documentation inherited.
-      public: virtual void
-        SetMaterial(MaterialPtr _material, bool _unique) override;
+  // Documentation inherited.
+  public: virtual MaterialPtr Material() const override;
 
-      /// \brief Load from a mesh
-      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
+  // Documentation inherited.
+  public: virtual void
+    SetMaterial(MaterialPtr _material, bool _unique) override;
 
-      /// \brief Update from a mesh
-      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
+  /// \brief Load from a mesh
+  public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
 
-      /// \brief Work-around the protected accessors and protected methods in Scene
-      public: virtual void InitObject(ScenePtr _scene,
-          unsigned int _id, const std::string &_name) override;
+  /// \brief Update from a mesh
+  public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
 
-      /// \brief OceanGeometry should be created by scene.
-      private: friend class Ogre2Scene;
+  /// \brief Work-around the protected accessors and protected methods in Scene
+  public: virtual void InitObject(ScenePtr _scene,
+      unsigned int _id, const std::string &_name) override;
 
-      /// \brief Pointer to private data
-      private: std::unique_ptr<Ogre2OceanGeometryPrivate> dataPtr;
-    };
+  /// \brief OceanGeometry should be created by scene.
+  private: friend class Ogre2Scene;
 
-    typedef std::shared_ptr<Ogre2OceanGeometry> Ogre2OceanGeometryPtr;
+  /// \brief Pointer to private data
+  private: std::unique_ptr<Ogre2OceanGeometryPrivate> dataPtr;
+};
 
-    }
-  }
+typedef std::shared_ptr<Ogre2OceanGeometry> Ogre2OceanGeometryPtr;
+
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_OGRE2_OGRE2OCEANGEOMETRY_HH_

--- a/gz-waves/src/systems/waves/Ogre2OceanVisual.cc
+++ b/gz-waves/src/systems/waves/Ogre2OceanVisual.cc
@@ -14,9 +14,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "Ogre2OceanVisual.hh"
-#include "Ogre2DynamicMesh.hh"
-
-#include "gz/common/SubMeshWithTangents.hh"
 
 #include <gz/common.hh>
 #include <gz/common/SubMesh.hh>
@@ -31,10 +28,17 @@
   #pragma warning(pop)
 #endif
 
-using namespace gz;
-using namespace rendering;
+#include "gz/common/SubMeshWithTangents.hh"
 
-class gz::rendering::Ogre2OceanVisualPrivate
+#include "Ogre2DynamicMesh.hh"
+
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+class Ogre2OceanVisualPrivate
 {
   /// \brief visual materal
   public: Ogre2MaterialPtr material = nullptr;
@@ -133,12 +137,12 @@ void Ogre2OceanVisual::LoadCube()
   // must specify vertices for each face and get
   // the orientation correct.
   gz::math::Vector3d p0(-1, -1,  1);
-  gz::math::Vector3d p1( 1, -1,  1);
-  gz::math::Vector3d p2( 1,  1,  1);
+  gz::math::Vector3d p1(+1, -1,  1);
+  gz::math::Vector3d p2(+1,  1,  1);
   gz::math::Vector3d p3(-1,  1,  1);
   gz::math::Vector3d p4(-1, -1, -1);
-  gz::math::Vector3d p5( 1, -1, -1);
-  gz::math::Vector3d p6( 1,  1, -1);
+  gz::math::Vector3d p5(+1, -1, -1);
+  gz::math::Vector3d p6(+1,  1, -1);
   gz::math::Vector3d p7(-1,  1, -1);
 
   // front face
@@ -361,3 +365,7 @@ void Ogre2OceanVisual::InitObject(ScenePtr _scene,
   this->Load();
   this->Init();
 }
+
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/Ogre2OceanVisual.hh
+++ b/gz-waves/src/systems/waves/Ogre2OceanVisual.hh
@@ -16,83 +16,85 @@
 #ifndef GZ_RENDERING_OGRE2_OGRE2OCEANVISUAL_HH_
 #define GZ_RENDERING_OGRE2_OGRE2OCEANVISUAL_HH_
 
-#include "BaseOceanVisual.hh"
-
-#include "gz/waves/OceanTile.hh"
+#include <memory>
+#include <string>
 
 #include <gz/rendering/ogre2/Ogre2Visual.hh>
 
-#include <memory>
+#include "gz/waves/OceanTile.hh"
+
+#include "BaseOceanVisual.hh"
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    // Forward declaration
-    class Ogre2OceanVisualPrivate;
+// Forward declaration
+class Ogre2OceanVisualPrivate;
 
-    /// \brief Ogre2.x implementation of an ocean visual class
-    class GZ_RENDERING_OGRE2_VISIBLE Ogre2OceanVisual :
-      public BaseOceanVisual<Ogre2Visual>
-    {
-      /// \brief Constructor
-      public: Ogre2OceanVisual();
+/// \brief Ogre2.x implementation of an ocean visual class
+class GZ_RENDERING_OGRE2_VISIBLE Ogre2OceanVisual :
+  public BaseOceanVisual<Ogre2Visual>
+{
+  /// \brief Constructor
+  public: Ogre2OceanVisual();
 
-      /// \brief Destructor
-      public: virtual ~Ogre2OceanVisual();
+  /// \brief Destructor
+  public: virtual ~Ogre2OceanVisual();
 
-      // Documentation inherited.
-      public: virtual void Init() override;
+  // Documentation inherited.
+  public: virtual void Init() override;
 
-      // Documentation inherited.
-      public: virtual void PreRender() override;
+  // Documentation inherited.
+  public: virtual void PreRender() override;
 
-      // Documentation inherited.
-      protected: virtual void Destroy() override;
+  // Documentation inherited.
+  protected: virtual void Destroy() override;
 
-      // Documentation inherited.
-      public: virtual MaterialPtr Material() const override;
+  // Documentation inherited.
+  public: virtual MaterialPtr Material() const override;
 
-      // Documentation inherited.
-      public: virtual void SetMaterial(
-        MaterialPtr _material, bool _unique) override;
+  // Documentation inherited.
+  public: virtual void SetMaterial(
+    MaterialPtr _material, bool _unique) override;
 
-      /// \brief Load a dynamic cube (example)
-      public: virtual void LoadCube() override;
+  /// \brief Load a dynamic cube (example)
+  public: virtual void LoadCube() override;
 
-      /// \brief Load from an ocean tile
-      public: virtual void LoadOceanTile(
-          waves::visual::OceanTilePtr _oceanTile) override;
+  /// \brief Load from an ocean tile
+  public: virtual void LoadOceanTile(
+      waves::visual::OceanTilePtr _oceanTile) override;
 
-      /// \brief Update from an ocean tile
-      public: virtual void UpdateOceanTile(
-          waves::visual::OceanTilePtr _oceanTile) override;
+  /// \brief Update from an ocean tile
+  public: virtual void UpdateOceanTile(
+      waves::visual::OceanTilePtr _oceanTile) override;
 
-      /// \brief Load from a mesh
-      public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
+  /// \brief Load from a mesh
+  public: virtual void LoadMesh(gz::common::MeshPtr _mesh) override;
 
-      /// \brief Update from a mesh
-      public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
+  /// \brief Update from a mesh
+  public: virtual void UpdateMesh(gz::common::MeshPtr _mesh) override;
 
-      /// \brief Set material to geometry.
-      /// \param[in] _material Ogre material.
-      protected: virtual void SetMaterialImpl(Ogre2MaterialPtr _material);
+  /// \brief Set material to geometry.
+  /// \param[in] _material Ogre material.
+  protected: virtual void SetMaterialImpl(Ogre2MaterialPtr _material);
 
-      /// \brief Work-around the protected accessors and protected methods in Scene
-      public: virtual void InitObject(ScenePtr _scene,
-          unsigned int _id, const std::string &_name) override;
+  /// \brief Work-around the protected accessors and protected methods in Scene
+  public: virtual void InitObject(ScenePtr _scene,
+      unsigned int _id, const std::string &_name) override;
 
-      private: friend class Ogre2Scene;
+  private: friend class Ogre2Scene;
 
-      /// \brief Private data class
-      private: std::unique_ptr<Ogre2OceanVisualPrivate> dataPtr;
-    };
+  /// \brief Private data class
+  private: std::unique_ptr<Ogre2OceanVisualPrivate> dataPtr;
+};
 
-    typedef std::shared_ptr<Ogre2OceanVisual> Ogre2OceanVisualPtr;
+typedef std::shared_ptr<Ogre2OceanVisual> Ogre2OceanVisualPtr;
 
-    }
-  }
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_OGRE2_OGRE2OCEANVISUAL_HH_

--- a/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.cc
+++ b/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.cc
@@ -15,25 +15,26 @@
 
 #include "Ogre2RenderEngineExtension.hh"
 
-#include "SceneNodeFactory.hh"
-#include "Ogre2SceneNodeFactory.hh"
-
 #include <gz/common/Console.hh>
 #include <gz/plugin/Register.hh>
 
 #include <gz/rendering/RenderEngine.hh>
 #include <gz/rendering/RenderingIface.hh>
 
+#include "SceneNodeFactory.hh"
+#include "Ogre2SceneNodeFactory.hh"
+
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
 //////////////////////////////////////////////////
-class GZ_RENDERING_OGRE2_HIDDEN
-    gz::rendering::Ogre2RenderEngineExtensionPrivate
+class GZ_RENDERING_OGRE2_HIDDEN Ogre2RenderEngineExtensionPrivate
 {
-  public: gz::rendering::SceneNodeFactoryPtr sceneNodeFactory;
+  public: SceneNodeFactoryPtr sceneNodeFactory;
 };
-
-using namespace gz;
-using namespace rendering;
 
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
@@ -156,6 +157,10 @@ SceneNodeFactoryPtr Ogre2RenderEngineExtension::SceneNodeFactory() const
 {
   return this->dataPtr->sceneNodeFactory;
 }
+
+}
+}  // namespace rendering
+}  // namespace gz
 
 //////////////////////////////////////////////////
 // Register this plugin

--- a/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.hh
+++ b/gz-waves/src/systems/waves/Ogre2RenderEngineExtension.hh
@@ -16,9 +16,9 @@
 #ifndef GZ_RENDERING_OGRE2_RENDERENGINEEXTENSION_HH_
 #define GZ_RENDERING_OGRE2_RENDERENGINEEXTENSION_HH_
 
-#include "BaseRenderEngineExtension.hh"
-#include "RenderEngineExtensionPlugin.hh"
-#include "RenderEngineExtension.hh"
+#include <map>
+#include <memory>
+#include <string>
 
 #include <gz/common/SingletonT.hh>
 
@@ -28,63 +28,63 @@
 #include "gz/rendering/ogre2/Ogre2RenderTypes.hh"
 #include <gz/rendering/ogre2/Export.hh>
 
-#include <map>
-#include <memory>
-#include <string>
+#include "BaseRenderEngineExtension.hh"
+#include "RenderEngineExtensionPlugin.hh"
+#include "RenderEngineExtension.hh"
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-    
-    // Forward declaration
-    class  Ogre2RenderEngineExtensionPrivate;
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    class GZ_RENDERING_OGRE2_VISIBLE Ogre2RenderEngineExtensionPlugin :
-      public RenderEngineExtensionPlugin
-    {
-      public: Ogre2RenderEngineExtensionPlugin();
+// Forward declaration
+class  Ogre2RenderEngineExtensionPrivate;
 
-      public: ~Ogre2RenderEngineExtensionPlugin();
+class GZ_RENDERING_OGRE2_VISIBLE Ogre2RenderEngineExtensionPlugin :
+  public RenderEngineExtensionPlugin
+{
+  public: Ogre2RenderEngineExtensionPlugin();
 
-      public: std::string Name() const;
+  public: ~Ogre2RenderEngineExtensionPlugin();
 
-      public: RenderEngineExtension *Extension() const;
-    };
+  public: std::string Name() const;
 
-    class GZ_RENDERING_OGRE2_VISIBLE Ogre2RenderEngineExtension :
-        public virtual BaseRenderEngineExtension,
-        public common::SingletonT<Ogre2RenderEngineExtension>
-    {
-      private: Ogre2RenderEngineExtension();
+  public: RenderEngineExtension *Extension() const;
+};
 
-      public: virtual ~Ogre2RenderEngineExtension();
+class GZ_RENDERING_OGRE2_VISIBLE Ogre2RenderEngineExtension :
+    public virtual BaseRenderEngineExtension,
+    public common::SingletonT<Ogre2RenderEngineExtension>
+{
+  private: Ogre2RenderEngineExtension();
 
-      public: virtual void Destroy() override;
+  public: virtual ~Ogre2RenderEngineExtension();
 
-      public: virtual std::string Name() const override;
+  public: virtual void Destroy() override;
 
-      public: virtual SceneNodeFactoryPtr SceneNodeFactory() const override;
+  public: virtual std::string Name() const override;
 
-      protected: virtual bool LoadImpl(
-          const std::map<std::string, std::string> &_params) override;
+  public: virtual SceneNodeFactoryPtr SceneNodeFactory() const override;
 
-      protected: virtual bool InitImpl() override;
+  protected: virtual bool LoadImpl(
+      const std::map<std::string, std::string> &_params) override;
 
-      private: void LoadAttempt();
+  protected: virtual bool InitImpl() override;
 
-      private: void InitAttempt();
+  private: void LoadAttempt();
 
-      /// \brief Pointer to private data
-      private: std::unique_ptr<Ogre2RenderEngineExtensionPrivate> dataPtr;
+  private: void InitAttempt();
 
-      /// \brief Singleton setup
-      private: friend class common::SingletonT<Ogre2RenderEngineExtension>;
-    };
+  /// \brief Pointer to private data
+  private: std::unique_ptr<Ogre2RenderEngineExtensionPrivate> dataPtr;
 
-    }
-  }
+  /// \brief Singleton setup
+  private: friend class common::SingletonT<Ogre2RenderEngineExtension>;
+};
+
 }
+}  // namespace rendering
+}  // namespace gz
 
-#endif
+#endif  // GZ_RENDERING_OGRE2_RENDERENGINEEXTENSION_HH_

--- a/gz-waves/src/systems/waves/Ogre2SceneNodeFactory.cc
+++ b/gz-waves/src/systems/waves/Ogre2SceneNodeFactory.cc
@@ -15,6 +15,9 @@
 
 #include "Ogre2SceneNodeFactory.hh"
 
+#include <memory>
+#include <string>
+
 #include "DisplacementMap.hh"
 #include "OceanGeometry.hh"
 #include "OceanVisual.hh"
@@ -23,8 +26,11 @@
 #include "Ogre2OceanGeometry.hh"
 #include "Ogre2OceanVisual.hh"
 
-using namespace gz;
-using namespace rendering;
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
 //////////////////////////////////////////////////
 Ogre2SceneNodeFactory::Ogre2SceneNodeFactory()
@@ -46,7 +52,7 @@ OceanVisualPtr Ogre2SceneNodeFactory::CreateOceanVisual(ScenePtr _scene)
 
   // create visual
   rendering::OceanVisualPtr visual =
-      std::make_shared<rendering::Ogre2OceanVisual>(); 
+      std::make_shared<rendering::Ogre2OceanVisual>();
   visual->InitObject(_scene, objId, objName);
 
   return visual;
@@ -62,7 +68,7 @@ OceanGeometryPtr Ogre2SceneNodeFactory::CreateOceanGeometry(ScenePtr _scene)
 
   // create geometry
   rendering::OceanGeometryPtr geometry =
-      std::make_shared<rendering::Ogre2OceanGeometry>(); 
+      std::make_shared<rendering::Ogre2OceanGeometry>();
   geometry->InitObject(_scene, objId, objName);
 
   return geometry;
@@ -78,7 +84,11 @@ DisplacementMapPtr Ogre2SceneNodeFactory::CreateDisplacementMap(
 {
   rendering::DisplacementMapPtr displacementMap =
       std::make_shared<rendering::Ogre2DisplacementMap>(
-          _scene, _material, _entity, _width, _height); 
+          _scene, _material, _entity, _width, _height);
 
   return displacementMap;
 }
+
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/Ogre2SceneNodeFactory.hh
+++ b/gz-waves/src/systems/waves/Ogre2SceneNodeFactory.hh
@@ -16,49 +16,50 @@
 #ifndef GZ_RENDERING_OGRE2_SCENENODEFACTORY_HH_
 #define GZ_RENDERING_OGRE2_SCENENODEFACTORY_HH_
 
-#include "SceneNodeFactory.hh"
-
 #include <gz/rendering/config.hh>
 #include <gz/rendering/Scene.hh>
 #include "gz/rendering/Export.hh"
 
 #include <gz/rendering/ogre2/Export.hh>
 
+#include "SceneNodeFactory.hh"
+
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    class GZ_RENDERING_OGRE2_VISIBLE Ogre2SceneNodeFactory :
-        public SceneNodeFactory
-    {
-      /// \brief Constructor
-      public: Ogre2SceneNodeFactory();
+class GZ_RENDERING_OGRE2_VISIBLE Ogre2SceneNodeFactory :
+    public SceneNodeFactory
+{
+  /// \brief Constructor
+  public: Ogre2SceneNodeFactory();
 
-      /// \brief Destructor
-      public: virtual ~Ogre2SceneNodeFactory();
+  /// \brief Destructor
+  public: virtual ~Ogre2SceneNodeFactory();
 
-      /// \brief Create an ocean visual
-      public: virtual OceanVisualPtr CreateOceanVisual(
-          ScenePtr _scene) override;
-    
-      /// \brief Create an ocean geometry
-      public: virtual OceanGeometryPtr CreateOceanGeometry(
-          ScenePtr _scene) override;
+  /// \brief Create an ocean visual
+  public: virtual OceanVisualPtr CreateOceanVisual(
+      ScenePtr _scene) override;
 
-      /// \brief Create a displacement map
-      public: virtual DisplacementMapPtr CreateDisplacementMap(
-          ScenePtr _scene,
-          MaterialPtr _material,
-          uint64_t _entity,
-          uint32_t _width,
-          uint32_t _height) override;
+  /// \brief Create an ocean geometry
+  public: virtual OceanGeometryPtr CreateOceanGeometry(
+      ScenePtr _scene) override;
 
-      private: unsigned int objId{50000};
-    };
+  /// \brief Create a displacement map
+  public: virtual DisplacementMapPtr CreateDisplacementMap(
+      ScenePtr _scene,
+      MaterialPtr _material,
+      uint64_t _entity,
+      uint32_t _width,
+      uint32_t _height) override;
 
-    }
-  }
+  private: unsigned int objId{50000};
+};
+
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_OGRE2_SCENENODEFACTORY_HH_

--- a/gz-waves/src/systems/waves/RenderEngineExtension.cc
+++ b/gz-waves/src/systems/waves/RenderEngineExtension.cc
@@ -15,9 +15,15 @@
 
 #include "RenderEngineExtension.hh"
 
-using namespace gz;
-using namespace rendering;
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-//////////////////////////////////////////////////
 RenderEngineExtension::~RenderEngineExtension() = default;
+
+}
+}  // namespace rendering
+}  // namespace gz
 

--- a/gz-waves/src/systems/waves/RenderEngineExtension.hh
+++ b/gz-waves/src/systems/waves/RenderEngineExtension.hh
@@ -34,58 +34,61 @@
 #ifndef GZ_RENDERING_RENDERENGINEEXTENSION_HH_
 #define GZ_RENDERING_RENDERENGINEEXTENSION_HH_
 
-#include "SceneNodeFactory.hh"
-
 #include <map>
 #include <string>
+
 #include <gz/rendering/config.hh>
 #include <gz/rendering/GraphicsAPI.hh>
 #include <gz/rendering/RenderTypes.hh>
 #include <gz/rendering/Export.hh>
 
+#include "SceneNodeFactory.hh"
+
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-    //
-    /// \brief An abstract interface to a concrete render-engine extension.
-    class GZ_RENDERING_VISIBLE RenderEngineExtension
-    {
-      /// \brief Destructor
-      public: virtual ~RenderEngineExtension();
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+//
+/// \brief An abstract interface to a concrete render-engine extension.
+class GZ_RENDERING_VISIBLE RenderEngineExtension
+{
+  /// \brief Destructor
+  public: virtual ~RenderEngineExtension();
 
-      /// \brief Load any necessary resources to set up the extension. This
-      /// should called before any other function.
-      /// \param[in] _params Parameters to be passed to the underlying
-      /// rendering engine extension.
-      /// \return True if the extension was successfully loaded
-      public: virtual bool Load(
-          const std::map<std::string, std::string> &_params = {}) = 0;
+  /// \brief Load any necessary resources to set up the extension. This
+  /// should called before any other function.
+  /// \param[in] _params Parameters to be passed to the underlying
+  /// rendering engine extension.
+  /// \return True if the extension was successfully loaded
+  public: virtual bool Load(
+      const std::map<std::string, std::string> &_params = {}) = 0;
 
-      /// \brief Initialize the extension. This should be called immediately
-      /// after a successful call to Load.
-      /// \return True if the extension was successfully initialized
-      public: virtual bool Init() = 0;
+  /// \brief Initialize the extension. This should be called immediately
+  /// after a successful call to Load.
+  /// \return True if the extension was successfully initialized
+  public: virtual bool Init() = 0;
 
-      /// \brief Destroys all scenes created by extension and releases all
-      /// loaded resources. This should be called when the given extension
-      /// will no longer be used during runtime.
-      /// \return True if the extension was successfully destroyed
-      public: virtual void Destroy() = 0;
+  /// \brief Destroys all scenes created by extension and releases all
+  /// loaded resources. This should be called when the given extension
+  /// will no longer be used during runtime.
+  /// \return True if the extension was successfully destroyed
+  public: virtual void Destroy() = 0;
 
-      /// \brief Determines if the extension has been initialized.
-      /// \return True if the extension is initialized
-      public: virtual bool IsInitialized() const = 0;
+  /// \brief Determines if the extension has been initialized.
+  /// \return True if the extension is initialized
+  public: virtual bool IsInitialized() const = 0;
 
-      /// \brief Get name of the extension.
-      /// \return The extension name
-      public: virtual std::string Name() const = 0;
+  /// \brief Get name of the extension.
+  /// \return The extension name
+  public: virtual std::string Name() const = 0;
 
-      /// \brief Get the SceneNodeFactory.
-      public: virtual SceneNodeFactoryPtr SceneNodeFactory() const = 0;
-    };
-    }
-  }
+  /// \brief Get the SceneNodeFactory.
+  public: virtual SceneNodeFactoryPtr SceneNodeFactory() const = 0;
+};
+
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_RENDERENGINEEXTENSION_HH_

--- a/gz-waves/src/systems/waves/RenderEngineExtensionManager.cc
+++ b/gz-waves/src/systems/waves/RenderEngineExtensionManager.cc
@@ -32,19 +32,23 @@
  *
  */
 
-#include "RenderEngineExtensionManager.hh"
-#include "RenderEngineExtension.hh"
-#include "RenderEngineExtensionPlugin.hh"
-
+#include <map>
+#include <mutex>
 
 #include <gz/common/Console.hh>
 #include <gz/common/SystemPaths.hh>
 #include <gz/plugin/Loader.hh>
 #include <gz/rendering/config.hh>
 
-#include <map>
-#include <mutex>
+#include "RenderEngineExtensionManager.hh"
+#include "RenderEngineExtension.hh"
+#include "RenderEngineExtensionPlugin.hh"
 
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
 /// \brief Holds information about an extension
 struct ExtensionInfo
@@ -54,11 +58,11 @@ struct ExtensionInfo
   std::string name;
 
   /// \brief The pointer to the render extension.
-  gz::rendering::RenderEngineExtension *extension;
+  RenderEngineExtension *extension;
 };
 
 /// \brief Private implementation of the RenderEngineExtensionManager class.
-class gz::rendering::RenderEngineExtensionManagerPrivate
+class RenderEngineExtensionManagerPrivate
 {
   /// \brief ExtensionMap that maps extension name to an extension pointer.
   typedef std::map<std::string, RenderEngineExtension *> ExtensionMap;
@@ -85,8 +89,9 @@ class gz::rendering::RenderEngineExtensionManagerPrivate
 
   /// \brief Unregister an extension using an ExtensionMap iterator.
   /// Once an extension is unregistered, it can no longer be loaded. Use
-  /// RenderEngineExtensionManagerPrivate::UnloadExtension to unload the extension
-  /// without unregistering it if you wish to load the extension again
+  /// RenderEngineExtensionManagerPrivate::UnloadExtension to unload the
+  /// extension without unregistering it if you wish to load the
+  /// extension again
   /// \param[in] _iter ExtensionMap iterator
   public: void UnregisterExtension(ExtensionIter _iter);
 
@@ -124,11 +129,7 @@ class gz::rendering::RenderEngineExtensionManagerPrivate
   public: std::recursive_mutex extensionsMutex;
 };
 
-using namespace gz;
-using namespace rendering;
-
 //////////////////////////////////////////////////
-// RenderEngineExtensionManager
 //////////////////////////////////////////////////
 RenderEngineExtensionManager::RenderEngineExtensionManager() :
   dataPtr(new RenderEngineExtensionManagerPrivate)
@@ -578,10 +579,15 @@ bool RenderEngineExtensionManagerPrivate::UnloadExtensionPlugin(
 }
 
 //////////////////////////////////////////////////
-void RenderEngineExtensionManagerPrivate::UnregisterExtension(ExtensionIter _iter)
+void RenderEngineExtensionManagerPrivate::UnregisterExtension(
+    ExtensionIter _iter)
 {
   _iter->second->Destroy();
 
   std::lock_guard<std::recursive_mutex> lock(this->extensionsMutex);
   this->extensions.erase(_iter);
 }
+
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/RenderEngineExtensionManager.hh
+++ b/gz-waves/src/systems/waves/RenderEngineExtensionManager.hh
@@ -40,6 +40,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include <gz/common/SingletonT.hh>
 #include <gz/utils/SuppressWarning.hh>
 #include <gz/rendering/config.hh>
@@ -47,124 +48,126 @@
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-    //
-    // forward declarations.
-    class RenderEngineExtension;
-    class RenderEngineExtensionManagerPrivate;
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    /// \class RenderEngineExtensionManager RenderEngineExtensionManager.hh
-    /// gz/rendering/RenderEngineExtensionManager.hh
-    /// \brief Collection of render-engine extensions. This provides access to
-    /// all the extensions available at runtime.
-    /// RenderEngineExtension objects should not be access directly, but instead
-    /// via the RenderEngineExtensionManager to maintain a flexible
-    /// render-engine agnostic design.
-    class GZ_RENDERING_VISIBLE RenderEngineExtensionManager :
-      public virtual common::SingletonT<RenderEngineExtensionManager>
-    {
-      /// \brief Constructor
-      public: RenderEngineExtensionManager();
+// forward declarations.
+class RenderEngineExtension;
+class RenderEngineExtensionManagerPrivate;
 
-      /// \brief Destructor
-      public: ~RenderEngineExtensionManager();
+/// \class RenderEngineExtensionManager RenderEngineExtensionManager.hh
+/// gz/rendering/RenderEngineExtensionManager.hh
+/// \brief Collection of render-engine extensions. This provides access to
+/// all the extensions available at runtime.
+/// RenderEngineExtension objects should not be access directly, but instead
+/// via the RenderEngineExtensionManager to maintain a flexible
+/// render-engine agnostic design.
+class GZ_RENDERING_VISIBLE RenderEngineExtensionManager :
+  public virtual common::SingletonT<RenderEngineExtensionManager>
+{
+  /// \brief Constructor
+  public: RenderEngineExtensionManager();
 
-      /// \brief Get the number of available extensions
-      /// \return the number of available extensions
-      public: unsigned int ExtensionCount() const;
+  /// \brief Destructor
+  public: ~RenderEngineExtensionManager();
 
-      /// \brief Determine if an extension with the given name is avaiable.
-      /// It also checks the list of default extensions supplied by
-      /// gz-rendering.
-      /// \param[in] _name Name of the desired extension
-      /// \return True if the specified extension is available
-      public: bool HasExtension(const std::string &_name) const;
+  /// \brief Get the number of available extensions
+  /// \return the number of available extensions
+  public: unsigned int ExtensionCount() const;
 
-      /// \brief Determine if an extension with the given name is already
-      /// loaded.
-      /// \param[in] _name Name of the desired extension
-      /// \return True if the specified extension is loaded.
-      public: bool IsExtensionLoaded(const std::string &_name) const;
+  /// \brief Determine if an extension with the given name is avaiable.
+  /// It also checks the list of default extensions supplied by
+  /// gz-rendering.
+  /// \param[in] _name Name of the desired extension
+  /// \return True if the specified extension is available
+  public: bool HasExtension(const std::string &_name) const;
 
-      /// \brief Get the list of all extensions already loaded.
-      /// \return Names of all loaded extensions.
-      public: std::vector<std::string> LoadedExtensions() const;
+  /// \brief Determine if an extension with the given name is already
+  /// loaded.
+  /// \param[in] _name Name of the desired extension
+  /// \return True if the specified extension is loaded.
+  public: bool IsExtensionLoaded(const std::string &_name) const;
 
-      /// \brief Get the extension with the given name. If the no
-      /// extension is registered under the given name, NULL will be
-      /// returned.
-      /// \param[in] _name Name of the desired extension
-      /// \param[in] _params Parameters to be passed to the extension.
-      /// \param[in] _path Another search path for extension plugin.
-      /// \return The specified extension
-      public: RenderEngineExtension *Extension(const std::string &_name,
-                  const std::map<std::string, std::string> &_params = {},
-                  const std::string &_path = "");
+  /// \brief Get the list of all extensions already loaded.
+  /// \return Names of all loaded extensions.
+  public: std::vector<std::string> LoadedExtensions() const;
 
-      /// \brief Get the extension at the given index. If no
-      /// extension is exists at the given index, NULL will be returned.
-      /// \param[in] _index Index of the desired extension
-      /// \param[in] _params Parameters to be passed to the render engine.
-      /// \param[in] _path Another search path for rendering engine plugin.
-      /// \return The specified extension
-      public: RenderEngineExtension *ExtensionAt(unsigned int _index,
-                  const std::map<std::string, std::string> &_params = {},
-                  const std::string &_path = "");
+  /// \brief Get the extension with the given name. If the no
+  /// extension is registered under the given name, NULL will be
+  /// returned.
+  /// \param[in] _name Name of the desired extension
+  /// \param[in] _params Parameters to be passed to the extension.
+  /// \param[in] _path Another search path for extension plugin.
+  /// \return The specified extension
+  public: RenderEngineExtension *Extension(const std::string &_name,
+              const std::map<std::string, std::string> &_params = {},
+              const std::string &_path = "");
 
-      /// \brief Unload the extension with the given name. If the no
-      /// extension is registered under the given name, false will be
-      /// returned.
-      /// \param[in] _name Name of the desired extension
-      /// \return  True if the engine is unloaded
-      public: bool UnloadExtension(const std::string &_name);
+  /// \brief Get the extension at the given index. If no
+  /// extension is exists at the given index, NULL will be returned.
+  /// \param[in] _index Index of the desired extension
+  /// \param[in] _params Parameters to be passed to the render engine.
+  /// \param[in] _path Another search path for rendering engine plugin.
+  /// \return The specified extension
+  public: RenderEngineExtension *ExtensionAt(unsigned int _index,
+              const std::map<std::string, std::string> &_params = {},
+              const std::string &_path = "");
 
-      /// \brief Unload the extension at the given index. If the no
-      /// extension is registered under the given name, false will be
-      /// returned.
-      /// \param[in] _index Index of the desired extension
-      /// \return  True if the engine is unloaded
-      public: bool UnloadExtensionAt(unsigned int _index);
+  /// \brief Unload the extension with the given name. If the no
+  /// extension is registered under the given name, false will be
+  /// returned.
+  /// \param[in] _name Name of the desired extension
+  /// \return  True if the engine is unloaded
+  public: bool UnloadExtension(const std::string &_name);
 
-      /// \brief Register a new extension under the given name. If the
-      /// given name is already in use, the extension will not be
-      /// registered.
-      /// \param[in] _name Name the extension will be registered under
-      /// \param[in] _engine Render-engine to be registered
-      public: void RegisterExtension(const std::string &_name,
-                  RenderEngineExtension *_engine);
+  /// \brief Unload the extension at the given index. If the no
+  /// extension is registered under the given name, false will be
+  /// returned.
+  /// \param[in] _index Index of the desired extension
+  /// \return  True if the engine is unloaded
+  public: bool UnloadExtensionAt(unsigned int _index);
 
-      /// \brief Unregister an extension registered under the given name.
-      /// If no extension is registered under the given name no work
-      /// will be done.
-      /// \param[in] _name Name of the extension to unregister
-      public: void UnregisterExtension(const std::string &_name);
+  /// \brief Register a new extension under the given name. If the
+  /// given name is already in use, the extension will not be
+  /// registered.
+  /// \param[in] _name Name the extension will be registered under
+  /// \param[in] _engine Render-engine to be registered
+  public: void RegisterExtension(const std::string &_name,
+              RenderEngineExtension *_engine);
 
-      /// \brief Unregister the given extension. If the given extension
-      /// is not currently registered, no work will be done.
-      /// \param[in] _engine Render-engine to unregister
-      public: void UnregisterExtension(RenderEngineExtension *_engine);
+  /// \brief Unregister an extension registered under the given name.
+  /// If no extension is registered under the given name no work
+  /// will be done.
+  /// \param[in] _name Name of the extension to unregister
+  public: void UnregisterExtension(const std::string &_name);
 
-      /// \brief Unregister an extension at the given index. If the no
-      /// extension is registered at the given index, no work will be done.
-      /// \param[in] _index Index of the extension to unregister
-      public: void UnregisterExtensionAt(unsigned int _index);
+  /// \brief Unregister the given extension. If the given extension
+  /// is not currently registered, no work will be done.
+  /// \param[in] _engine Render-engine to unregister
+  public: void UnregisterExtension(RenderEngineExtension *_engine);
 
-      /// \brief Set the plugin paths from which render engines can be loaded.
-      /// \param[in] _paths The list of the plugin paths
-      public: void SetPluginPaths(const std::list<std::string> &_paths);
+  /// \brief Unregister an extension at the given index. If the no
+  /// extension is registered at the given index, no work will be done.
+  /// \param[in] _index Index of the extension to unregister
+  public: void UnregisterExtensionAt(unsigned int _index);
 
-      GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \brief private implementation details
-      private: std::unique_ptr<RenderEngineExtensionManagerPrivate> dataPtr;
-      GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
+  /// \brief Set the plugin paths from which render engines can be loaded.
+  /// \param[in] _paths The list of the plugin paths
+  public: void SetPluginPaths(const std::list<std::string> &_paths);
 
-      /// \brief required SingletonT friendship
-      private: friend class
-          gz::common::SingletonT<RenderEngineExtensionManager>;
-    };
-    }
-  }
+  GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
+  /// \brief private implementation details
+  private: std::unique_ptr<RenderEngineExtensionManagerPrivate> dataPtr;
+  GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
+
+  /// \brief required SingletonT friendship
+  private: friend class
+      gz::common::SingletonT<RenderEngineExtensionManager>;
+};
+
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_RENDERENGINEEXTENSIONMANAGER_HH_

--- a/gz-waves/src/systems/waves/RenderEngineExtensionPlugin.cc
+++ b/gz-waves/src/systems/waves/RenderEngineExtensionPlugin.cc
@@ -34,12 +34,16 @@
 
 #include "RenderEngineExtensionPlugin.hh"
 
-class gz::rendering::RenderEngineExtensionPluginPrivate
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+//////////////////////////////////////////////////
+class RenderEngineExtensionPluginPrivate
 {
 };
-
-using namespace gz;
-using namespace rendering;
 
 //////////////////////////////////////////////////
 RenderEngineExtensionPlugin::RenderEngineExtensionPlugin()
@@ -50,3 +54,6 @@ RenderEngineExtensionPlugin::RenderEngineExtensionPlugin()
 //////////////////////////////////////////////////
 RenderEngineExtensionPlugin::~RenderEngineExtensionPlugin() = default;
 
+}
+}  // namespace rendering
+}  // namespace gz

--- a/gz-waves/src/systems/waves/RenderEngineExtensionPlugin.hh
+++ b/gz-waves/src/systems/waves/RenderEngineExtensionPlugin.hh
@@ -44,37 +44,39 @@
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-    //
-    // Forward declarations
-    class RenderEngineExtension;
-    class RenderEngineExtensionPluginPrivate;
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    /// \brief Base plugin class for render engine extensions
-    class GZ_RENDERING_VISIBLE RenderEngineExtensionPlugin
-    {
-      /// \brief Constructor
-      public: RenderEngineExtensionPlugin();
+// Forward declarations
+class RenderEngineExtension;
+class RenderEngineExtensionPluginPrivate;
 
-      /// \brief Destructor
-      public: virtual ~RenderEngineExtensionPlugin();
+/// \brief Base plugin class for render engine extensions
+class GZ_RENDERING_VISIBLE RenderEngineExtensionPlugin
+{
+  /// \brief Constructor
+  public: RenderEngineExtensionPlugin();
 
-      /// \brief Get the name of extension
-      /// \return Name of render engine extension
-      public: virtual std::string Name() const = 0;
+  /// \brief Destructor
+  public: virtual ~RenderEngineExtensionPlugin();
 
-      /// \brief Get a pointer to the extension
-      /// \return Render engine extension instance
-      public: virtual RenderEngineExtension *Extension() const = 0;
+  /// \brief Get the name of extension
+  /// \return Name of render engine extension
+  public: virtual std::string Name() const = 0;
 
-      /// \brief Pointer to private data class
-      GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
-      public: std::unique_ptr<RenderEngineExtensionPluginPrivate> dataPtr;
-      GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
-    };
-    }
-  }
+  /// \brief Get a pointer to the extension
+  /// \return Render engine extension instance
+  public: virtual RenderEngineExtension *Extension() const = 0;
+
+  /// \brief Pointer to private data class
+  GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
+  public: std::unique_ptr<RenderEngineExtensionPluginPrivate> dataPtr;
+  GZ_UTILS_WARN_RESUME__DLL_INTERFACE_MISSING
+};
+
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_RENDERENGINEEXTENSIONPLUGIN_HH_

--- a/gz-waves/src/systems/waves/SceneNodeFactory.cc
+++ b/gz-waves/src/systems/waves/SceneNodeFactory.cc
@@ -15,9 +15,15 @@
 
 #include "SceneNodeFactory.hh"
 
-using namespace gz;
-using namespace rendering;
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-//////////////////////////////////////////////////
 SceneNodeFactory::~SceneNodeFactory() = default;
+
+}
+}  // namespace rendering
+}  // namespace gz
 

--- a/gz-waves/src/systems/waves/SceneNodeFactory.hh
+++ b/gz-waves/src/systems/waves/SceneNodeFactory.hh
@@ -16,45 +16,46 @@
 #ifndef GZ_RENDERING_SCENENODEFACTORY_HH_
 #define GZ_RENDERING_SCENENODEFACTORY_HH_
 
-#include "DisplacementMap.hh"
-#include "OceanGeometry.hh"
-#include "OceanVisual.hh"
+#include <memory>
 
 #include <gz/rendering/config.hh>
 #include <gz/rendering/Scene.hh>
 #include "gz/rendering/Export.hh"
 
-#include <memory>
+#include "DisplacementMap.hh"
+#include "OceanGeometry.hh"
+#include "OceanVisual.hh"
 
 namespace gz
 {
-  namespace rendering
-  {
-    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    class GZ_RENDERING_VISIBLE SceneNodeFactory
-    {
-      /// \brief Destructor
-      public: virtual ~SceneNodeFactory();
+class GZ_RENDERING_VISIBLE SceneNodeFactory
+{
+  /// \brief Destructor
+  public: virtual ~SceneNodeFactory();
 
-      /// \brief Create an ocean visual
-      public: virtual OceanVisualPtr CreateOceanVisual(ScenePtr _scene) = 0;
-    
-      /// \brief Create an ocean geometry
-      public: virtual OceanGeometryPtr CreateOceanGeometry(ScenePtr _scene) = 0;
+  /// \brief Create an ocean visual
+  public: virtual OceanVisualPtr CreateOceanVisual(ScenePtr _scene) = 0;
 
-      /// \brief Create a displacement map
-      public: virtual DisplacementMapPtr CreateDisplacementMap(
-          ScenePtr _scene,
-          MaterialPtr _material,
-          uint64_t _entity,
-          uint32_t _width,
-          uint32_t _height) = 0;
-    };
+  /// \brief Create an ocean geometry
+  public: virtual OceanGeometryPtr CreateOceanGeometry(ScenePtr _scene) = 0;
 
-    typedef std::shared_ptr<SceneNodeFactory> SceneNodeFactoryPtr;
+  /// \brief Create a displacement map
+  public: virtual DisplacementMapPtr CreateDisplacementMap(
+      ScenePtr _scene,
+      MaterialPtr _material,
+      uint64_t _entity,
+      uint32_t _width,
+      uint32_t _height) = 0;
+};
 
-    }
-  }
+typedef std::shared_ptr<SceneNodeFactory> SceneNodeFactoryPtr;
+
 }
-#endif
+}  // namespace rendering
+}  // namespace gz
+
+#endif  // GZ_RENDERING_SCENENODEFACTORY_HH_

--- a/gz-waves/src/systems/waves/WavesModel.cc
+++ b/gz-waves/src/systems/waves/WavesModel.cc
@@ -15,36 +15,37 @@
 
 #include "WavesModel.hh"
 
-#include "gz/waves/Utilities.hh"
-#include "gz/waves/Wavefield.hh"
-#include "gz/waves/WaveParameters.hh"
-
-#include "gz/waves/components/Wavefield.hh"
-
-#include <gz/common/Profiler.hh>
-#include <gz/plugin/Register.hh>
-
-#include <gz/sim/components/Name.hh>
-#include <gz/sim/components/World.hh>
-
-#include <gz/sim/Model.hh>
-#include <gz/sim/Util.hh>
-
-#include <sdf/Element.hh>
-
 #include <chrono>
 #include <list>
 #include <mutex>
 #include <vector>
 #include <string>
 
-using namespace gz;
-using namespace sim;
-using namespace systems;
+#include <gz/common/Profiler.hh>
+#include <gz/plugin/Register.hh>
+#include <gz/sim/components/Name.hh>
+#include <gz/sim/components/World.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/Util.hh>
+
+#include <sdf/Element.hh>
+
+#include "gz/waves/Utilities.hh"
+#include "gz/waves/Wavefield.hh"
+#include "gz/waves/WaveParameters.hh"
+#include "gz/waves/components/Wavefield.hh"
+
+namespace gz
+{
+namespace sim
+{
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace systems
+{
 
 /// \brief Modelled on the Wind and LiftDrags systems.
-/// Applies at the model level rather than the world 
-class gz::sim::systems::WavesModelPrivate
+/// Applies at the model level rather than the world
+class WavesModelPrivate
 {
   /// \brief Destructor
   public: ~WavesModelPrivate();
@@ -215,7 +216,8 @@ void WavesModelPrivate::Load(EntityComponentManager &_ecm)
       << this->wavefieldEntity << "]\n";
 
   // fetch the wavefield back to check...
-  auto wfComp = _ecm.Component<waves::components::Wavefield>(this->wavefieldEntity);
+  auto wfComp = _ecm.Component<waves::components::Wavefield>(
+      this->wavefieldEntity);
   if (!wfComp)
   {
     gzwarn << "WavesModel: could not find wavefield in entity ["
@@ -235,7 +237,7 @@ void WavesModelPrivate::UpdateWaves(const UpdateInfo &_info,
     EntityComponentManager &/*_ecm*/)
 {
   if (!this->isStatic)
-  {  
+  {
     // Throttle update [30 FPS by default]
     auto updatePeriod = 1.0/this->updateRate;
     double simTime = std::chrono::duration<double>(_info.simTime).count();
@@ -247,11 +249,16 @@ void WavesModelPrivate::UpdateWaves(const UpdateInfo &_info,
   }
 }
 
-//////////////////////////////////////////////////
-GZ_ADD_PLUGIN(WavesModel,
-                    gz::sim::System,
-                    WavesModel::ISystemConfigure,
-                    WavesModel::ISystemPreUpdate)
+}  // namespace systems
+}
+}  // namespace sim
+}  // namespace gz
 
-GZ_ADD_PLUGIN_ALIAS(WavesModel,
-  "gz::sim::systems::WavesModel")
+//////////////////////////////////////////////////
+GZ_ADD_PLUGIN(gz::sim::systems::WavesModel,
+              gz::sim::System,
+              gz::sim::systems::WavesModel::ISystemConfigure,
+              gz::sim::systems::WavesModel::ISystemPreUpdate)
+
+GZ_ADD_PLUGIN_ALIAS(gz::sim::systems::WavesModel,
+                   "gz::sim::systems::WavesModel")

--- a/gz-waves/src/systems/waves/WavesModel.hh
+++ b/gz-waves/src/systems/waves/WavesModel.hh
@@ -28,38 +28,39 @@ namespace sim
 inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace systems
 {
-  // Forward declaration
-  class WavesModelPrivate;
+// Forward declaration
+class WavesModelPrivate;
 
-  /// \brief A plugin for surface waves
-  class WavesModel
-      : public System,
-        public ISystemConfigure,
-        public ISystemPreUpdate
-  {
-    /// \brief Constructor
-    public: WavesModel();
+/// \brief A plugin for surface waves
+class WavesModel
+    : public System,
+      public ISystemConfigure,
+      public ISystemPreUpdate
+{
+  /// \brief Constructor
+  public: WavesModel();
 
-    /// \brief Destructor
-    public: ~WavesModel() override;
+  /// \brief Destructor
+  public: ~WavesModel() override;
 
-    // Documentation inherited
-    public: void Configure(const Entity &_entity,
-                           const std::shared_ptr<const sdf::Element> &_sdf,
-                           EntityComponentManager &_ecm,
-                           EventManager &_eventMgr) final;
+  // Documentation inherited
+  public: void Configure(const Entity &_entity,
+                         const std::shared_ptr<const sdf::Element> &_sdf,
+                         EntityComponentManager &_ecm,
+                         EventManager &_eventMgr) final;
 
-    /// Documentation inherited
-    public: void PreUpdate(
-                const UpdateInfo &_info,
-                EntityComponentManager &_ecm) override;
+  /// Documentation inherited
+  public: void PreUpdate(
+              const UpdateInfo &_info,
+              EntityComponentManager &_ecm) override;
 
-    /// \brief Private data pointer
-    private: std::unique_ptr<WavesModelPrivate> dataPtr;
-  };
-  }
+  /// \brief Private data pointer
+  private: std::unique_ptr<WavesModelPrivate> dataPtr;
+};
+
+}  // namespace systems
 }
-}
-}
+}  // namespace sim
+}  // namespace gz
 
-#endif
+#endif  // GZ_SIM_SYSTEMS_WAVESMODEL_HH_

--- a/gz-waves/src/systems/waves/WavesVisual.hh
+++ b/gz-waves/src/systems/waves/WavesVisual.hh
@@ -28,38 +28,39 @@ namespace sim
 inline namespace GZ_SIM_VERSION_NAMESPACE {
 namespace systems
 {
-  // Forward declaration
-  class WavesVisualPrivate;
+// Forward declaration
+class WavesVisualPrivate;
 
-  /// \brief A plugin for surface waves
-  class WavesVisual
-      : public System,
-        public ISystemConfigure,
-        public ISystemPreUpdate
-  {
-    /// \brief Constructor
-    public: WavesVisual();
+/// \brief A plugin for surface waves
+class WavesVisual
+    : public System,
+      public ISystemConfigure,
+      public ISystemPreUpdate
+{
+  /// \brief Constructor
+  public: WavesVisual();
 
-    /// \brief Destructor
-    public: ~WavesVisual() override;
+  /// \brief Destructor
+  public: ~WavesVisual() override;
 
-    // Documentation inherited
-    public: void Configure(const Entity &_entity,
-                           const std::shared_ptr<const sdf::Element> &_sdf,
-                           EntityComponentManager &_ecm,
-                           EventManager &_eventMgr) final;
+  // Documentation inherited
+  public: void Configure(const Entity &_entity,
+                          const std::shared_ptr<const sdf::Element> &_sdf,
+                          EntityComponentManager &_ecm,
+                          EventManager &_eventMgr) final;
 
-    /// Documentation inherited
-    public: void PreUpdate(
-                const UpdateInfo &_info,
-                EntityComponentManager &_ecm) override;
+  /// Documentation inherited
+  public: void PreUpdate(
+              const UpdateInfo &_info,
+              EntityComponentManager &_ecm) override;
 
-    /// \brief Private data pointer
-    private: std::unique_ptr<WavesVisualPrivate> dataPtr;
-  };
-  }
+  /// \brief Private data pointer
+  private: std::unique_ptr<WavesVisualPrivate> dataPtr;
+};
+
+}  // namespace systems
 }
-}
-}
+}  // namespace sim
+}  // namespace gz
 
-#endif
+#endif  // GZ_SIM_SYSTEMS_WAVESVISUAL_HH_

--- a/gz-waves/test/performance/EigenReturnByValue.cc
+++ b/gz-waves/test/performance/EigenReturnByValue.cc
@@ -17,5 +17,4 @@
 
 TEST(EigenReturnByValue, ArrayReturnByValue)
 {
-
 }

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimBaseAmplitudes.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimBaseAmplitudes.cc
@@ -13,13 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include <chrono>
-#include <iostream>
-#include <string>
+#include <gtest/gtest.h>
 
 #include <Eigen/Dense>
 
-#include <gtest/gtest.h>
+#include <chrono>
+#include <iostream>
+#include <string>
 
 #include "LinearRandomFFTWaveSimulationImpl.hh"
 
@@ -29,14 +29,13 @@ using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;
 
-using namespace gz;
-using namespace waves;
+using gz::waves::LinearRandomFFTWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
 class LinearRandomFFTWaveSimTest: public ::testing::Test
 {
-public:
+ public:
   // number of evaluations
   int num_runs_ = 100;
 

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimCurrentAmplitudes.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimCurrentAmplitudes.cc
@@ -13,13 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include <chrono>
-#include <iostream>
-#include <string>
+#include <gtest/gtest.h>
 
 #include <Eigen/Dense>
 
-#include <gtest/gtest.h>
+#include <chrono>
+#include <iostream>
+#include <string>
 
 #include "LinearRandomFFTWaveSimulationImpl.hh"
 
@@ -29,14 +29,13 @@ using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;
 
-using namespace gz;
-using namespace waves;
+using gz::waves::LinearRandomFFTWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
 class LinearRandomFFTWaveSimTest: public ::testing::Test
 {
-public:
+ public:
   // number of evaluations
   int num_runs_ = 1000;
 

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimDisplacements.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimDisplacements.cc
@@ -13,13 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include <chrono>
-#include <iostream>
-#include <string>
+#include <gtest/gtest.h>
 
 #include <Eigen/Dense>
 
-#include <gtest/gtest.h>
+#include <chrono>
+#include <iostream>
+#include <string>
 
 #include "LinearRandomFFTWaveSimulationImpl.hh"
 
@@ -29,14 +29,13 @@ using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;
 
-using namespace gz;
-using namespace waves;
+using gz::waves::LinearRandomFFTWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
 class LinearRandomFFTWaveSimTest: public ::testing::Test
 {
-public: 
+ public:
   // number of evaluations
   int num_runs_ = 1000;
 

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimElevationAt.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimElevationAt.cc
@@ -13,13 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include <chrono>
-#include <iostream>
-#include <string>
+#include <gtest/gtest.h>
 
 #include <Eigen/Dense>
 
-#include <gtest/gtest.h>
+#include <chrono>
+#include <iostream>
+#include <string>
 
 #include "LinearRandomFFTWaveSimulationImpl.hh"
 
@@ -29,14 +29,13 @@ using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;
 
-using namespace gz;
-using namespace waves;
+using gz::waves::LinearRandomFFTWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
 class LinearRandomFFTWaveSimTest: public ::testing::Test
 {
-public:
+ public:
   // number of evaluations
   int num_runs_ = 1000;
 

--- a/gz-waves/test/performance/LinearRegularWaveSimDisplacements.cc
+++ b/gz-waves/test/performance/LinearRegularWaveSimDisplacements.cc
@@ -13,13 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include <chrono>
-#include <iostream>
-#include <string>
+#include <gtest/gtest.h>
 
 #include <Eigen/Dense>
 
-#include <gtest/gtest.h>
+#include <chrono>
+#include <iostream>
+#include <string>
 
 #include "gz/waves/LinearRegularWaveSimulation.hh"
 
@@ -29,14 +29,13 @@ using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;
 
-using namespace gz;
-using namespace waves;
+using gz::waves::LinearRegularWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
 class LinearRegularWaveSimTest: public ::testing::Test
 {
-public:
+ public:
   // number of evaluations
   int num_runs_ = 1000;
 

--- a/gz-waves/test/performance/WaveSpectrumECKV.cc
+++ b/gz-waves/test/performance/WaveSpectrumECKV.cc
@@ -13,21 +13,21 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+
 #include <chrono>
 #include <iostream>
 #include <string>
 #include <vector>
-
-#include <Eigen/Dense>
-
-#include <gtest/gtest.h>
 
 #include "gz/waves/WaveSpectrum.hh"
 
 using Eigen::ArrayXXd;
 
 namespace Eigen
-{ 
+{
   typedef Eigen::Array<
     double,
     Eigen::Dynamic,
@@ -40,18 +40,13 @@ using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;
 
-using namespace gz;
-using namespace waves;
+using gz::waves::ECKVWaveSpectrum;
 
 //////////////////////////////////////////////////
 // Define fixture
 class WaveSpectrumECKVPerfFixture: public ::testing::Test
-{ 
-public: 
-  virtual ~WaveSpectrumECKVPerfFixture()
-  {
-  }
-
+{
+ public:
   WaveSpectrumECKVPerfFixture()
   {
     double kx_nyquist = M_PI * nx_ / lx_;
@@ -60,11 +55,11 @@ public:
     Eigen::ArrayXd kx_v(nx_);
     Eigen::ArrayXd ky_v(ny_);
 
-    for (int i=0; i<nx_; ++i)
+    for (int i=0; i < nx_; ++i)
     {
       kx_v(i) = (i * 2.0 / nx_ - 1.0) * kx_nyquist;
     }
-    for (int i=0; i<ny_; ++i)
+    for (int i=0; i < ny_; ++i)
     {
       ky_v(i) = (i * 2.0 / ny_ - 1.0) * ky_nyquist;
     }
@@ -72,7 +67,7 @@ public:
     // broadcast to matrices (aka meshgrid)
     Eigen::ArrayXXd kx = Eigen::ArrayXXd::Zero(nx_, ny_);
     kx.colwise() += kx_v;
-    
+
     Eigen::ArrayXXd ky = Eigen::ArrayXXd::Zero(nx_, ny_);
     ky.rowwise() += ky_v.transpose();
 
@@ -82,15 +77,11 @@ public:
 
     // create spectrum
     spectrum_ = ECKVWaveSpectrum(u19_);
-  } 
-
-  virtual void SetUp() override
-  { 
-    cap_s_ = Eigen::ArrayXXd::Zero(nx_, ny_);
   }
 
-  virtual void TearDown() override
+  void SetUp() override
   {
+    cap_s_ = Eigen::ArrayXXd::Zero(nx_, ny_);
   }
 
   // number of evaluations

--- a/gz-waves/test/plots/PLOT_GnuPlotExample.cc
+++ b/gz-waves/test/plots/PLOT_GnuPlotExample.cc
@@ -13,10 +13,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <gnuplot-iostream.h>
+
 #include <cstdlib>
 #include <iostream>
 #include <vector>
-#include <gnuplot-iostream.h>
 
 int main(int /*argc*/, const char **/*argv*/)
 {
@@ -54,7 +55,6 @@ int main(int /*argc*/, const char **/*argv*/)
       gp << "plot '-' w l title 'eta'\n";
       gp.send1d(std::make_tuple(pts_t, pts_eta));
     }
-
   }
   catch(...)
   {

--- a/gz-waves/test/plots/PLOT_LinearRandomFFTWaves.cc
+++ b/gz-waves/test/plots/PLOT_LinearRandomFFTWaves.cc
@@ -13,20 +13,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <gnuplot-iostream.h>
+
+#include <Eigen/Dense>
+
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <vector>
 
- #include <Eigen/Dense>
-
-#include <gnuplot-iostream.h>
-
 #include <gz/waves/WaveSimulation.hh>
 #include <gz/waves/LinearRandomFFTWaveSimulation.hh>
 
-using namespace gz;
-using namespace waves;
+using gz::waves::Index;
+using gz::waves::LinearRandomFFTWaveSimulation;
 
 int main(int /*argc*/, const char **/*argv*/)
 {
@@ -50,7 +50,7 @@ int main(int /*argc*/, const char **/*argv*/)
       wave_sim->SetWindVelocity(10.0, 0.0);
       wave_sim->SetLambda(0.0);
       wave_sim->SetTime(5.0);
-      
+
       double sample_time = 60.0;
       std::vector<double> pts_t;
       std::vector<double> pts_eta;
@@ -157,7 +157,6 @@ int main(int /*argc*/, const char **/*argv*/)
         gp.send1d(std::make_tuple(pts_x, pts_p[iz]));
       }
     }
-
   }
   catch(...)
   {

--- a/gz-waves/test/plots/PLOT_LinearRandomWaves.cc
+++ b/gz-waves/test/plots/PLOT_LinearRandomWaves.cc
@@ -13,20 +13,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <gnuplot-iostream.h>
+
+#include <Eigen/Dense>
+
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <vector>
 
- #include <Eigen/Dense>
-
-#include <gnuplot-iostream.h>
-
 #include <gz/waves/WaveSimulation.hh>
 #include <gz/waves/LinearRandomWaveSimulation.hh>
 
-using namespace gz;
-using namespace waves;
+using gz::waves::Index;
+using gz::waves::LinearRandomWaveSimulation;
 
 int main(int /*argc*/, const char **/*argv*/)
 {
@@ -51,7 +51,7 @@ int main(int /*argc*/, const char **/*argv*/)
       wave_sim->SetMaxOmega(6.0);
       wave_sim->SetWindVelocity(10.0, 0.0);
       wave_sim->SetTime(5.0);
-      
+
       double sample_time = 60.0;
       std::vector<double> pts_t;
       std::vector<double> pts_eta;
@@ -160,7 +160,6 @@ int main(int /*argc*/, const char **/*argv*/)
         gp.send1d(std::make_tuple(pts_x, pts_p[iz]));
       }
     }
-
   }
   catch(...)
   {

--- a/gz-waves/test/plots/PLOT_LinearRegularWaves.cc
+++ b/gz-waves/test/plots/PLOT_LinearRegularWaves.cc
@@ -13,20 +13,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <gnuplot-iostream.h>
+
+#include <Eigen/Dense>
+
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <vector>
 
- #include <Eigen/Dense>
-
-#include <gnuplot-iostream.h>
-
 #include <gz/waves/WaveSimulation.hh>
 #include <gz/waves/LinearRegularWaveSimulation.hh>
 
-using namespace gz;
-using namespace waves;
+using gz::waves::Index;
+using gz::waves::LinearRegularWaveSimulation;
 
 int main(int /*argc*/, const char **/*argv*/)
 {
@@ -51,7 +51,7 @@ int main(int /*argc*/, const char **/*argv*/)
       wave_sim->SetAmplitude(2.0);
       wave_sim->SetPeriod(12.0);
       wave_sim->SetTime(0.0);
-      
+
       double sample_time = 60.0;
       std::vector<double> pts_t;
       std::vector<double> pts_eta;

--- a/gz-waves/test/plots/PLOT_WaveSpectrum.cc
+++ b/gz-waves/test/plots/PLOT_WaveSpectrum.cc
@@ -13,22 +13,23 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <gnuplot-iostream.h>
+
+#include <Eigen/Dense>
+
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <vector>
-
- #include <Eigen/Dense>
-
-#include <gnuplot-iostream.h>
 
 #include <gz/waves/WaveSimulation.hh>
 #include <gz/waves/WaveSpectrum.hh>
 
 using Eigen::ArrayXd;
 
-using namespace gz;
-using namespace waves;
+using gz::waves::Index;
+using gz::waves::ECKVWaveSpectrum;
+using gz::waves::PiersonMoskowitzWaveSpectrum;
 
 // https://stackoverflow.com/questions/16605967/set-precision-of-stdto-string-when-converting-floating-point-values
 template <typename T>
@@ -125,7 +126,6 @@ int main(int /*argc*/, const char **/*argv*/)
           pts_s[iu].push_back(s);
         }
       }
-
 
       // assume we always have at least one plot
       std::string plot_str("plot '-' w l title 'u19 = ");


### PR DESCRIPTION
This PR applies the  cpplint workflow to the remaining source and headers (tests and plugins).


## Details

- Performance tests
- Plots
- `include/gz/waves/common`
- `include/gz/waves/common`
- Hydrodynamics plugin
- DynamicGeometry plugin
- Waves plugin

Additional filters are required for the plugins that follow Gazebo style.
