### PR TITLE
Eigen: remove using declarations and use scoped types.

### DIFF
--- a/gz-waves/include/gz/waves/LinearRandomFFTWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomFFTWaveSimulation.hh
@@ -16,13 +16,11 @@
 #ifndef GZ_WAVES_LINEARRANDOMFFTWAVESIMULATION_HH_
 #define GZ_WAVES_LINEARRANDOMFFTWAVESIMULATION_HH_
 
+#include <Eigen/Dense>
+
 #include <memory>
 
-#include <Eigen/Dense> // NOLINT - cpplint false positive.
-
 #include "gz/waves/WaveSimulation.hh"
-
-using Eigen::ArrayXXd;
 
 namespace gz
 {

--- a/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRandomWaveSimulation.hh
@@ -16,13 +16,11 @@
 #ifndef GZ_WAVES_LINEARRANDOMWAVESIMULATION_HH_
 #define GZ_WAVES_LINEARRANDOMWAVESIMULATION_HH_
 
+#include <Eigen/Dense>
+
 #include <memory>
 
-#include <Eigen/Dense> // NOLINT - cpplint false positive.
-
 #include "gz/waves/WaveSimulation.hh"
-
-using Eigen::ArrayXXd;
 
 namespace gz
 {

--- a/gz-waves/include/gz/waves/LinearRegularWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/LinearRegularWaveSimulation.hh
@@ -16,13 +16,11 @@
 #ifndef GZ_WAVES_LINEARREGULARWAVESIMULATION_HH_
 #define GZ_WAVES_LINEARREGULARWAVESIMULATION_HH_
 
+#include <Eigen/Dense>
+
 #include <memory>
 
-#include <Eigen/Dense> // NOLINT - cpplint false positive.
-
 #include "gz/waves/WaveSimulation.hh"
-
-using Eigen::ArrayXXd;
 
 namespace gz
 {

--- a/gz-waves/include/gz/waves/WaveSimulation.hh
+++ b/gz-waves/include/gz/waves/WaveSimulation.hh
@@ -18,9 +18,9 @@
 
 #include <Eigen/Dense>
 
-#include "gz/waves/Types.hh"
+#include <memory>
 
-using Eigen::ArrayXXd;
+#include "gz/waves/Types.hh"
 
 namespace gz
 {

--- a/gz-waves/include/gz/waves/WaveSpectrum.hh
+++ b/gz-waves/include/gz/waves/WaveSpectrum.hh
@@ -18,8 +18,6 @@
 
 #include <Eigen/Dense>
 
-using Eigen::ArrayXXd;
-
 namespace gz
 {
 namespace waves

--- a/gz-waves/include/gz/waves/WaveSpreadingFunction.hh
+++ b/gz-waves/include/gz/waves/WaveSpreadingFunction.hh
@@ -18,8 +18,6 @@
 
 #include <Eigen/Dense>
 
-using Eigen::ArrayXXd;
-
 namespace gz
 {
 namespace waves

--- a/gz-waves/include/gz/waves/Wavefield.hh
+++ b/gz-waves/include/gz/waves/Wavefield.hh
@@ -19,6 +19,8 @@
 #ifndef GZ_WAVES_WAVEFIELD_HH_
 #define GZ_WAVES_WAVEFIELD_HH_
 
+#include <Eigen/Dense>
+
 #include <memory>
 #include <string>
 

--- a/gz-waves/src/EigenFFTW_TEST.cc
+++ b/gz-waves/src/EigenFFTW_TEST.cc
@@ -24,9 +24,6 @@
 #include <memory>
 #include <string>
 
-using Eigen::ArrayXXcd;
-using Eigen::ArrayXcd;
-
 namespace Eigen
 {
   typedef Eigen::Array<
@@ -127,7 +124,7 @@ TEST(EigenFFWT, DFT_C2C_1D)
     }
   }
 
-  { // using Eigen::ArrayXcd
+  { // Eigen::ArrayXcd
     Eigen::ArrayXcd in = Eigen::ArrayXcd::Zero(n);
     Eigen::ArrayXcd out = Eigen::ArrayXcd::Zero(n);
 

--- a/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationImpl.hh
@@ -26,11 +26,6 @@
 #include "gz/waves/WaveSimulation.hh"
 #include "gz/waves/LinearRandomFFTWaveSimulation.hh"
 
-using Eigen::ArrayXXcd;
-using Eigen::ArrayXXd;
-using Eigen::ArrayXcd;
-using Eigen::ArrayXd;
-
 namespace Eigen
 {
   typedef Eigen::Array<

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRef.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRef.hh
@@ -20,8 +20,6 @@
 
 #include "gz/waves/WaveSimulation.hh"
 
-using Eigen::ArrayXXd;
-
 namespace gz
 {
 namespace waves

--- a/gz-waves/src/LinearRandomFFTWaveSimulationRefImpl.hh
+++ b/gz-waves/src/LinearRandomFFTWaveSimulationRefImpl.hh
@@ -25,11 +25,6 @@
 #include "gz/waves/WaveSimulation.hh"
 #include "LinearRandomFFTWaveSimulationRef.hh"
 
-using Eigen::ArrayXXcd;
-using Eigen::ArrayXXd;
-using Eigen::ArrayXcd;
-using Eigen::ArrayXd;
-
 namespace Eigen
 {
   typedef Eigen::Array<

--- a/gz-waves/src/LinearRandomFFTWaveSimulation_TEST.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulation_TEST.cc
@@ -26,8 +26,6 @@
 #include "LinearRandomFFTWaveSimulationImpl.hh"
 #include "LinearRandomFFTWaveSimulationRefImpl.hh"
 
-using Eigen::ArrayXXd;
-
 using gz::waves::Index;
 using gz::waves::LinearRandomFFTWaveSimulation;
 using gz::waves::LinearRandomFFTWaveSimulationRef;

--- a/gz-waves/src/LinearRegularWaveSimulation.cc
+++ b/gz-waves/src/LinearRegularWaveSimulation.cc
@@ -19,9 +19,6 @@
 
 #include "gz/waves/Physics.hh"
 
-using Eigen::ArrayXXd;
-using Eigen::ArrayXd;
-
 namespace gz
 {
 namespace waves

--- a/gz-waves/src/LinearRegularWaveSimulation_TEST.cc
+++ b/gz-waves/src/LinearRegularWaveSimulation_TEST.cc
@@ -32,11 +32,6 @@
 #include "gz/waves/Types.hh"
 #include "gz/waves/WaveSpectrum.hh"
 
-// using namespace gz;
-// using namespace waves;
-
-using Eigen::ArrayXXd;
-
 using gz::waves::Index;
 using gz::waves::IWaveSimulation;
 using gz::waves::LinearRegularWaveSimulation;

--- a/gz-waves/src/TrochoidIrregularWaveSimulation.cc
+++ b/gz-waves/src/TrochoidIrregularWaveSimulation.cc
@@ -15,6 +15,8 @@
 
 #include "gz/waves/TrochoidIrregularWaveSimulation.hh"
 
+#include <Eigen/Dense>
+
 #include <vector>
 
 #include "gz/waves/Types.hh"

--- a/gz-waves/src/systems/waves/DisplacementMap.hh
+++ b/gz-waves/src/systems/waves/DisplacementMap.hh
@@ -23,8 +23,6 @@
 #include <gz/rendering/config.hh>
 #include <gz/rendering/Export.hh>
 
-using Eigen::ArrayXXd;
-
 namespace gz
 {
 namespace rendering

--- a/gz-waves/src/systems/waves/Ogre2DisplacementMap.hh
+++ b/gz-waves/src/systems/waves/Ogre2DisplacementMap.hh
@@ -30,8 +30,6 @@
 
 #include "DisplacementMap.hh"
 
-using Eigen::ArrayXXd;
-
 namespace gz
 {
 namespace rendering

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimBaseAmplitudes.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimBaseAmplitudes.cc
@@ -23,8 +23,6 @@
 
 #include "LinearRandomFFTWaveSimulationImpl.hh"
 
-using Eigen::ArrayXXd;
-
 using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimCurrentAmplitudes.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimCurrentAmplitudes.cc
@@ -23,8 +23,6 @@
 
 #include "LinearRandomFFTWaveSimulationImpl.hh"
 
-using Eigen::ArrayXXd;
-
 using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimDisplacements.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimDisplacements.cc
@@ -23,8 +23,6 @@
 
 #include "LinearRandomFFTWaveSimulationImpl.hh"
 
-using Eigen::ArrayXXd;
-
 using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;

--- a/gz-waves/test/performance/LinearRandomFFTWaveSimElevationAt.cc
+++ b/gz-waves/test/performance/LinearRandomFFTWaveSimElevationAt.cc
@@ -23,8 +23,6 @@
 
 #include "LinearRandomFFTWaveSimulationImpl.hh"
 
-using Eigen::ArrayXXd;
-
 using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;

--- a/gz-waves/test/performance/LinearRegularWaveSimDisplacements.cc
+++ b/gz-waves/test/performance/LinearRegularWaveSimDisplacements.cc
@@ -23,8 +23,6 @@
 
 #include "gz/waves/LinearRegularWaveSimulation.hh"
 
-using Eigen::ArrayXXd;
-
 using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;

--- a/gz-waves/test/performance/WaveSpectrumECKV.cc
+++ b/gz-waves/test/performance/WaveSpectrumECKV.cc
@@ -24,8 +24,6 @@
 
 #include "gz/waves/WaveSpectrum.hh"
 
-using Eigen::ArrayXXd;
-
 namespace Eigen
 {
   typedef Eigen::Array<

--- a/gz-waves/test/plots/PLOT_WaveSpectrum.cc
+++ b/gz-waves/test/plots/PLOT_WaveSpectrum.cc
@@ -25,8 +25,6 @@
 #include <gz/waves/WaveSimulation.hh>
 #include <gz/waves/WaveSpectrum.hh>
 
-using Eigen::ArrayXd;
-
 using gz::waves::Index;
 using gz::waves::ECKVWaveSpectrum;
 using gz::waves::PiersonMoskowitzWaveSpectrum;
@@ -56,10 +54,11 @@ int main(int /*argc*/, const char **/*argv*/)
       ECKVWaveSpectrum spectrum;
 
       Index nk = 200;
-      Eigen::ArrayXd k = Eigen::pow(10.0, ArrayXd::LinSpaced(nk, -3.0, 4.0));
+      Eigen::ArrayXd k =
+          Eigen::pow(10.0, Eigen::ArrayXd::LinSpaced(nk, -3.0, 4.0));
 
       Index nu = 5;
-      Eigen::ArrayXd u10 = ArrayXd::LinSpaced(nu, 0.0, 20.0);
+      Eigen::ArrayXd u10 = Eigen::ArrayXd::LinSpaced(nu, 0.0, 20.0);
 
       std::vector<double> pts_k;
       std::vector<std::vector<double>> pts_s(u10.size());
@@ -107,10 +106,11 @@ int main(int /*argc*/, const char **/*argv*/)
       PiersonMoskowitzWaveSpectrum spectrum;
 
       Index nk = 200;
-      Eigen::ArrayXd k = Eigen::pow(10.0, ArrayXd::LinSpaced(nk, -3.0, 4.0));
+      Eigen::ArrayXd k =
+          Eigen::pow(10.0, Eigen::ArrayXd::LinSpaced(nk, -3.0, 4.0));
 
       Index nu = 5;
-      Eigen::ArrayXd u19 = ArrayXd::LinSpaced(nu, 0.0, 20.0);
+      Eigen::ArrayXd u19 = Eigen::ArrayXd::LinSpaced(nu, 0.0, 20.0);
 
       std::vector<double> pts_k;
       std::vector<std::vector<double>> pts_s(u19.size());


### PR DESCRIPTION
Tidy up use of `using` directives. We always scope Eigen types so remove unused / confusing `using Eigen::*` entries.  

## Details

- Remove using Eigen::ArrayXd etc.
- Use the fully scoped namespace.
