### PR TITLE
Wave Sim: make interface methods const

### DIFF
--- a/gz-waves/include/gz/waves/LinearRandomFFTWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomFFTWaveSimulation.hh
@@ -57,12 +57,12 @@ class LinearRandomFFTWaveSimulation :
   #if 0
   void Elevation(
       double x, double y,
-      double& eta) override;
+      double& eta) const override;
 
   void Elevation(
       const Eigen::Ref<const Eigen::ArrayXd>& x,
       const Eigen::Ref<const Eigen::ArrayXd>& y,
-      Eigen::Ref<Eigen::ArrayXd> eta) override;
+      Eigen::Ref<Eigen::ArrayXd> eta) const override;
 
   void Pressure(
       double x, double y, double z,
@@ -72,25 +72,25 @@ class LinearRandomFFTWaveSimulation :
       const Eigen::Ref<const Eigen::ArrayXd>& x,
       const Eigen::Ref<const Eigen::ArrayXd>& y,
       const Eigen::Ref<const Eigen::ArrayXd>& z,
-      Eigen::Ref<Eigen::ArrayXd> pressure) override;
+      Eigen::Ref<Eigen::ArrayXd> pressure) const override;
   #endif
 
   // lookup interface - array
   void ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h) override;
+      Eigen::Ref<Eigen::ArrayXXd> h) const override;
 
   void ElevationDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) const override;
 
   void DisplacementAt(
       Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy) override;
+      Eigen::Ref<Eigen::ArrayXXd> sy) const override;
 
   void DisplacementDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
   void DisplacementAndDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> h,
@@ -100,24 +100,24 @@ class LinearRandomFFTWaveSimulation :
       Eigen::Ref<Eigen::ArrayXXd> dhdy,
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
   void PressureAt(
       Index iz,
-      Eigen::Ref<Eigen::ArrayXXd> pressure) override;
+      Eigen::Ref<Eigen::ArrayXXd> pressure) const override;
 
   // lookup interface - scalar
   void ElevationAt(
       Index ix, Index iy,
-      double& eta) override;
+      double& eta) const override;
 
   void DisplacementAt(
       Index ix, Index iy,
-      double& sx, double& sy) override;
+      double& sx, double& sy) const override;
 
   void PressureAt(
       Index ix, Index iy, Index iz,
-      double& pressure) override;
+      double& pressure) const override;
 
   // public class declaration - for testing
   class Impl;

--- a/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
@@ -84,39 +84,39 @@ class LinearRandomWaveSimulation :
   // IWaveField - interface.
   void Elevation(
       double x, double y,
-      double &eta) override;
+      double &eta) const override;
 
   void Elevation(
       const Eigen::Ref<const Eigen::ArrayXd>& x,
       const Eigen::Ref<const Eigen::ArrayXd>& y,
-      Eigen::Ref<Eigen::ArrayXd> eta) override;
+      Eigen::Ref<Eigen::ArrayXd> eta) const override;
 
   void Pressure(
       double x, double y, double z,
-      double& pressure) override;
+      double& pressure) const override;
 
   void Pressure(
       const Eigen::Ref<const Eigen::ArrayXd>& x,
       const Eigen::Ref<const Eigen::ArrayXd>& y,
       const Eigen::Ref<const Eigen::ArrayXd>& z,
-      Eigen::Ref<Eigen::ArrayXd> pressure) override;
+      Eigen::Ref<Eigen::ArrayXd> pressure) const override;
 
   // lookup interface - array
   void ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h) override;
+      Eigen::Ref<Eigen::ArrayXXd> h) const override;
 
   void ElevationDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) const override;
 
   void DisplacementAt(
       Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy) override;
+      Eigen::Ref<Eigen::ArrayXXd> sy) const override;
 
   void DisplacementDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
   void DisplacementAndDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> h,
@@ -126,24 +126,24 @@ class LinearRandomWaveSimulation :
       Eigen::Ref<Eigen::ArrayXXd> dhdy,
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
   void PressureAt(
       Index iz,
-      Eigen::Ref<Eigen::ArrayXXd> pressure) override;
+      Eigen::Ref<Eigen::ArrayXXd> pressure) const override;
 
   // lookup interface - scalar
   void ElevationAt(
       Index ix, Index iy,
-      double& eta) override;
+      double& eta) const override;
 
   void DisplacementAt(
       Index ix, Index iy,
-      double& sx, double& sy) override;
+      double& sx, double& sy) const override;
 
   void PressureAt(
       Index ix, Index iy, Index iz,
-      double& pressure) override;
+      double& pressure) const override;
 
  private:
   class Impl;

--- a/gz-waves/include/gz/waves/LinearRegularWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRegularWaveSimulation.hh
@@ -74,39 +74,39 @@ class LinearRegularWaveSimulation :
   // interpolation interface
   void Elevation(
       double x, double y,
-      double& eta) override;
+      double& eta) const override;
 
   void Elevation(
       const Eigen::Ref<const Eigen::ArrayXd>& x,
       const Eigen::Ref<const Eigen::ArrayXd>& y,
-      Eigen::Ref<Eigen::ArrayXd> eta) override;
+      Eigen::Ref<Eigen::ArrayXd> eta) const override;
 
   void Pressure(
       double x, double y, double z,
-      double& pressure) override;
+      double& pressure) const override;
 
   void Pressure(
       const Eigen::Ref<const Eigen::ArrayXd>& x,
       const Eigen::Ref<const Eigen::ArrayXd>& y,
       const Eigen::Ref<const Eigen::ArrayXd>& z,
-      Eigen::Ref<Eigen::ArrayXd> pressure) override;
+      Eigen::Ref<Eigen::ArrayXd> pressure) const override;
 
   // lookup interface - array
   void ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h) override;
+      Eigen::Ref<Eigen::ArrayXXd> h) const override;
 
   void ElevationDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) const override;
 
   void DisplacementAt(
       Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy) override;
+      Eigen::Ref<Eigen::ArrayXXd> sy) const override;
 
   void DisplacementDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
   void DisplacementAndDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> h,
@@ -116,24 +116,24 @@ class LinearRegularWaveSimulation :
       Eigen::Ref<Eigen::ArrayXXd> dhdy,
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
   void PressureAt(
       Index iz,
-      Eigen::Ref<Eigen::ArrayXXd> pressure) override;
+      Eigen::Ref<Eigen::ArrayXXd> pressure) const override;
 
   // lookup interface - scalar
   void ElevationAt(
       Index ix, Index iy,
-      double &eta) override;
+      double &eta) const override;
 
   void DisplacementAt(
       Index ix, Index iy,
-      double& sx, double& sy) override;
+      double& sx, double& sy) const override;
 
   void PressureAt(
       Index ix, Index iy, Index iz,
-      double& pressure) override;
+      double& pressure) const override;
 
  private:
   class Impl;

--- a/gz-waves/include/gz/waves/TrochoidIrregularWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/TrochoidIrregularWaveSimulation.hh
@@ -53,20 +53,20 @@ class TrochoidIrregularWaveSimulation :
 
   // lookup interface - array
   void ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h) override;
+      Eigen::Ref<Eigen::ArrayXXd> h) const override;
 
   void ElevationDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) const override;
 
   void DisplacementAt(
       Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy) override;
+      Eigen::Ref<Eigen::ArrayXXd> sy) const override;
 
   void DisplacementDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
   void DisplacementAndDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> h,
@@ -76,24 +76,24 @@ class TrochoidIrregularWaveSimulation :
       Eigen::Ref<Eigen::ArrayXXd> dhdy,
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
   void PressureAt(
       Index iz,
-      Eigen::Ref<Eigen::ArrayXXd> pressure) override;
+      Eigen::Ref<Eigen::ArrayXXd> pressure) const override;
 
   // lookup interface - scalar
   void ElevationAt(
       Index ix, Index iy,
-      double &eta) override;
+      double &eta) const override;
 
   void DisplacementAt(
       Index ix, Index iy,
-      double& sx, double& sy) override;
+      double& sx, double& sy) const override;
 
   void PressureAt(
       Index ix, Index iy, Index iz,
-      double& pressure) override;
+      double& pressure) const override;
 
  private:
   class Impl;

--- a/gz-waves/include/gz/waves/WaveSimulation.hh
+++ b/gz-waves/include/gz/waves/WaveSimulation.hh
@@ -34,22 +34,22 @@ class IWaveField
 
   virtual void Elevation(
       double x, double y,
-      double& eta) = 0;
+      double& eta) const = 0;
 
   virtual void Elevation(
       const Eigen::Ref<const Eigen::ArrayXd>& x,
       const Eigen::Ref<const Eigen::ArrayXd>& y,
-      Eigen::Ref<Eigen::ArrayXd> eta) = 0;
+      Eigen::Ref<Eigen::ArrayXd> eta) const = 0;
 
   virtual void Pressure(
       double x, double y, double z,
-      double& pressure) = 0;
+      double& pressure) const = 0;
 
   virtual void Pressure(
       const Eigen::Ref<const Eigen::ArrayXd>& x,
       const Eigen::Ref<const Eigen::ArrayXd>& y,
       const Eigen::Ref<const Eigen::ArrayXd>& z,
-      Eigen::Ref<Eigen::ArrayXd> pressure) = 0;
+      Eigen::Ref<Eigen::ArrayXd> pressure) const = 0;
 };
 
 // compute a wave field on a discrete grid
@@ -73,32 +73,32 @@ class IWaveSimulation
   // lookup interface - scalar
   virtual void ElevationAt(
       Index ix, Index iy,
-      double& eta) = 0;
+      double& eta) const = 0;
 
   virtual void DisplacementAt(
       Index ix, Index iy,
-      double& sx, double& sy) = 0;
+      double& sx, double& sy) const = 0;
 
   virtual void PressureAt(
       Index ix, Index iy, Index iz,
-      double& pressure) = 0;
+      double& pressure) const = 0;
 
   // lookup interface - array
   virtual void ElevationAt(
-      Eigen::Ref<Eigen::ArrayXXd> h) = 0;
+      Eigen::Ref<Eigen::ArrayXXd> h) const = 0;
 
   virtual void ElevationDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dhdx,
-      Eigen::Ref<Eigen::ArrayXXd> dhdy) = 0;
+      Eigen::Ref<Eigen::ArrayXXd> dhdy) const = 0;
 
   virtual void DisplacementAt(
       Eigen::Ref<Eigen::ArrayXXd> sx,
-      Eigen::Ref<Eigen::ArrayXXd> sy) = 0;
+      Eigen::Ref<Eigen::ArrayXXd> sy) const = 0;
 
   virtual void DisplacementDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) = 0;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const = 0;
 
   virtual void DisplacementAndDerivAt(
       Eigen::Ref<Eigen::ArrayXXd> h,
@@ -108,11 +108,11 @@ class IWaveSimulation
       Eigen::Ref<Eigen::ArrayXXd> dhdy,
       Eigen::Ref<Eigen::ArrayXXd> dsxdx,
       Eigen::Ref<Eigen::ArrayXXd> dsydy,
-      Eigen::Ref<Eigen::ArrayXXd> dsxdy) = 0;
+      Eigen::Ref<Eigen::ArrayXXd> dsxdy) const = 0;
 
   virtual void PressureAt(
       Index iz,
-      Eigen::Ref<Eigen::ArrayXXd> pressure) = 0;
+      Eigen::Ref<Eigen::ArrayXXd> pressure) const = 0;
 };
 
 }  // namespace waves

--- a/gz-waves/src/LinearRandomFFTWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulation.cc
@@ -714,7 +714,7 @@ Index LinearRandomFFTWaveSimulation::SizeZ() const
 
 //////////////////////////////////////////////////
 void LinearRandomFFTWaveSimulation::ElevationAt(
-    Eigen::Ref<Eigen::ArrayXXd> h)
+    Eigen::Ref<Eigen::ArrayXXd> h) const
 {
   impl_->ElevationAt(h);
 }
@@ -722,7 +722,7 @@ void LinearRandomFFTWaveSimulation::ElevationAt(
 //////////////////////////////////////////////////
 void LinearRandomFFTWaveSimulation::ElevationDerivAt(
     Eigen::Ref<Eigen::ArrayXXd> dhdx,
-    Eigen::Ref<Eigen::ArrayXXd> dhdy)
+    Eigen::Ref<Eigen::ArrayXXd> dhdy) const
 {
   impl_->ElevationDerivAt(dhdx, dhdy);
 }
@@ -730,7 +730,7 @@ void LinearRandomFFTWaveSimulation::ElevationDerivAt(
 //////////////////////////////////////////////////
 void LinearRandomFFTWaveSimulation::DisplacementAt(
     Eigen::Ref<Eigen::ArrayXXd> sx,
-    Eigen::Ref<Eigen::ArrayXXd> sy)
+    Eigen::Ref<Eigen::ArrayXXd> sy) const
 {
   impl_->DisplacementAt(sx, sy);
 }
@@ -739,7 +739,7 @@ void LinearRandomFFTWaveSimulation::DisplacementAt(
 void LinearRandomFFTWaveSimulation::DisplacementDerivAt(
     Eigen::Ref<Eigen::ArrayXXd> dsxdx,
     Eigen::Ref<Eigen::ArrayXXd> dsydy,
-    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
 {
   impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
 }
@@ -753,7 +753,7 @@ void LinearRandomFFTWaveSimulation::DisplacementAndDerivAt(
     Eigen::Ref<Eigen::ArrayXXd> dhdy,
     Eigen::Ref<Eigen::ArrayXXd> dsxdx,
     Eigen::Ref<Eigen::ArrayXXd> dsydy,
-    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
 {
   impl_->ElevationAt(h);
   impl_->ElevationDerivAt(dhdx, dhdy);
@@ -764,7 +764,7 @@ void LinearRandomFFTWaveSimulation::DisplacementAndDerivAt(
 //////////////////////////////////////////////////
 void LinearRandomFFTWaveSimulation::PressureAt(
     Index iz,
-    Eigen::Ref<Eigen::ArrayXXd> pressure)
+    Eigen::Ref<Eigen::ArrayXXd> pressure) const
 {
   impl_->PressureAt(iz, pressure);
 }
@@ -772,7 +772,7 @@ void LinearRandomFFTWaveSimulation::PressureAt(
 //////////////////////////////////////////////////
 void LinearRandomFFTWaveSimulation::ElevationAt(
     Index ix, Index iy,
-    double& eta)
+    double& eta) const
 {
   impl_->ElevationAt(ix, iy, eta);
 }
@@ -780,7 +780,7 @@ void LinearRandomFFTWaveSimulation::ElevationAt(
 //////////////////////////////////////////////////
 void LinearRandomFFTWaveSimulation::DisplacementAt(
     Index ix, Index iy,
-    double& sx, double& sy)
+    double& sx, double& sy) const
 {
   impl_->DisplacementAt(ix, iy, sx, sy);
 }
@@ -788,7 +788,7 @@ void LinearRandomFFTWaveSimulation::DisplacementAt(
 //////////////////////////////////////////////////
 void LinearRandomFFTWaveSimulation::PressureAt(
     Index ix, Index iy, Index iz,
-    double& pressure)
+    double& pressure) const
 {
   impl_->PressureAt(ix, iy, iz, pressure);
 }

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRef.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRef.cc
@@ -784,7 +784,7 @@ namespace waves
 
   //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulationRef::ElevationAt(
-    Eigen::Ref<Eigen::ArrayXXd> h)
+    Eigen::Ref<Eigen::ArrayXXd> h) const
   {
     impl_->ElevationAt(h);
   }
@@ -792,7 +792,7 @@ namespace waves
   //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulationRef::ElevationDerivAt(
     Eigen::Ref<Eigen::ArrayXXd> dhdx,
-    Eigen::Ref<Eigen::ArrayXXd> dhdy)
+    Eigen::Ref<Eigen::ArrayXXd> dhdy) const
   {
     impl_->ElevationDerivAt(dhdx, dhdy);
   }
@@ -800,7 +800,7 @@ namespace waves
   //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulationRef::DisplacementAt(
     Eigen::Ref<Eigen::ArrayXXd> sx,
-    Eigen::Ref<Eigen::ArrayXXd> sy)
+    Eigen::Ref<Eigen::ArrayXXd> sy) const
   {
     impl_->DisplacementAt(sx, sy);
   }
@@ -809,7 +809,7 @@ namespace waves
   void LinearRandomFFTWaveSimulationRef::DisplacementDerivAt(
     Eigen::Ref<Eigen::ArrayXXd> dsxdx,
     Eigen::Ref<Eigen::ArrayXXd> dsydy,
-    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
   {
     impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
   }
@@ -823,7 +823,7 @@ namespace waves
     Eigen::Ref<Eigen::ArrayXXd> dhdy,
     Eigen::Ref<Eigen::ArrayXXd> dsxdx,
     Eigen::Ref<Eigen::ArrayXXd> dsydy,
-    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
   {
     impl_->ElevationAt(h);
     impl_->ElevationDerivAt(dhdx, dhdy);

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRef.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRef.hh
@@ -48,20 +48,20 @@ class LinearRandomFFTWaveSimulationRef :
     Index SizeZ() const override;
 
     void ElevationAt(
-        Eigen::Ref<Eigen::ArrayXXd> h) override;
+        Eigen::Ref<Eigen::ArrayXXd> h) const override;
 
     void ElevationDerivAt(
         Eigen::Ref<Eigen::ArrayXXd> dhdx,
-        Eigen::Ref<Eigen::ArrayXXd> dhdy) override;
+        Eigen::Ref<Eigen::ArrayXXd> dhdy) const override;
 
     void DisplacementAt(
         Eigen::Ref<Eigen::ArrayXXd> sx,
-        Eigen::Ref<Eigen::ArrayXXd> sy) override;
+        Eigen::Ref<Eigen::ArrayXXd> sy) const override;
 
     void DisplacementDerivAt(
         Eigen::Ref<Eigen::ArrayXXd> dsxdx,
         Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+        Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
     void DisplacementAndDerivAt(
         Eigen::Ref<Eigen::ArrayXXd> h,
@@ -71,7 +71,7 @@ class LinearRandomFFTWaveSimulationRef :
         Eigen::Ref<Eigen::ArrayXXd> dhdy,
         Eigen::Ref<Eigen::ArrayXXd> dsxdx,
         Eigen::Ref<Eigen::ArrayXXd> dsydy,
-        Eigen::Ref<Eigen::ArrayXXd> dsxdy) override;
+        Eigen::Ref<Eigen::ArrayXXd> dsxdy) const override;
 
   // public class declaration - for testing
   class Impl;

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -516,7 +516,7 @@ Index LinearRandomWaveSimulation::SizeZ() const
 
 void LinearRandomWaveSimulation::Elevation(
     double x, double y,
-    double &eta)
+    double &eta) const
 {
   impl_->Elevation(x, y, eta);
 }
@@ -524,14 +524,14 @@ void LinearRandomWaveSimulation::Elevation(
 void LinearRandomWaveSimulation::Elevation(
     const Eigen::Ref<const Eigen::ArrayXd>& x,
     const Eigen::Ref<const Eigen::ArrayXd>& y,
-    Eigen::Ref<Eigen::ArrayXd> eta)
+    Eigen::Ref<Eigen::ArrayXd> eta) const
 {
   impl_->Elevation(x, y, eta);
 }
 
 void LinearRandomWaveSimulation::Pressure(
     double x, double y, double z,
-    double& pressure)
+    double& pressure) const
 {
   impl_->Pressure(x, y, z, pressure);
 }
@@ -540,14 +540,14 @@ void LinearRandomWaveSimulation::Pressure(
     const Eigen::Ref<const Eigen::ArrayXd>& x,
     const Eigen::Ref<const Eigen::ArrayXd>& y,
     const Eigen::Ref<const Eigen::ArrayXd>& z,
-    Eigen::Ref<Eigen::ArrayXd> pressure)
+    Eigen::Ref<Eigen::ArrayXd> pressure) const
 {
   impl_->Pressure(x, y, z, pressure);
 }
 
 //////////////////////////////////////////////////
 void LinearRandomWaveSimulation::ElevationAt(
-    Eigen::Ref<Eigen::ArrayXXd> h)
+    Eigen::Ref<Eigen::ArrayXXd> h) const
 {
   impl_->ElevationAt(h);
 }
@@ -555,7 +555,7 @@ void LinearRandomWaveSimulation::ElevationAt(
 //////////////////////////////////////////////////
 void LinearRandomWaveSimulation::ElevationDerivAt(
     Eigen::Ref<Eigen::ArrayXXd> dhdx,
-    Eigen::Ref<Eigen::ArrayXXd> dhdy)
+    Eigen::Ref<Eigen::ArrayXXd> dhdy) const
 {
   impl_->ElevationDerivAt(dhdx, dhdy);
 }
@@ -563,7 +563,7 @@ void LinearRandomWaveSimulation::ElevationDerivAt(
 //////////////////////////////////////////////////
 void LinearRandomWaveSimulation::DisplacementAt(
     Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*sy*/)
+    Eigen::Ref<Eigen::ArrayXXd> /*sy*/) const
 {
   // no xy-displacement
 }
@@ -572,7 +572,7 @@ void LinearRandomWaveSimulation::DisplacementAt(
 void LinearRandomWaveSimulation::DisplacementDerivAt(
     Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
     Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+    Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/) const
 {
   // no xy-displacement
 }
@@ -586,7 +586,7 @@ void LinearRandomWaveSimulation::DisplacementAndDerivAt(
     Eigen::Ref<Eigen::ArrayXXd> dhdy,
     Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
     Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
-    Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+    Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/) const
 {
   impl_->ElevationAt(h);
   impl_->ElevationDerivAt(dhdx, dhdy);
@@ -595,7 +595,7 @@ void LinearRandomWaveSimulation::DisplacementAndDerivAt(
 //////////////////////////////////////////////////
 void LinearRandomWaveSimulation::PressureAt(
     Index iz,
-    Eigen::Ref<Eigen::ArrayXXd> pressure)
+    Eigen::Ref<Eigen::ArrayXXd> pressure) const
 {
   impl_->PressureAt(iz, pressure);
 }
@@ -603,7 +603,7 @@ void LinearRandomWaveSimulation::PressureAt(
 //////////////////////////////////////////////////
 void LinearRandomWaveSimulation::ElevationAt(
     Index ix, Index iy,
-    double& eta)
+    double& eta) const
 {
   impl_->ElevationAt(ix, iy, eta);
 }
@@ -611,7 +611,7 @@ void LinearRandomWaveSimulation::ElevationAt(
 //////////////////////////////////////////////////
 void LinearRandomWaveSimulation::DisplacementAt(
     Index /*ix*/, Index /*iy*/,
-    double& /*sx*/, double& /*sy*/)
+    double& /*sx*/, double& /*sy*/) const
 {
   // no xy-displacement
 }
@@ -619,7 +619,7 @@ void LinearRandomWaveSimulation::DisplacementAt(
 //////////////////////////////////////////////////
 void LinearRandomWaveSimulation::PressureAt(
     Index ix, Index iy, Index iz,
-    double& pressure)
+    double& pressure) const
 {
   impl_->PressureAt(ix, iy, iz, pressure);
 }

--- a/gz-waves/src/LinearRegularWaveSimulation.cc
+++ b/gz-waves/src/LinearRegularWaveSimulation.cc
@@ -616,7 +616,7 @@ Index LinearRegularWaveSimulation::SizeZ() const
 //////////////////////////////////////////////////
 void LinearRegularWaveSimulation::Elevation(
   double x, double y,
-  double &eta)
+  double &eta) const
 {
   impl_->Elevation(x, y, eta);
 }
@@ -625,7 +625,7 @@ void LinearRegularWaveSimulation::Elevation(
 void LinearRegularWaveSimulation::Elevation(
   const Eigen::Ref<const Eigen::ArrayXd>& x,
   const Eigen::Ref<const Eigen::ArrayXd>& y,
-  Eigen::Ref<Eigen::ArrayXd> eta)
+  Eigen::Ref<Eigen::ArrayXd> eta) const
 {
   impl_->Elevation(x, y, eta);
 }
@@ -633,7 +633,7 @@ void LinearRegularWaveSimulation::Elevation(
 //////////////////////////////////////////////////
 void LinearRegularWaveSimulation::Pressure(
   double x, double y, double z,
-  double& pressure)
+  double& pressure) const
 {
   impl_->Pressure(x, y, z, pressure);
 }
@@ -643,14 +643,14 @@ void LinearRegularWaveSimulation::Pressure(
   const Eigen::Ref<const Eigen::ArrayXd>& x,
   const Eigen::Ref<const Eigen::ArrayXd>& y,
   const Eigen::Ref<const Eigen::ArrayXd>& z,
-  Eigen::Ref<Eigen::ArrayXd> pressure)
+  Eigen::Ref<Eigen::ArrayXd> pressure) const
 {
   impl_->Pressure(x, y, z, pressure);
 }
 
 //////////////////////////////////////////////////
 void LinearRegularWaveSimulation::ElevationAt(
-  Eigen::Ref<Eigen::ArrayXXd> h)
+  Eigen::Ref<Eigen::ArrayXXd> h) const
 {
   impl_->ElevationAt(h);
 }
@@ -658,7 +658,7 @@ void LinearRegularWaveSimulation::ElevationAt(
 //////////////////////////////////////////////////
 void LinearRegularWaveSimulation::ElevationDerivAt(
   Eigen::Ref<Eigen::ArrayXXd> dhdx,
-  Eigen::Ref<Eigen::ArrayXXd> dhdy)
+  Eigen::Ref<Eigen::ArrayXXd> dhdy) const
 {
   impl_->ElevationDerivAt(dhdx, dhdy);
 }
@@ -666,7 +666,7 @@ void LinearRegularWaveSimulation::ElevationDerivAt(
 //////////////////////////////////////////////////
 void LinearRegularWaveSimulation::DisplacementAt(
   Eigen::Ref<Eigen::ArrayXXd> /*sx*/,
-  Eigen::Ref<Eigen::ArrayXXd> /*sy*/)
+  Eigen::Ref<Eigen::ArrayXXd> /*sy*/) const
 {
   // No xy-displacement
 }
@@ -675,7 +675,7 @@ void LinearRegularWaveSimulation::DisplacementAt(
 void LinearRegularWaveSimulation::DisplacementDerivAt(
   Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
   Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
-  Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+  Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/) const
 {
   // No xy-displacement
 }
@@ -689,7 +689,7 @@ void LinearRegularWaveSimulation::DisplacementAndDerivAt(
   Eigen::Ref<Eigen::ArrayXXd> dhdy,
   Eigen::Ref<Eigen::ArrayXXd> dsxdx,
   Eigen::Ref<Eigen::ArrayXXd> dsydy,
-  Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+  Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
 {
   // impl_->DisplacementAndDerivAt(
   //     h, sx, sy, dhdx, dhdy, dsxdx, dsydy, dsxdy);
@@ -702,7 +702,7 @@ void LinearRegularWaveSimulation::DisplacementAndDerivAt(
 //////////////////////////////////////////////////
 void LinearRegularWaveSimulation::ElevationAt(
   Index ix, Index iy,
-  double& eta)
+  double& eta) const
 {
   impl_->ElevationAt(ix, iy, eta);
 }
@@ -710,7 +710,7 @@ void LinearRegularWaveSimulation::ElevationAt(
 //////////////////////////////////////////////////
 void LinearRegularWaveSimulation::DisplacementAt(
   Index /*ix*/, Index /*iy*/,
-  double& /*sx*/, double& /*sy*/)
+  double& /*sx*/, double& /*sy*/) const
 {
   // No xy-displacement
 }
@@ -718,7 +718,7 @@ void LinearRegularWaveSimulation::DisplacementAt(
 //////////////////////////////////////////////////
 void LinearRegularWaveSimulation::PressureAt(
   Index ix, Index iy, Index iz,
-  double& pressure)
+  double& pressure) const
 {
   impl_->PressureAt(ix, iy, iz, pressure);
 }
@@ -726,7 +726,7 @@ void LinearRegularWaveSimulation::PressureAt(
 //////////////////////////////////////////////////
 void LinearRegularWaveSimulation::PressureAt(
   Index iz,
-  Eigen::Ref<Eigen::ArrayXXd> pressure)
+  Eigen::Ref<Eigen::ArrayXXd> pressure) const
 {
   impl_->PressureAt(iz, pressure);
 }

--- a/gz-waves/src/TrochoidIrregularWaveSimulation.cc
+++ b/gz-waves/src/TrochoidIrregularWaveSimulation.cc
@@ -315,7 +315,7 @@ void TrochoidIrregularWaveSimulation::DisplacementAndDerivAt(
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::PressureAt(
     Index ,
-    Eigen::Ref<Eigen::ArrayXXd> ) const
+    Eigen::Ref<Eigen::ArrayXXd>) const
 {
   assert(0 && "Not implemented");
 }

--- a/gz-waves/src/TrochoidIrregularWaveSimulation.cc
+++ b/gz-waves/src/TrochoidIrregularWaveSimulation.cc
@@ -265,7 +265,7 @@ Index TrochoidIrregularWaveSimulation::SizeZ() const
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::ElevationAt(
-  Eigen::Ref<Eigen::ArrayXXd> h)
+  Eigen::Ref<Eigen::ArrayXXd> h) const
 {
   impl_->ElevationAt(h);
 }
@@ -273,7 +273,7 @@ void TrochoidIrregularWaveSimulation::ElevationAt(
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::ElevationDerivAt(
   Eigen::Ref<Eigen::ArrayXXd> dhdx,
-  Eigen::Ref<Eigen::ArrayXXd> dhdy)
+  Eigen::Ref<Eigen::ArrayXXd> dhdy) const
 {
   impl_->ElevationDerivAt(dhdx, dhdy);
 }
@@ -281,7 +281,7 @@ void TrochoidIrregularWaveSimulation::ElevationDerivAt(
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::DisplacementAt(
   Eigen::Ref<Eigen::ArrayXXd> sx,
-  Eigen::Ref<Eigen::ArrayXXd> sy)
+  Eigen::Ref<Eigen::ArrayXXd> sy) const
 {
   impl_->DisplacementAt(sx, sy);
 }
@@ -290,7 +290,7 @@ void TrochoidIrregularWaveSimulation::DisplacementAt(
 void TrochoidIrregularWaveSimulation::DisplacementDerivAt(
   Eigen::Ref<Eigen::ArrayXXd> dsxdx,
   Eigen::Ref<Eigen::ArrayXXd> dsydy,
-  Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+  Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
 {
   impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
 }
@@ -304,7 +304,7 @@ void TrochoidIrregularWaveSimulation::DisplacementAndDerivAt(
   Eigen::Ref<Eigen::ArrayXXd> dhdy,
   Eigen::Ref<Eigen::ArrayXXd> dsxdx,
   Eigen::Ref<Eigen::ArrayXXd> dsydy,
-  Eigen::Ref<Eigen::ArrayXXd> dsxdy)
+  Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
 {
   impl_->ElevationAt(h);
   impl_->ElevationDerivAt(dhdx, dhdy);
@@ -315,7 +315,7 @@ void TrochoidIrregularWaveSimulation::DisplacementAndDerivAt(
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::PressureAt(
     Index ,
-    Eigen::Ref<Eigen::ArrayXXd> )
+    Eigen::Ref<Eigen::ArrayXXd> ) const
 {
   assert(0 && "Not implemented");
 }
@@ -323,7 +323,7 @@ void TrochoidIrregularWaveSimulation::PressureAt(
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::ElevationAt(
     Index , Index ,
-    double&)
+    double&) const
 {
   assert(0 && "Not implemented");
 }
@@ -331,7 +331,7 @@ void TrochoidIrregularWaveSimulation::ElevationAt(
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::DisplacementAt(
     Index , Index ,
-    double&, double&)
+    double&, double&) const
 {
   assert(0 && "Not implemented");
 }
@@ -339,7 +339,7 @@ void TrochoidIrregularWaveSimulation::DisplacementAt(
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::PressureAt(
     Index , Index , Index ,
-    double&)
+    double&) const
 {
   assert(0 && "Not implemented");
 }


### PR DESCRIPTION
Make access to displacements and derivatives const (logically const, lazy evaluation post update).
