### PR TITLE
Waves: ensure a Wavefield made available via the ECM is const.

### DIFF
--- a/gz-waves/include/gz/waves/Wavefield.hh
+++ b/gz-waves/include/gz/waves/Wavefield.hh
@@ -65,7 +65,9 @@ class Wavefield
 };
 
 typedef std::shared_ptr<Wavefield> WavefieldPtr;
+typedef std::shared_ptr<const Wavefield> WavefieldConstPtr;
 typedef std::weak_ptr<Wavefield> WavefieldWeakPtr;
+typedef std::weak_ptr<const Wavefield> WavefieldConstWeakPtr;
 }  // namespace waves
 }  // namespace gz
 

--- a/gz-waves/include/gz/waves/components/Wavefield.hh
+++ b/gz-waves/include/gz/waves/components/Wavefield.hh
@@ -19,7 +19,8 @@ inline namespace GZ_WAVES_VERSION_NAMESPACE {
 namespace components
 {
   /// \brief This component holds an entity's wavefield.
-  using Wavefield = gz::sim::components::Component<waves::WavefieldPtr, class WavefieldTag>;
+  using Wavefield = gz::sim::components::Component<
+      waves::WavefieldConstWeakPtr, class WavefieldTag>;
   GZ_SIM_REGISTER_COMPONENT("gz_waves_components.Wavefield", Wavefield)
 }
 }

--- a/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -276,7 +276,7 @@ class HydrodynamicsPrivate
   public: Entity wavefieldEntity{kNullEntity};
 
   /// \brief The wavefield.
-  public: waves::WavefieldWeakPtr wavefield;
+  public: waves::WavefieldConstWeakPtr wavefield;
 
   ////////// BEGIN HYDRODYNAMICS PLUGIN
 


### PR DESCRIPTION
This PR changes the pointer type stored in a `component::Wavefield` from WavefieldPtr to WavefieldConstWeakPtr.

This does two things:

1. It prevents another system plugin binding to the Wavefield owned by the WaveModel plugins using a shared pointer instead of the intended weak pointer.
2. It prevents another system plugin from calling the Wavefield's Update method. This is the repsonsibility of the owning WaveModel plugin.