### PR TITLE
Waves: add dimension accessors to TriangulatedGrid

### DIFF
--- a/gz-waves/include/gz/waves/OceanTile.hh
+++ b/gz-waves/include/gz/waves/OceanTile.hh
@@ -16,8 +16,8 @@
 #ifndef GZ_WAVES_OCEANTILE_HH_
 #define GZ_WAVES_OCEANTILE_HH_
 
+#include <array>
 #include <memory>
-#include <tuple>
 #include <vector>
 
 #include <gz/math.hh>
@@ -47,11 +47,11 @@ class OceanTileT
   explicit OceanTileT(WaveParametersPtr params, bool has_visuals = true);
 
   /// \brief The size of the wave tile (m).
-  std::tuple<double, double> TileSize() const;
+  std::array<double, 2> TileSize() const;
 
   /// \brief The number of cells in the wave tile in each direction.
   /// The tile contains (nx + 1) * (ny + 1) vertices.
-  std::tuple<Index, Index> CellCount() const;
+  std::array<Index, 2> CellCount() const;
 
   void SetWindVelocity(double ux, double uy);
 

--- a/gz-waves/include/gz/waves/TriangulatedGrid.hh
+++ b/gz-waves/include/gz/waves/TriangulatedGrid.hh
@@ -18,6 +18,7 @@
 #ifndef GZ_WAVES_TRIANGULATEDGRID_HH_
 #define GZ_WAVES_TRIANGULATEDGRID_HH_
 
+#include <array>
 #include <memory>
 #include <vector>
 
@@ -63,6 +64,9 @@ class TriangulatedGrid
   void UpdatePoints(const std::vector<cgal::Point3>& from);
   void UpdatePoints(const std::vector<math::Vector3d>& from);
   void UpdatePoints(const cgal::Mesh& from);
+
+  std::array<double, 2> TileSize() const;
+  std::array<Index, 2> CellCount() const;
 
  private:
   class Private;

--- a/gz-waves/include/gz/waves/WaveParameters.hh
+++ b/gz-waves/include/gz/waves/WaveParameters.hh
@@ -18,9 +18,9 @@
 #ifndef GZ_WAVES_WAVEPARAMETERS_HH_
 #define GZ_WAVES_WAVEPARAMETERS_HH_
 
+#include <array>
 #include <memory>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include <gz/math/Vector2.hh>
@@ -67,10 +67,10 @@ class WaveParameters
   std::string Algorithm() const;
 
   /// \brief The size of the wave tile (m).
-  std::tuple<double, double> TileSize() const;
+  std::array<double, 2> TileSize() const;
 
   /// \brief The number of cells in the wave tile in each direction.
-  std::tuple<Index, Index> CellCount() const;
+  std::array<Index, 2> CellCount() const;
 
   /// \brief The number of wave components.
   Index Number() const;

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -17,6 +17,7 @@
 
 #include <Eigen/Dense>
 
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <vector>
@@ -1013,16 +1014,16 @@ void OceanTileT<gz::math::Vector3d>::SetWindVelocity(double ux, double uy)
 
 //////////////////////////////////////////////////
 template <>
-std::tuple<double, double> OceanTileT<gz::math::Vector3d>::TileSize() const
+std::array<double, 2> OceanTileT<gz::math::Vector3d>::TileSize() const
 {
-  return std::make_tuple(impl_->lx_, impl_->ly_);
+  return {impl_->lx_, impl_->ly_};
 }
 
 //////////////////////////////////////////////////
 template <>
-std::tuple<Index, Index> OceanTileT<gz::math::Vector3d>::CellCount() const
+std::array<Index, 2> OceanTileT<gz::math::Vector3d>::CellCount() const
 {
-  return std::make_tuple(impl_->nx_, impl_->ny_);
+  return {impl_->nx_, impl_->ny_};
 }
 
 //////////////////////////////////////////////////
@@ -1135,16 +1136,16 @@ void OceanTileT<cgal::Point3>::SetWindVelocity(double ux, double uy)
 
 //////////////////////////////////////////////////
 template <>
-std::tuple<double, double> OceanTileT<cgal::Point3>::TileSize() const
+std::array<double, 2> OceanTileT<cgal::Point3>::TileSize() const
 {
-  return std::make_tuple(impl_->lx_, impl_->ly_);
+  return {impl_->lx_, impl_->ly_};
 }
 
 //////////////////////////////////////////////////
 template <>
-std::tuple<Index, Index> OceanTileT<cgal::Point3>::CellCount() const
+std::array<Index, 2> OceanTileT<cgal::Point3>::CellCount() const
 {
-  return std::make_tuple(impl_->nx_, impl_->ny_);
+  return {impl_->nx_, impl_->ny_};
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/TriangulatedGrid.cc
+++ b/gz-waves/src/TriangulatedGrid.cc
@@ -568,7 +568,8 @@ void TriangulatedGrid::Private::UpdatePoints(const cgal::Mesh& from) {
 
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
-TriangulatedGrid::~TriangulatedGrid() {
+TriangulatedGrid::~TriangulatedGrid()
+{
 }
 
 //////////////////////////////////////////////////
@@ -578,18 +579,21 @@ TriangulatedGrid::TriangulatedGrid(Index nx, Index ny, double lx, double ly) :
 }
 
 //////////////////////////////////////////////////
-void TriangulatedGrid::CreateMesh() {
+void TriangulatedGrid::CreateMesh()
+{
   impl_->CreateMesh();
 }
 
 //////////////////////////////////////////////////
-void TriangulatedGrid::CreateTriangulation() {
+void TriangulatedGrid::CreateTriangulation()
+{
   impl_->CreateTriangulation();
 }
 
 //////////////////////////////////////////////////
 std::unique_ptr<TriangulatedGrid> TriangulatedGrid::Create(
-    Index nx, Index ny, double lx, double ly) {
+    Index nx, Index ny, double lx, double ly)
+{
   std::unique_ptr<TriangulatedGrid> instance =
       std::make_unique<TriangulatedGrid>(nx, ny, lx, ly);
   instance->CreateMesh();
@@ -599,76 +603,102 @@ std::unique_ptr<TriangulatedGrid> TriangulatedGrid::Create(
 
 //////////////////////////////////////////////////
 bool TriangulatedGrid::Locate(const cgal::Point3& query,
-    int64_t& faceIndex) const {
+    int64_t& faceIndex) const
+{
   return impl_->Locate(query, faceIndex);
 }
 
 //////////////////////////////////////////////////
 bool TriangulatedGrid::Height(const cgal::Point3& query,
-    double& height) const {
+    double& height) const
+{
   return impl_->Height(query, height);
 }
 
 //////////////////////////////////////////////////
 bool TriangulatedGrid::Height(const std::vector<cgal::Point3>& queries,
-    std::vector<double>& heights) const {
+    std::vector<double>& heights) const
+{
   return impl_->Height(queries, heights);
 }
 
 //////////////////////////////////////////////////
-bool TriangulatedGrid::Interpolate(TriangulatedGrid& patch) const {
+bool TriangulatedGrid::Interpolate(TriangulatedGrid& patch) const
+{
   return impl_->Interpolate(patch);
 }
 
 //////////////////////////////////////////////////
-const Point3Range& TriangulatedGrid::Points() const {
+const Point3Range& TriangulatedGrid::Points() const
+{
   return impl_->Points();
 }
 
 //////////////////////////////////////////////////
-const Index3Range& TriangulatedGrid::Indices() const {
+const Index3Range& TriangulatedGrid::Indices() const
+{
   return impl_->Indices();
 }
 
 //////////////////////////////////////////////////
-const cgal::Point3& TriangulatedGrid::Origin() const {
+const cgal::Point3& TriangulatedGrid::Origin() const
+{
   return impl_->Origin();
 }
 
 //////////////////////////////////////////////////
-void TriangulatedGrid::ApplyPose(const gz::math::Pose3d& pose) {
+void TriangulatedGrid::ApplyPose(const gz::math::Pose3d& pose)
+{
   impl_->ApplyPose(pose);
 }
 
 //////////////////////////////////////////////////
-bool TriangulatedGrid::IsValid(bool verbose) const {
+bool TriangulatedGrid::IsValid(bool verbose) const
+{
   return impl_->IsValid(verbose);
 }
 
 //////////////////////////////////////////////////
-void TriangulatedGrid::DebugPrintMesh() const {
+void TriangulatedGrid::DebugPrintMesh() const
+{
   impl_->DebugPrintMesh();
 }
 
 //////////////////////////////////////////////////
-void TriangulatedGrid::DebugPrintTriangulation() const {
+void TriangulatedGrid::DebugPrintTriangulation() const
+{
   impl_->DebugPrintTriangulation();
 }
 
 //////////////////////////////////////////////////
-void TriangulatedGrid::UpdatePoints(const std::vector<cgal::Point3>& from) {
+void TriangulatedGrid::UpdatePoints(const std::vector<cgal::Point3>& from)
+{
   impl_->UpdatePoints(from);
 }
 
 //////////////////////////////////////////////////
 void TriangulatedGrid::UpdatePoints(
-    const std::vector<gz::math::Vector3d>& from) {
+    const std::vector<gz::math::Vector3d>& from)
+{
   impl_->UpdatePoints(from);
 }
 
 //////////////////////////////////////////////////
-void TriangulatedGrid::UpdatePoints(const cgal::Mesh& from) {
+void TriangulatedGrid::UpdatePoints(const cgal::Mesh& from)
+{
   impl_->UpdatePoints(from);
+}
+
+//////////////////////////////////////////////////
+std::array<double, 2> TriangulatedGrid::TileSize() const
+{
+  return {impl_->lx_, impl_->ly_};
+}
+
+//////////////////////////////////////////////////
+std::array<Index, 2> TriangulatedGrid::CellCount() const
+{
+  return {impl_->nx_, impl_->ny_};
 }
 
 }  // namespace waves

--- a/gz-waves/src/WaveParameters.cc
+++ b/gz-waves/src/WaveParameters.cc
@@ -15,10 +15,10 @@
 
 #include "gz/waves/WaveParameters.hh"
 
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <string>
-#include <tuple>
 
 #include <gz/common.hh>
 #include <gz/msgs.hh>
@@ -58,10 +58,10 @@ class WaveParametersPrivate
   std::string algorithm_{"fft"};
 
   /// \brief The size of the wave tile.
-  std::tuple<double, double> tile_size_{256.0, 256.0};
+  std::array<double, 2> tile_size_{256.0, 256.0};
 
   /// \brief The size of the wave tile.
-  std::tuple<Index, Index> cell_count_{128, 128};
+  std::array<Index, 2> cell_count_{128, 128};
 
   /// \brief The number of component waves.
   Index number_{1};
@@ -292,7 +292,7 @@ void WaveParameters::SetFromSDF(sdf::Element& sdf)
       sdf::Errors errors;
       if (param->Get(value, errors))
       {
-        impl_->tile_size_ = std::make_tuple(value[0], value[1]);
+        impl_->tile_size_ = {value[0], value[1]};
         found = true;
       }
     }
@@ -302,7 +302,7 @@ void WaveParameters::SetFromSDF(sdf::Element& sdf)
       sdf::Errors errors;
       if (param->Get(value, errors))
       {
-        impl_->tile_size_ = std::make_tuple(value, value);
+        impl_->tile_size_ = {value, value};
         found = true;
       }
     }
@@ -323,7 +323,7 @@ void WaveParameters::SetFromSDF(sdf::Element& sdf)
       sdf::Errors errors;
       if (param->Get(value, errors))
       {
-        impl_->cell_count_ = std::make_tuple(value[0], value[1]);
+        impl_->cell_count_ = {value[0], value[1]};
         found = true;
       }
     }
@@ -334,7 +334,7 @@ void WaveParameters::SetFromSDF(sdf::Element& sdf)
       if (param->Get(value, errors))
       {
         Index index = value;
-        impl_->cell_count_ = std::make_tuple(index, index);
+        impl_->cell_count_ = {index, index};
         found = true;
       }
     }
@@ -393,13 +393,13 @@ std::string WaveParameters::Algorithm() const
 }
 
 //////////////////////////////////////////////////
-std::tuple<double, double> WaveParameters::TileSize() const
+std::array<double, 2> WaveParameters::TileSize() const
 {
   return impl_->tile_size_;
 }
 
 //////////////////////////////////////////////////
-std::tuple<Index, Index> WaveParameters::CellCount() const
+std::array<Index, 2> WaveParameters::CellCount() const
 {
   return impl_->cell_count_;
 }
@@ -504,27 +504,27 @@ void WaveParameters::SetAlgorithm(const std::string& value)
 //////////////////////////////////////////////////
 void WaveParameters::SetTileSize(double value)
 {
-  impl_->tile_size_ = std::make_tuple(value, value);
+  impl_->tile_size_ = {value, value};
   impl_->Recalculate();
 }
 
 void WaveParameters::SetTileSize(double lx, double ly)
 {
-  impl_->tile_size_ = std::make_tuple(lx, ly);
+  impl_->tile_size_ = {lx, ly};
   impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
 void WaveParameters::SetCellCount(Index value)
 {
-  impl_->cell_count_ = std::make_tuple(value, value);
+  impl_->cell_count_ = {value, value};
   impl_->Recalculate();
 }
 
 //////////////////////////////////////////////////
 void WaveParameters::SetCellCount(Index nx, Index ny)
 {
-  impl_->cell_count_ = std::make_tuple(nx, ny);
+  impl_->cell_count_ = {nx, ny};
   impl_->Recalculate();
 }
 


### PR DESCRIPTION
Add accessors for the tile size and cell count to TriangulatedGrid.

Use std::array  instead of std::tuple to return dimensions (modifying #116). This is more appropriate for homogeneous data.

