### PR TITLE
Waves: optimise FFT wave simulation current amplitude update

### DIFF
--- a/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
@@ -218,8 +218,6 @@ class LinearRandomFFTWaveSimulation::Impl
   //////////////////////////////////////////////////
   // storage for current amplitudes (nx * ny)
   Eigen::ArrayXcd zhat_;
-  Eigen::ArrayXd  cos_wt_;
-  Eigen::ArrayXd  sin_wt_;
 
   //////////////////////////////////////////////////
   // storage for base amplitudes (fft order)
@@ -231,8 +229,12 @@ class LinearRandomFFTWaveSimulation::Impl
   Eigen::ArrayXd rho_;
   Eigen::ArrayXd sigma_;
 
-  // angular temporal frequency
-  Eigen::ArrayXd omega_k_;
+  // unique angular temporal frequency, index and reverse lookup
+  std::vector<double> uomega_k_;
+  std::vector<Index>  uindex_;
+  std::vector<Index>  uinverse_;
+  Eigen::ArrayXd      ucos_wt_;
+  Eigen::ArrayXd      usin_wt_;
 
   /// \brief For testing
   friend class LinearRandomFFTWaveSimFixture;


### PR DESCRIPTION
This PR optimises the update of current amplitudes in the FFT wave simulation.

## Details

Instrumentation reveals that updating `sin(wt)` and `cos(wt)` contributes > 50% of the amplitude update. This change reduces the number of evaluations by maintaining a list of the unique values of the angular frequency and a reverse lookup index. Because the wavenumber magnitude is evaluated on a regular grid the number of unique values of the angular frequency is approx 1/5 - 1/10 of the full `nx * ny` array.