### PR TITLE
Static: add cppcheck workflow

### DIFF
--- a/.github/workflows/ccpcheck.yml
+++ b/.github/workflows/ccpcheck.yml
@@ -1,0 +1,45 @@
+# GitHub Action to run cppcheck
+# 
+name: Cppcheck
+
+on: [push, pull_request]
+
+jobs:
+  cpplint:
+    runs-on: ubuntu-latest
+    name: Cppcheck
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install cppcheck
+      - name: Cppcheck Core Library
+        run: |
+          cppcheck --std=c++17 ./gz-waves/include/gz/waves/*.hh
+          cppcheck --std=c++17 ./gz-waves/src/*.cc ./gz-waves/src/*.hh
+      - name: Cppcheck Tests
+        run: |
+          cppcheck --std=c++17 ./gz-waves/test/performance/*.cc
+          cppcheck --std=c++17 ./gz-waves/test/plots/*.cc
+      - name: Cppcheck Hydrodynamics Plugin
+        run: |
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./gz-waves/src/systems/hydrodynamics/*.hh
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./gz-waves/src/systems/hydrodynamics/*.cc
+      - name: Cppcheck DynamicGeometry Plugin
+        run: |
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./gz-waves/src/systems/dynamic/*.hh
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./gz-waves/src/systems/dynamic/*.cc
+      - name: Cppcheck Waves Plugin
+        run: |
+          cppcheck --std=c++17 ./gz-waves/include/gz/common/*.hh
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./gz-waves/src/systems/waves/*.hh
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./gz-waves/src/systems/waves/*.cc
+

--- a/.github/workflows/ccplint.yml
+++ b/.github/workflows/ccplint.yml
@@ -30,15 +30,20 @@ jobs:
         run: |
           cpplint ./gz-waves/test/performance/*.cc
           cpplint ./gz-waves/test/plots/*.cc
-          cpplint --filter=-whitespace/blank_line,-whitespace/indent ./gz-waves/include/gz/common/*.hh
       - name: Cpplint Hydrodynamics Plugin
         run: |
-          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard ./gz-waves/src/systems/hydrodynamics/*
+          cpplint \
+            --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard \
+            ./gz-waves/src/systems/hydrodynamics/*
       - name: Cpplint DynamicGeometry Plugin
         run: |
-          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard ./gz-waves/src/systems/dynamic/*
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard \
+            ./gz-waves/src/systems/dynamic/*
       - name: Cpplint Waves Plugin
         run: |
-          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard ./gz-waves/src/systems/waves/*.hh
-          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard,-whitespace/newline ./gz-waves/src/systems/waves/*.cc
-
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent \
+            ./gz-waves/include/gz/common/*.hh
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard \
+            ./gz-waves/src/systems/waves/*.hh
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard,-whitespace/newline \
+            ./gz-waves/src/systems/waves/*.cc

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Ubuntu Jammy CI](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ubuntu-jammy-ci.yml/badge.svg)](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ubuntu-jammy-ci.yml)
 [![macOS Monterey CI](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/macos-monterey-ci.yml/badge.svg)](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/macos-monterey-ci.yml)
 [![Cpplint](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ccplint.yml/badge.svg)](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ccplint.yml)
+[![Cppcheck](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ccpcheck.yml/badge.svg)](https://github.com/srmainwaring/asv_wave_sim/actions/workflows/ccpcheck.yml)
 
 This package contains plugins that support the simulation of waves and surface vessels in [Gazebo](https://gazebosim.org/home).
 

--- a/gz-waves/test/performance/EigenReturnByValue.cc
+++ b/gz-waves/test/performance/EigenReturnByValue.cc
@@ -15,6 +15,6 @@
 
 #include <gtest/gtest.h>
 
-TEST(EigenReturnByValue, ArrayReturnByValue)
+TEST(EigenReturnByValueTest, ArrayReturnByValue)
 {
 }

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimBaseAmplitudes.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimBaseAmplitudes.cc
@@ -33,7 +33,7 @@ using gz::waves::LinearRandomFFTWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
-class LinearRandomFFTWaveSimTest: public ::testing::Test
+class LinearRandomFFTWaveSimBaseAmplitudesTest: public ::testing::Test
 {
  public:
   // number of evaluations
@@ -47,7 +47,7 @@ class LinearRandomFFTWaveSimTest: public ::testing::Test
 };
 
 //////////////////////////////////////////////////
-TEST_F(LinearRandomFFTWaveSimTest, BaseAmplitudes)
+TEST_F(LinearRandomFFTWaveSimBaseAmplitudesTest, BaseAmplitudes)
 {
   LinearRandomFFTWaveSimulation::Impl model(lx_, ly_, nx_, ny_);
   auto start = steady_clock::now();

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimCurrentAmplitudes.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimCurrentAmplitudes.cc
@@ -33,7 +33,7 @@ using gz::waves::LinearRandomFFTWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
-class LinearRandomFFTWaveSimTest: public ::testing::Test
+class LinearRandomFFTWaveSimCurrentAmplitudesTest: public ::testing::Test
 {
  public:
   // number of evaluations
@@ -47,7 +47,7 @@ class LinearRandomFFTWaveSimTest: public ::testing::Test
 };
 
 //////////////////////////////////////////////////
-TEST_F(LinearRandomFFTWaveSimTest, CurrentAmplitudes)
+TEST_F(LinearRandomFFTWaveSimCurrentAmplitudesTest, CurrentAmplitudes)
 {
   LinearRandomFFTWaveSimulation::Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimDisplacements.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimDisplacements.cc
@@ -33,7 +33,7 @@ using gz::waves::LinearRandomFFTWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
-class LinearRandomFFTWaveSimTest: public ::testing::Test
+class LinearRandomFFTWaveSimDisplacementsTest: public ::testing::Test
 {
  public:
   // number of evaluations
@@ -47,7 +47,7 @@ class LinearRandomFFTWaveSimTest: public ::testing::Test
 };
 
 //////////////////////////////////////////////////
-TEST_F(LinearRandomFFTWaveSimTest, Elevation)
+TEST_F(LinearRandomFFTWaveSimDisplacementsTest, Elevation)
 {
   LinearRandomFFTWaveSimulation::Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
@@ -71,7 +71,7 @@ TEST_F(LinearRandomFFTWaveSimTest, Elevation)
 }
 
 //////////////////////////////////////////////////
-TEST_F(LinearRandomFFTWaveSimTest, DisplacementsAndDeriatives)
+TEST_F(LinearRandomFFTWaveSimDisplacementsTest, DisplacementsAndDeriatives)
 {
   LinearRandomFFTWaveSimulation::Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimElevationAt.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimElevationAt.cc
@@ -33,7 +33,7 @@ using gz::waves::LinearRandomFFTWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
-class LinearRandomFFTWaveSimTest: public ::testing::Test
+class LinearRandomFFTWaveSimElevationAtTest: public ::testing::Test
 {
  public:
   // number of evaluations
@@ -47,7 +47,7 @@ class LinearRandomFFTWaveSimTest: public ::testing::Test
 };
 
 //////////////////////////////////////////////////
-TEST_F(LinearRandomFFTWaveSimTest, ElevationAtScalar)
+TEST_F(LinearRandomFFTWaveSimElevationAtTest, ElevationAtScalar)
 {
   LinearRandomFFTWaveSimulation::Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();
@@ -71,7 +71,7 @@ TEST_F(LinearRandomFFTWaveSimTest, ElevationAtScalar)
 }
 
 //////////////////////////////////////////////////
-TEST_F(LinearRandomFFTWaveSimTest, ElevationAtArray)
+TEST_F(LinearRandomFFTWaveSimElevationAtTest, ElevationAtArray)
 {
   LinearRandomFFTWaveSimulation::Impl model(lx_, ly_, nx_, ny_);
   model.ComputeBaseAmplitudes();

--- a/gz-waves/test/performance/LinearRegularWaveSimDisplacements.cc
+++ b/gz-waves/test/performance/LinearRegularWaveSimDisplacements.cc
@@ -33,7 +33,7 @@ using gz::waves::LinearRegularWaveSimulation;
 
 //////////////////////////////////////////////////
 // Define fixture
-class LinearRegularWaveSimTest: public ::testing::Test
+class LinearRegularWaveSimDisplacementsTest: public ::testing::Test
 {
  public:
   // number of evaluations
@@ -47,7 +47,7 @@ class LinearRegularWaveSimTest: public ::testing::Test
 };
 
 //////////////////////////////////////////////////
-TEST_F(LinearRegularWaveSimTest, Elevation)
+TEST_F(LinearRegularWaveSimDisplacementsTest, Elevation)
 {
   LinearRegularWaveSimulation model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(false);
@@ -67,7 +67,7 @@ TEST_F(LinearRegularWaveSimTest, Elevation)
 }
 
 //////////////////////////////////////////////////
-TEST_F(LinearRegularWaveSimTest, ElevationVectorised)
+TEST_F(LinearRegularWaveSimDisplacementsTest, ElevationVectorised)
 {
   LinearRegularWaveSimulation model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(true);
@@ -87,7 +87,7 @@ TEST_F(LinearRegularWaveSimTest, ElevationVectorised)
 }
 
 //////////////////////////////////////////////////
-TEST_F(LinearRegularWaveSimTest, DisplacementsAndDeriatives)
+TEST_F(LinearRegularWaveSimDisplacementsTest, DisplacementsAndDeriatives)
 {
   LinearRegularWaveSimulation model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(false);
@@ -117,7 +117,8 @@ TEST_F(LinearRegularWaveSimTest, DisplacementsAndDeriatives)
 }
 
 //////////////////////////////////////////////////
-TEST_F(LinearRegularWaveSimTest, DisplacementsAndDeriativesVectorised)
+TEST_F(LinearRegularWaveSimDisplacementsTest,
+    DisplacementsAndDeriativesVectorised)
 {
   LinearRegularWaveSimulation model(lx_, ly_, nx_, ny_);
   model.SetUseVectorised(true);

--- a/gz-waves/test/performance/WaveSpectrumECKV.cc
+++ b/gz-waves/test/performance/WaveSpectrumECKV.cc
@@ -44,10 +44,10 @@ using gz::waves::ECKVWaveSpectrum;
 
 //////////////////////////////////////////////////
 // Define fixture
-class WaveSpectrumECKVPerfFixture: public ::testing::Test
+class WaveSpectrumECKVTest: public ::testing::Test
 {
  public:
-  WaveSpectrumECKVPerfFixture()
+  WaveSpectrumECKVTest()
   {
     double kx_nyquist = M_PI * nx_ / lx_;
     double ky_nyquist = M_PI * ny_ / ly_;
@@ -103,7 +103,7 @@ class WaveSpectrumECKVPerfFixture: public ::testing::Test
 };
 
 //////////////////////////////////////////////////
-TEST_F(WaveSpectrumECKVPerfFixture, ArrayXXdDoubleLoopColMajor)
+TEST_F(WaveSpectrumECKVTest, ArrayXXdDoubleLoopColMajor)
 {
   // non-vector version
   std::cerr << "Eigen::ArrayXXd double loop\n";
@@ -126,7 +126,7 @@ TEST_F(WaveSpectrumECKVPerfFixture, ArrayXXdDoubleLoopColMajor)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSpectrumECKVPerfFixture, ArrayXXdDoubleLoopRowMajor)
+TEST_F(WaveSpectrumECKVTest, ArrayXXdDoubleLoopRowMajor)
 {
   // loop in 'wrong' order
   std::cerr << "Eigen::ArrayXXd double loop, 'wrong' order\n";
@@ -149,7 +149,7 @@ TEST_F(WaveSpectrumECKVPerfFixture, ArrayXXdDoubleLoopRowMajor)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSpectrumECKVPerfFixture, ArrayXXdReshapedIterator)
+TEST_F(WaveSpectrumECKVTest, ArrayXXdReshapedIterator)
 {
   // reshaped
   std::cerr << "Eigen::ArrayXXd reshaped iterator\n";
@@ -175,7 +175,7 @@ TEST_F(WaveSpectrumECKVPerfFixture, ArrayXXdReshapedIterator)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSpectrumECKVPerfFixture, StdVectorDoubleLoop)
+TEST_F(WaveSpectrumECKVTest, StdVectorDoubleLoop)
 {
   // using row major std::vector
   std::cerr << "std::vector double loop\n";
@@ -208,7 +208,7 @@ TEST_F(WaveSpectrumECKVPerfFixture, StdVectorDoubleLoop)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSpectrumECKVPerfFixture, StdVectorSingleLoop)
+TEST_F(WaveSpectrumECKVTest, StdVectorSingleLoop)
 {
   // using row major std::vector
   std::cerr << "std::vector single loop\n";
@@ -238,7 +238,7 @@ TEST_F(WaveSpectrumECKVPerfFixture, StdVectorSingleLoop)
 }
 
 //////////////////////////////////////////////////
-TEST_F(WaveSpectrumECKVPerfFixture, ArrayXXdCWise)
+TEST_F(WaveSpectrumECKVTest, ArrayXXdCWise)
 {
   // Eigen cwise-array calc
   std::cerr << "Eigen cwise-array\n";


### PR DESCRIPTION
This PR applies a cppcheck workflow to the project.

## Details

### Apply cppcheck

- Apply cppcheck to core library
- Apply cppcheck to tests
- Apply cppcheck to dynamic and hydrodynamics plugins
- Apply cppcheck to waves plugins
- Add cppcheck status badge to README

### Other changes

- Change test fixture names (breaking the one definition rule).
- Move cpplint for include/gz/common under waves plugin checks.
- Update cpplint formatting - reduce line length.

### Notes

- Suppress unknownMacro error. The Gazebo plugin macros are not found with a simple configuration.
