### PR TITLE
Waves Client: enable steepness update

### DIFF
--- a/gz-waves/include/gz/waves/LinearRandomFFTWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomFFTWaveSimulation.hh
@@ -45,6 +45,8 @@ class LinearRandomFFTWaveSimulation :
 
   void SetWindVelocity(double ux, double uy) override;
 
+  void SetSteepness(double value) override;
+
   void SetTime(double value) override;
 
   Index SizeX() const override;

--- a/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
@@ -73,6 +73,8 @@ class LinearRandomWaveSimulation :
 
   void SetWindVelocity(double ux, double uy) override;
 
+  void SetSteepness(double value) override;
+
   void SetTime(double value) override;
 
   Index SizeX() const override;

--- a/gz-waves/include/gz/waves/LinearRegularWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRegularWaveSimulation.hh
@@ -63,6 +63,8 @@ class LinearRegularWaveSimulation :
 
   void SetWindVelocity(double ux, double uy) override;
 
+  void SetSteepness(double value) override;
+
   void SetTime(double value) override;
 
   Index SizeX() const override;

--- a/gz-waves/include/gz/waves/OceanTile.hh
+++ b/gz-waves/include/gz/waves/OceanTile.hh
@@ -55,6 +55,8 @@ class OceanTileT
 
   void SetWindVelocity(double ux, double uy);
 
+  void SetSteepness(double value);
+
   void Create();
 
   // Returns a new gz::common::Mesh. The caller must take ownership.

--- a/gz-waves/include/gz/waves/TrochoidIrregularWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/TrochoidIrregularWaveSimulation.hh
@@ -43,6 +43,10 @@ class TrochoidIrregularWaveSimulation :
 
   void SetWindVelocity(double ux, double uy) override;
 
+  /// \todo(srmainwaring) deprecate / remove
+  void SetSteepness(double value) override;
+
+  /// \todo(srmainwaring) deprecate / remove
   void SetTime(double time) override;
 
   Index SizeX() const override;

--- a/gz-waves/include/gz/waves/WaveSimulation.hh
+++ b/gz-waves/include/gz/waves/WaveSimulation.hh
@@ -68,6 +68,9 @@ class IWaveSimulation
   virtual void SetWindVelocity(double ux, double uy) = 0;
 
   /// \todo(srmainwaring) deprecate or move?
+  virtual void SetSteepness(double value) = 0;
+
+  /// \todo(srmainwaring) deprecate or move?
   virtual void SetTime(double value) = 0;
 
   // lookup interface - scalar

--- a/gz-waves/src/LinearRandomFFTWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulation.cc
@@ -88,6 +88,12 @@ void LinearRandomFFTWaveSimulation::Impl::SetWindVelocity(
 }
 
 //////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::Impl::SetSteepness(double value)
+{
+  lambda_ = value;
+}
+
+//////////////////////////////////////////////////
 void LinearRandomFFTWaveSimulation::Impl::SetTime(double time)
 {
   ComputeCurrentAmplitudes(time);
@@ -686,6 +692,12 @@ void LinearRandomFFTWaveSimulation::SetLambda(double value)
 void LinearRandomFFTWaveSimulation::SetWindVelocity(double ux, double uy)
 {
   impl_->SetWindVelocity(ux, uy);
+}
+
+//////////////////////////////////////////////////
+void LinearRandomFFTWaveSimulation::SetSteepness(double value)
+{
+  impl_->SetSteepness(value);
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
@@ -81,6 +81,8 @@ class LinearRandomFFTWaveSimulation::Impl
   /// \brief Set the components of the wind velocity (U10) in [m/s]
   void SetWindVelocity(double ux, double uy);
 
+  void SetSteepness(double value);
+
   /// \brief Set the current time in seconds
   void SetTime(double value);
 

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRef.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRef.cc
@@ -84,6 +84,12 @@ namespace waves
   }
 
   //////////////////////////////////////////////////
+  void LinearRandomFFTWaveSimulationRef::Impl::SetSteepness(double value)
+  {
+    lambda_ = value;
+  }
+
+  //////////////////////////////////////////////////
   void LinearRandomFFTWaveSimulationRef::Impl::SetTime(double time)
   {
     ComputeCurrentAmplitudes(time);
@@ -756,6 +762,12 @@ namespace waves
   void LinearRandomFFTWaveSimulationRef::SetWindVelocity(double ux, double uy)
   {
     impl_->SetWindVelocity(ux, uy);
+  }
+
+  //////////////////////////////////////////////////
+  void LinearRandomFFTWaveSimulationRef::SetSteepness(double value)
+  {
+    impl_->SetSteepness(value);
   }
 
   //////////////////////////////////////////////////

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRef.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRef.hh
@@ -39,6 +39,8 @@ class LinearRandomFFTWaveSimulationRef :
 
     void SetWindVelocity(double ux, double uy) override;
 
+    void SetSteepness(double value) override;
+
     void SetTime(double value) override;
 
     Index SizeX() const override;

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRefImpl.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRefImpl.hh
@@ -70,6 +70,8 @@ class LinearRandomFFTWaveSimulationRef::Impl
   /// \brief Set the components of the wind velocity (U10) in [m/s]
   void SetWindVelocity(double ux, double uy);
 
+  void SetSteepness(double value);
+
   /// \brief Set the current time in seconds
   void SetTime(double value);
 

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -491,6 +491,12 @@ void LinearRandomWaveSimulation::SetWindVelocity(double ux, double uy)
 }
 
 //////////////////////////////////////////////////
+void LinearRandomWaveSimulation::SetSteepness(double value)
+{
+  /// \todo(srmainwaring) IMPLEMENT
+}
+
+//////////////////////////////////////////////////
 void LinearRandomWaveSimulation::SetTime(double value)
 {
   impl_->SetTime(value);

--- a/gz-waves/src/LinearRegularWaveSimulation.cc
+++ b/gz-waves/src/LinearRegularWaveSimulation.cc
@@ -89,8 +89,6 @@ class LinearRegularWaveSimulation::Impl
 
   void SetPeriod(double value);
 
-  void SetWindVelocity(double ux, double uy);
-
   void SetTime(double value);
 
   // interpolation interface
@@ -272,13 +270,6 @@ void LinearRegularWaveSimulation::Impl::SetAmplitude(double value)
 void LinearRegularWaveSimulation::Impl::SetPeriod(double value)
 {
   period_ = value;
-}
-
-//////////////////////////////////////////////////
-void LinearRegularWaveSimulation::Impl::SetWindVelocity(
-    double /*_ux*/, double /*_uy*/)
-{
-  // @TODO NO IMPLEMENTATION
 }
 
 //////////////////////////////////////////////////
@@ -584,9 +575,15 @@ void LinearRegularWaveSimulation::SetPeriod(double value)
 }
 
 //////////////////////////////////////////////////
-void LinearRegularWaveSimulation::SetWindVelocity(double ux, double uy)
+void LinearRegularWaveSimulation::SetWindVelocity(double /*ux*/, double /*uy*/)
 {
-  impl_->SetWindVelocity(ux, uy);
+  /// \todo(srmainwaring) IMPLEMENT
+}
+
+//////////////////////////////////////////////////
+void LinearRegularWaveSimulation::SetSteepness(double value)
+{
+  /// \todo(srmainwaring) IMPLEMENT
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -72,6 +72,7 @@ class OceanTilePrivate
   explicit OceanTilePrivate(WaveParametersPtr params, bool has_visuals = true);
 
   void SetWindVelocity(double ux, double uy);
+  void SetSteepness(double value);
 
   bool                        has_visuals_;
   /// \brief FFT size (nx, ny must be a power of 2)
@@ -367,6 +368,13 @@ template <typename Vector3>
 void OceanTilePrivate<Vector3>::SetWindVelocity(double ux, double uy)
 {
   wave_sim_->SetWindVelocity(ux, uy);
+}
+
+//////////////////////////////////////////////////
+template <typename Vector3>
+void OceanTilePrivate<Vector3>::SetSteepness(double value)
+{
+  wave_sim_->SetSteepness(value);
 }
 
 //////////////////////////////////////////////////
@@ -1014,6 +1022,13 @@ void OceanTileT<gz::math::Vector3d>::SetWindVelocity(double ux, double uy)
 
 //////////////////////////////////////////////////
 template <>
+void OceanTileT<gz::math::Vector3d>::SetSteepness(double value)
+{
+  impl_->SetSteepness(value);
+}
+
+//////////////////////////////////////////////////
+template <>
 std::array<double, 2> OceanTileT<gz::math::Vector3d>::TileSize() const
 {
   return {impl_->lx_, impl_->ly_};
@@ -1132,6 +1147,13 @@ template <>
 void OceanTileT<cgal::Point3>::SetWindVelocity(double ux, double uy)
 {
   impl_->SetWindVelocity(ux, uy);
+}
+
+//////////////////////////////////////////////////
+template <>
+void OceanTileT<cgal::Point3>::SetSteepness(double value)
+{
+  impl_->SetSteepness(value);
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/TrochoidIrregularWaveSimulation.cc
+++ b/gz-waves/src/TrochoidIrregularWaveSimulation.cc
@@ -240,6 +240,12 @@ void TrochoidIrregularWaveSimulation::SetWindVelocity(double ux, double uy)
 }
 
 //////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetSteepness(double /*value*/)
+{
+  /// \todo(srmainwaring) IMPLEMENT
+}
+
+//////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::SetTime(double time)
 {
   impl_->SetTime(time);

--- a/gz-waves/src/TrochoidIrregularWaveSimulation.cc
+++ b/gz-waves/src/TrochoidIrregularWaveSimulation.cc
@@ -240,7 +240,8 @@ void TrochoidIrregularWaveSimulation::SetWindVelocity(double ux, double uy)
 }
 
 //////////////////////////////////////////////////
-void TrochoidIrregularWaveSimulation::SetSteepness(double /*value*/)
+void TrochoidIrregularWaveSimulation::SetSteepness(
+    double /*value*/)
 {
   /// \todo(srmainwaring) IMPLEMENT
 }

--- a/gz-waves/src/Wavefield.cc
+++ b/gz-waves/src/Wavefield.cc
@@ -170,12 +170,6 @@ void WavefieldPrivate::OnWaveMsg(const gz::msgs::Param& msg)
 
   // gzmsg << msg.DebugString();
 
-  // // Get parameters from message
-  // double wind_angle = 0.0;
-  // double wind_speed = 0.0;
-  // wind_angle = Utilities::MsgParamDouble(*msg, "wind_angle", wind_angle);
-  // wind_speed = Utilities::MsgParamDouble(*msg, "wind_speed", wind_speed);
-
   // current wind speed and angle
   double wind_speed = params_->WindSpeed();
   double wind_angle_rad = params_->WindAngleRad();
@@ -223,6 +217,8 @@ void WavefieldPrivate::OnWaveMsg(const gz::msgs::Param& msg)
   ocean_tile_->SetWindVelocity(
       params_->WindVelocity().X(),
       params_->WindVelocity().Y());
+  ocean_tile_->SetSteepness(
+      params_->Steepness());
 }
 
 }  // namespace waves

--- a/gz-waves/src/systems/waves/WavesVisual.cc
+++ b/gz-waves/src/systems/waves/WavesVisual.cc
@@ -702,9 +702,11 @@ void WavesVisualPrivate::OnUpdate()
 
       if (this->waveParamsDirty)
       {
-        double newUx = this->waveParams->WindVelocity().X();
-        double newUy = this->waveParams->WindVelocity().Y();
-        this->oceanTile->SetWindVelocity(newUx, newUy);
+        this->oceanTile->SetWindVelocity(
+            this->waveParams->WindVelocity().X(),
+            this->waveParams->WindVelocity().Y());
+        this->oceanTile->SetSteepness(
+            this->waveParams->Steepness());
         this->waveParamsDirty = false;
       }
 
@@ -783,14 +785,11 @@ void WavesVisualPrivate::OnUpdate()
 
       if (this->waveParamsDirty)
       {
-        double newUx = this->waveParams->WindVelocity().X();
-        double newUy = this->waveParams->WindVelocity().Y();
-        // double s  = this->waveParams->Steepness();
-
-        // set params
-        this->mWaveSim->SetWindVelocity(newUx, newUy);
-        // waveSim->SetLambda(s);
-
+        this->mWaveSim->SetWindVelocity(
+            this->waveParams->WindVelocity().X(),
+            this->waveParams->WindVelocity().Y());
+        this->mWaveSim->SetSteepness(
+            this->waveParams->Steepness());
         this->waveParamsDirty = false;
       }
 


### PR DESCRIPTION
This change allows the wave steepness parameter to be set while the simulation is running.

## Details

- Enable steepness parameter to be updated in the GUI (previously changes were ignored).
- Add SetSteepness method to relevant classes and interfaces.

