### PR TITLE
Hydrodynamics: automate sizing of water patch

### DIFF
--- a/.github/workflows/ccplint.yml
+++ b/.github/workflows/ccplint.yml
@@ -32,13 +32,14 @@ jobs:
           cpplint ./gz-waves/test/plots/*.cc
       - name: Cpplint Hydrodynamics Plugin
         run: |
-          cpplint \
-            --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard \
-            ./gz-waves/src/systems/hydrodynamics/*
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard,-whitespace/newline \
+            ./gz-waves/src/systems/hydrodynamics/*.hh \
+            ./gz-waves/src/systems/hydrodynamics/*.cc
       - name: Cpplint DynamicGeometry Plugin
         run: |
           cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard \
-            ./gz-waves/src/systems/dynamic/*
+            ./gz-waves/src/systems/dynamic/*.hh \
+            ./gz-waves/src/systems/dynamic/*.cc
       - name: Cpplint Waves Plugin
         run: |
           cpplint --filter=-whitespace/blank_line,-whitespace/indent \


### PR DESCRIPTION
This change automates the calculation of the water patch base on the axis aligned bounding box of the model's collision meshes. 

Closes #9

## Details

- Add a method to calculate an AABB from a collision mesh.
- Reorder the hydrodynamics physics initialisation to calculate the union of the AABB for each collision contained within a link.
- Use the resulting AABB for each link to set the size of the water patch - it has sides of length slightly larger than the diameter of the bounding sphere.
- Create a patch for each link and centre it on the link origin. This is because the AABB for the initial configuration of the model may not be maximal (think of an initially coiled tether comprising many links, or a line of buoys). 



