### PR TITLE
Build: update settings for gnuplot-iostream

### DIFF
--- a/gz-waves/cmake/Add_gnuplot-iostream.cmake
+++ b/gz-waves/cmake/Add_gnuplot-iostream.cmake
@@ -10,3 +10,7 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(gnuplot-iostream)
+
+# The project does not set gnuplot-iostream_INCLUDE_DIRS so use
+# gnuplot-iostream_SOURCE_DIR instead.
+set(gnuplot-iostream_INCLUDE_DIRS ${gnuplot-iostream_SOURCE_DIR})

--- a/gz-waves/test/plots/CMakeLists.txt
+++ b/gz-waves/test/plots/CMakeLists.txt
@@ -1,22 +1,9 @@
 
 #============================================================================
-# Find dependencies
+# Find additional dependencies
 #============================================================================
 
-#--------------------------------------
-# Check gnuplot-iostream is populated
-# message("gnuplot-iostream_POPULATED: ${gnuplot-iostream_POPULATED}")
-# message("gnuplot-iostream_INCLUDE_DIRS: ${gnuplot-iostream_INCLUDE_DIRS}")
-# message("gnuplot-iostream_SOURCE_DIR: ${gnuplot-iostream_SOURCE_DIR}")
-
-#--------------------------------------
-# Find gnuplot-iostream
-# 
-# The header is used by the examples in test/plots.
-# gnuplot-iostream_INCLUDE_DIRS is not set by the project so we use
-# gnuplot-iostream_SOURCE_DIR instead.
 find_package(Boost COMPONENTS iostreams)
-set(gnuplot-iostream_INCLUDE_DIRS ${gnuplot-iostream_SOURCE_DIR})
 
 #============================================================================
 # Add executables


### PR DESCRIPTION
Remove debug comments from plots CMakeLists.txt and place the logic for setting `gnuplot-iostream_INCLUDE_DIRS` into the custom .cmake module for gnuplot-iostream.