### PR TITLE
Waves: allow ocean tile to have different dimensions in each direction.

### DIFF
--- a/gz-waves/include/gz/waves/OceanTile.hh
+++ b/gz-waves/include/gz/waves/OceanTile.hh
@@ -17,6 +17,7 @@
 #define GZ_WAVES_OCEANTILE_HH_
 
 #include <memory>
+#include <tuple>
 #include <vector>
 
 #include <gz/math.hh>
@@ -40,15 +41,17 @@ class OceanTileT
  public:
   virtual ~OceanTileT();
 
-  explicit OceanTileT(Index nx, double lx, bool has_visuals = true);
+  explicit OceanTileT(Index nx, Index ny, double lx, double ly,
+      bool has_visuals = true);
 
   explicit OceanTileT(WaveParametersPtr params, bool has_visuals = true);
 
-  /// \brief The tile size (or length) lx.
-  double TileSize() const;
+  /// \brief The size of the wave tile (m).
+  std::tuple<double, double> TileSize() const;
 
-  /// \brief The tile resolution (nx). The tile contains (nx + 1)**2 vertices.
-  Index Resolution() const;
+  /// \brief The number of cells in the wave tile in each direction.
+  /// The tile contains (nx + 1) * (ny + 1) vertices.
+  std::tuple<Index, Index> CellCount() const;
 
   void SetWindVelocity(double ux, double uy);
 

--- a/gz-waves/include/gz/waves/TriangulatedGrid.hh
+++ b/gz-waves/include/gz/waves/TriangulatedGrid.hh
@@ -39,11 +39,11 @@ class TriangulatedGrid
 {
  public:
   virtual ~TriangulatedGrid();
-  TriangulatedGrid(Index num_segments, double length);
+  TriangulatedGrid(Index nx, Index ny, double lx, double ly);
   void CreateMesh();
   void CreateTriangulation();
   static std::unique_ptr<TriangulatedGrid> Create(
-      Index num_segments, double length);
+      Index nx, Index ny, double lx, double ly);
 
   bool Locate(const cgal::Point3& query, int64_t& faceIndex) const;
   bool Height(const cgal::Point3& query, double& height) const;

--- a/gz-waves/include/gz/waves/WaveParameters.hh
+++ b/gz-waves/include/gz/waves/WaveParameters.hh
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include <gz/math/Vector2.hh>
@@ -66,12 +67,12 @@ class WaveParameters
   std::string Algorithm() const;
 
   /// \brief The size of the wave tile (m).
-  double TileSize() const;
+  std::tuple<double, double> TileSize() const;
 
-  /// \brief The number of cells in the wave tile in each direction (N).
-  Index CellCount() const;
+  /// \brief The number of cells in the wave tile in each direction.
+  std::tuple<Index, Index> CellCount() const;
 
-  /// \brief The number of wave components (3 max if visualisation required).
+  /// \brief The number of wave components.
   Index Number() const;
 
   /// \brief The angle between the mean wave direction and the
@@ -127,14 +128,27 @@ class WaveParameters
 
   /// \brief Set the size of the wave tile (m).
   ///
-  /// \param[in] value  The size of the wave tile (m).
+  /// \param[in] value  The size of the wave tile in both directions (m).
   void SetTileSize(double value);
+
+  /// \brief Set the size of the wave tile (m).
+  ///
+  /// \param[in] lx  The size of the wave tile in the x-direction (m).
+  /// \param[in] ly  The size of the wave tile in the y-direction (m).
+  void SetTileSize(double lx, double ly);
 
   /// \brief Set the number of cells in the wave tile
   ///        in each direction.
   ///
-  /// \param[in] value  The number of cells.
+  /// \param[in] value  The number of cells in both directions.
   void SetCellCount(Index value);
+
+  /// \brief Set the number of cells in the wave tile
+  ///        in each direction.
+  ///
+  /// \param[in] nx  The number of cells in the x-direction.
+  /// \param[in] ny  The number of cells in the y-direction.
+  void SetCellCount(Index nx, Index ny);
 
   /// \brief Set the number of wave components (3 max).
   ///

--- a/gz-waves/src/LinearRegularWaveSimulation_TEST.cc
+++ b/gz-waves/src/LinearRegularWaveSimulation_TEST.cc
@@ -479,7 +479,7 @@ TEST(OceanTile, LinearRegularWaveSimulation)
   double time = 0.0;
 
   // Ocean tile (in server mode)
-  std::unique_ptr<OceanTile> oceanTile(new OceanTile(N, L, false));
+  std::unique_ptr<OceanTile> oceanTile(new OceanTile(N, N, L, L, false));
   oceanTile->SetWindVelocity(25.0, 0.0);
   oceanTile->Create();
 

--- a/gz-waves/src/TriangulatedGrid.cc
+++ b/gz-waves/src/TriangulatedGrid.cc
@@ -41,7 +41,7 @@ namespace waves
 class TriangulatedGrid::Private {
  public:
   ~Private();
-  Private(Index num_segments, double length);
+  Private(Index nx, Index ny, double lx, double ly);
   void CreateMesh();
   void CreateTriangulation();
 
@@ -83,8 +83,10 @@ class TriangulatedGrid::Private {
   typedef Triangulation::Face Face;
 
   // Dimensions
-  Index num_segments_;
-  double length_;
+  Index nx_;
+  Index ny_;
+  double lx_;
+  double ly_;
 
   // Mesh
   cgal::Point3              origin_;
@@ -102,22 +104,25 @@ TriangulatedGrid::Private::~Private() {
 }
 
 //////////////////////////////////////////////////
-TriangulatedGrid::Private::Private(Index num_segments, double length) :
-  num_segments_(num_segments), length_(length), origin_(CGAL::ORIGIN) {
+TriangulatedGrid::Private::Private(Index nx, Index ny, double lx, double ly) :
+  nx_(nx), ny_(ny), lx_(lx), ly_(ly), origin_(CGAL::ORIGIN) {
 }
 
 //////////////////////////////////////////////////
 void TriangulatedGrid::Private::CreateMesh() {
-  double dl = length_ / num_segments_;
-  double lm = - length_ / 2.0;
-  const Index nplus1 = num_segments_ + 1;
+  double dlx = lx_ / nx_;
+  double dly = ly_ / ny_;
+  double lxm = - lx_ / 2.0;
+  double lym = - ly_ / 2.0;
+  const Index nx_plus1 = nx_ + 1;
+  const Index ny_plus1 = ny_ + 1;
 
-  // Points - (num_segments_+1) points_ in each row / column
-  for (int64_t iy=0; iy <= num_segments_; ++iy) {
-    double py = iy * dl + lm;
-    for (int64_t ix=0; ix <= num_segments_; ++ix) {
+  // Points - (nx_+1) points_ in each row / column
+  for (int64_t iy=0; iy <= ny_; ++iy) {
+    double py = iy * dly + lym;
+    for (int64_t ix=0; ix <= nx_; ++ix) {
       // Vertex position
-      double px = ix * dl + lm;
+      double px = ix * dlx + lxm;
       cgal::Point3 point(px, py, 0.0);
       points_.push_back(point);
     }
@@ -126,13 +131,13 @@ void TriangulatedGrid::Private::CreateMesh() {
   points0_ = points_;
 
   // Face indices
-  for (int64_t iy=0; iy < num_segments_; ++iy) {
-    for (int64_t ix=0; ix < num_segments_; ++ix) {
+  for (int64_t iy=0; iy < ny_; ++iy) {
+    for (int64_t ix=0; ix < nx_; ++ix) {
       // Get the points in the cell coordinates
-      int64_t idx0 = iy * nplus1 + ix;
-      int64_t idx1 = iy * nplus1 + ix + 1;
-      int64_t idx2 = (iy+1) * nplus1 + ix + 1;
-      int64_t idx3 = (iy+1) * nplus1 + ix;
+      int64_t idx0 = iy * nx_plus1 + ix;
+      int64_t idx1 = iy * nx_plus1 + ix + 1;
+      int64_t idx2 = (iy+1) * nx_plus1 + ix + 1;
+      int64_t idx3 = (iy+1) * nx_plus1 + ix;
 
       // Face indices
       indices_.push_back({ idx0, idx1, idx2 });
@@ -141,23 +146,24 @@ void TriangulatedGrid::Private::CreateMesh() {
   }
 
   // Infinite indices (follow edges counter clockwise around grid)
-  infinite_indices_.resize(4*num_segments_);
-  for (int64_t i=0; i < num_segments_; ++i) {
-    // bottom
-    int64_t idx = i;
-    infinite_indices_[i] = { idx, idx+1 };
+  infinite_indices_.resize(2*nx_ + 2*ny_);
+  for (int64_t ix=0; ix < nx_; ++ix) {
+    // bottom (0..nx-1)
+    int64_t idx = ix;
+    infinite_indices_[ix] = { idx, idx + 1 };
 
-    // right
-    idx = i * nplus1 + num_segments_;
-    infinite_indices_[num_segments_+i] = { idx, idx+nplus1 };
+    // top (nx+ny..2*nx+ny-1)
+    idx = ny_ * nx_plus1 + ix;
+    infinite_indices_[2*nx_ + ny_ - 1 - ix] = { idx + 1, idx };
+  }
+  for (int64_t iy=0; iy < ny_; ++iy) {
+    // right (nx..nx+ny-1)
+    int64_t idx = iy * nx_plus1 + nx_;
+    infinite_indices_[nx_ + iy] = { idx, idx + nx_plus1 };
 
-    // top
-    idx = num_segments_ * nplus1 + i;
-    infinite_indices_[3*num_segments_-1-i] = { idx+1, idx };
-
-    // left
-    idx = i * nplus1;
-    infinite_indices_[4*num_segments_-1-i] = { idx+nplus1, idx };
+    // left (2*nx+ny..2*nx+2*ny-1)
+    idx = iy * nx_plus1;
+    infinite_indices_[2*nx_ + 2*ny_ - 1 - iy] = { idx + nx_plus1, idx };
   }
 }
 
@@ -197,12 +203,12 @@ void TriangulatedGrid::Private::CreateTriangulation() {
   // std::cout << "set vertex info: " << timer.time() << " s" << "\n";
 
   // Constraint indices
-  const Index nplus1 = num_segments_ + 1;
+  const Index nx_plus1 = nx_ + 1;
   std::vector<std::pair < size_t, int64_t>> cindices;
-  for (int64_t iy=0; iy < num_segments_; ++iy) {
-    for (int64_t ix=0; ix < num_segments_; ++ix) {
-      int64_t idx1 = iy * nplus1 + ix;
-      int64_t idx2 = (iy + 1) * nplus1 + (ix + 1);
+  for (int64_t iy=0; iy < ny_; ++iy) {
+    for (int64_t ix=0; ix < nx_; ++ix) {
+      int64_t idx1 = iy * nx_plus1 + ix;
+      int64_t idx2 = (iy + 1) * nx_plus1 + (ix + 1);
       cindices.push_back(std::make_pair(idx1, idx2));
     }
   }
@@ -444,8 +450,10 @@ bool TriangulatedGrid::Private::IsValid(bool verbose) const {
 
 //////////////////////////////////////////////////
 void TriangulatedGrid::Private::DebugPrintMesh() const {
-  std::cout << "num_segments: " << num_segments_ << "\n";
-  std::cout << "length: " << length_ << "\n";
+  std::cout << "nx: " << nx_ << "\n";
+  std::cout << "ny: " << ny_ << "\n";
+  std::cout << "lx: " << lx_ << "\n";
+  std::cout << "ly: " << ly_ << "\n";
 
   std::cout << "points: [" << points_.size() << "]" << "\n";
   for (auto&& p : points_) {
@@ -564,8 +572,8 @@ TriangulatedGrid::~TriangulatedGrid() {
 }
 
 //////////////////////////////////////////////////
-TriangulatedGrid::TriangulatedGrid(Index num_segments, double length) :
-  impl_(new TriangulatedGrid::Private(num_segments, length))
+TriangulatedGrid::TriangulatedGrid(Index nx, Index ny, double lx, double ly) :
+  impl_(new TriangulatedGrid::Private(nx, ny, lx, ly))
 {
 }
 
@@ -581,9 +589,9 @@ void TriangulatedGrid::CreateTriangulation() {
 
 //////////////////////////////////////////////////
 std::unique_ptr<TriangulatedGrid> TriangulatedGrid::Create(
-    Index num_segments, double length) {
+    Index nx, Index ny, double lx, double ly) {
   std::unique_ptr<TriangulatedGrid> instance =
-      std::make_unique<TriangulatedGrid>(num_segments, length);
+      std::make_unique<TriangulatedGrid>(nx, ny, lx, ly);
   instance->CreateMesh();
   instance->CreateTriangulation();
   return instance;

--- a/gz-waves/src/TriangulatedGrid_TEST.cc
+++ b/gz-waves/src/TriangulatedGrid_TEST.cc
@@ -39,9 +39,11 @@ using gz::waves::TriangulatedGrid;
 //////////////////////////////////////////////////
 TEST(TriangulatedGrid, Create) {
   // Create
-  Index n = 2;
-  Index length = 100.0;
-  auto grid = TriangulatedGrid::Create(n, length);
+  Index nx = 16;
+  Index ny = 16;
+  Index lx = 100.0;
+  Index ly = 100.0;
+  auto grid = TriangulatedGrid::Create(nx, ny, lx, ly);
   std::unique_ptr<TriangulatedGrid> tri_grid = std::move(grid);
   // tri_grid->DebugPrintMesh();
   // tri_grid->DebugPrintTriangulation();
@@ -60,10 +62,13 @@ TEST(TriangulatedGrid, Create) {
 //////////////////////////////////////////////////
 TEST(TriangulatedGrid, Height) {
   // Create
-  Index n = 16;
-  Index length = 100.0;
-  Index nplus1 = n + 1;
-  auto grid = TriangulatedGrid::Create(n, length);
+  Index nx = 16;
+  Index ny = 16;
+  Index lx = 100.0;
+  Index ly = 100.0;
+  Index nx_plus1 = nx + 1;
+  Index ny_plus1 = ny + 1;
+  auto grid = TriangulatedGrid::Create(nx, ny, lx, ly);
   std::unique_ptr<TriangulatedGrid> source = std::move(grid);
   EXPECT_TRUE(source->IsValid());
 
@@ -75,9 +80,9 @@ TEST(TriangulatedGrid, Height) {
 
   // Set points
   Point3Range points = source->Points();
-  for (Index iy=0; iy < nplus1; ++iy) {
-    for (Index ix=0; ix < nplus1; ++ix) {
-      int64_t idx = iy * nplus1 + ix;
+  for (Index iy=0; iy < ny_plus1; ++iy) {
+    for (Index ix=0; ix < nx_plus1; ++ix) {
+      int64_t idx = iy * nx_plus1 + ix;
       double value = ix + iy;
       const cgal::Point3& p = points[idx];
       points[idx] = cgal::Point3(p.x(), p.y(), value);
@@ -93,18 +98,21 @@ TEST(TriangulatedGrid, Height) {
 //////////////////////////////////////////////////
 TEST(TriangulatedGrid, Interpolate) {
   // Create
-  Index n = 16;
-  Index length = 100.0;
-  Index nplus1 = n + 1;
-  auto grid1 = TriangulatedGrid::Create(n, length);
+  Index nx = 16;
+  Index ny = 16;
+  Index lx = 100.0;
+  Index ly = 100.0;
+  Index nx_plus1 = nx + 1;
+  Index ny_plus1 = ny + 1;
+  auto grid1 = TriangulatedGrid::Create(nx, ny, lx, ly);
   std::unique_ptr<TriangulatedGrid> source = std::move(grid1);
   EXPECT_TRUE(source->IsValid());
 
   // Set points
   Point3Range points = source->Points();
-  for (Index iy=0; iy < nplus1; ++iy) {
-    for (Index ix=0; ix < nplus1; ++ix) {
-      int64_t idx = iy * nplus1 + ix;
+  for (Index iy=0; iy < ny_plus1; ++iy) {
+    for (Index ix=0; ix < nx_plus1; ++ix) {
+      int64_t idx = iy * nx_plus1 + ix;
       double value = ix + iy;
       const cgal::Point3& p = points[idx];
       points[idx] = cgal::Point3(p.x(), p.y(), value);
@@ -115,7 +123,7 @@ TEST(TriangulatedGrid, Interpolate) {
   // source->DebugPrintTriangulation();
 
   // Create patch
-  auto grid2 = TriangulatedGrid::Create(2, 10.0);
+  auto grid2 = TriangulatedGrid::Create(2, 2, 10.0, 10.0);
   std::unique_ptr<TriangulatedGrid> patch = std::move(grid2);
   // patch->DebugPrintMesh();
   // patch->DebugPrintTriangulation();

--- a/gz-waves/src/systems/waves/WavesVisual.cc
+++ b/gz-waves/src/systems/waves/WavesVisual.cc
@@ -591,8 +591,8 @@ void WavesVisualPrivate::OnUpdate()
   double simTime = this->currentSimTimeSeconds;
 
   // ocean tile parameters
-  // waves::Index N = this->waveParams->CellCount();
-  double L = this->waveParams->TileSize();
+  auto [nx, ny] = this->waveParams->CellCount();
+  auto [lx, ly] = this->waveParams->TileSize();
   double ux = this->waveParams->WindVelocity().X();
   double uy = this->waveParams->WindVelocity().Y();
 
@@ -644,8 +644,8 @@ void WavesVisualPrivate::OnUpdate()
           {
             // tile position
             gz::math::Vector3d tilePosition(
-              position.X() + ix * L,
-              position.Y() + iy * L,
+              position.X() + ix * lx,
+              position.Y() + iy * ly,
               position.Z() + 0.0);
 
 #define GZ_WAVES_UPDATE_VISUALS 1
@@ -753,8 +753,8 @@ void WavesVisualPrivate::OnUpdate()
           {
             // tile position
             gz::math::Vector3d tilePosition(
-              position.X() + ix * L,
-              position.Y() + iy * L,
+              position.X() + ix * lx,
+              position.Y() + iy * ly,
               position.Z() + 0.0);
 
             /// \note: replaced with cloned geometry from primary visual
@@ -899,21 +899,21 @@ void WavesVisualPrivate::CreateShaderMaterial()
 //////////////////////////////////////////////////
 void WavesVisualPrivate::InitWaveSim()
 {
-  waves::Index N = this->waveParams->CellCount();
-  double L   = this->waveParams->TileSize();
+  auto [nx, ny] = this->waveParams->CellCount();
+  auto [lx, ly] = this->waveParams->TileSize();
   double ux  = this->waveParams->WindVelocity().X();
   double uy  = this->waveParams->WindVelocity().Y();
   double s   = this->waveParams->Steepness();
 
   // create wave model
   std::unique_ptr<gz::waves::LinearRandomFFTWaveSimulation> waveSim(
-      new gz::waves::LinearRandomFFTWaveSimulation(L, L, N, N));
+      new gz::waves::LinearRandomFFTWaveSimulation(lx, ly, nx, ny));
 
   // set params
   waveSim->SetWindVelocity(ux, uy);
   waveSim->SetLambda(s);
 
-  waves::Index N2 = N * N;
+  waves::Index N2 = nx * ny;
   this->mHeights = Eigen::ArrayXd::Zero(N2);
   this->mDisplacementsX = Eigen::ArrayXd::Zero(N2);
   this->mDisplacementsY = Eigen::ArrayXd::Zero(N2);
@@ -1083,12 +1083,12 @@ void WavesVisualPrivate::InitTextures()
   gzmsg << "WavesVisualPrivate::InitTextures\n";
 
   // ocean tile parameters
-  uint32_t N = static_cast<uint32_t>(this->waveParams->CellCount());
+  auto [nx, ny] = this->waveParams->CellCount();
 
   rendering::SceneNodeFactoryPtr sceneNodeFactory =
       this->extension->SceneNodeFactory();
   this->displacementMap = sceneNodeFactory->CreateDisplacementMap(
-    this->scene, this->oceanMaterial, this->entity, N, N);
+    this->scene, this->oceanMaterial, this->entity, nx, ny);
   this->displacementMap->InitTextures();
 }
 


### PR DESCRIPTION
This change allows the dimensions of the wave tile to be set independently in the x and y directions. This affects both the tile size (in metres), and the cell count controlling the grid resolution.

The FFT wave generator had been  previously updated to cope with non-square grids, this change updates the Gazebo system plugins and interfaces to use that feature.

## Details

The tile dimensions are controlled by the SDF elements:

```xml
      <tile_size>500.0</tile_size>
      <cell_count>128</cell_count>
```

which may now optionally be set as vectors:

```xml
      <tile_size>500.0 125.0</tile_size>
      <cell_count>128 32</cell_count>
```

There is a breaking change to the interface of the classes `OceanTile` and `WaveParameters` to return tuples instead of single values for the TileSize and CellCount.

![wave-grid-size](https://user-images.githubusercontent.com/24916364/213218761-4c3a66c0-9365-4f6c-93e9-f146967e6d95.jpg)
Figure: a single tile may now have different size and resolution in the x and y directions.

## Context

For FFT generated waves using spectra with spreading functions, it is usually desirable to use square grids for the ocean tile. An example where the asymmetric grid is useful is when analysing a linear wave-body model where the incident waves for the wave excitation force are expected to be uni-directional. In this case, for performance, we'd like to use an alternative wave generator with good resolution in the direction of the wave travel and lower resolution the the perpendicular direction. 
