### PR TITLE
Waves: replace CGAL with Eigen in the Wavefield class interface.

### DIFF
--- a/gz-waves/include/gz/waves/Wavefield.hh
+++ b/gz-waves/include/gz/waves/Wavefield.hh
@@ -26,8 +26,6 @@
 
 #include <gz/math.hh>
 
-#include "gz/waves/CGALTypes.hh"
-
 namespace gz
 {
 namespace waves
@@ -46,7 +44,7 @@ class Wavefield
   explicit Wavefield(const std::string& world_name);
 
   /// \brief Compute the height at a point (vertical distance to surface).
-  bool Height(const cgal::Point3& point, double& height) const;
+  bool Height(const Eigen::Vector3d& point, double& height) const;
 
   /// \brief Get the wave parameters.
   std::shared_ptr<const WaveParameters> GetParameters() const;

--- a/gz-waves/src/Wavefield.cc
+++ b/gz-waves/src/Wavefield.cc
@@ -89,7 +89,7 @@ Wavefield::Wavefield(const std::string& world_name) :
 }
 
 //////////////////////////////////////////////////
-bool Wavefield::Height(const cgal::Point3& point, double& height) const
+bool Wavefield::Height(const Eigen::Vector3d& point, double& height) const
 {
   /// \todo(srmainwaring) the calculation assumes that the tile origin
   /// is at its center.

--- a/gz-waves/src/WavefieldSampler.cc
+++ b/gz-waves/src/WavefieldSampler.cc
@@ -119,7 +119,8 @@ void WavefieldSampler::UpdatePatch()
     const auto& vertex = *vb;
     const auto& p0 = target->point(vertex);
     double height = 0.0;
-    impl_->wavefield_->Height(p0, height);
+    impl_->wavefield_->Height(
+        Eigen::Vector3d(p0.x(), p0.y(), p0.z()), height);
     cgal::Point3 p1(p0.x(), p0.y(), height);
     target->point(vertex) = p1;
     // gzmsg << target->point(vertex) << std::endl;

--- a/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -741,15 +741,14 @@ void HydrodynamicsPrivate::UpdatePhysics(const UpdateInfo &/*_info*/,
     EntityComponentManager &_ecm)
 {
   ////////// BEGIN TESTING
-
+  #if 0
   // Get the wave height at the origin
-  // double simTime = std::chrono::duration<double>(_info.simTime).count();
-  cgal::Point3 point(0.0, 0.0, 0.0);
+  double simTime = std::chrono::duration<double>(_info.simTime).count();
+  Eigen::Vector3d point(0.0, 0.0, 0.0);
   double waveHeight{0.0};
   this->wavefield.lock()->Height(point, waveHeight);
-
-  // gzmsg << "[" << simTime << "] : " << waveHeight << "\n";
-
+  gzmsg << "[" << simTime << "] : " << waveHeight << "\n";
+  #endif
   ////////// END TESTING
 
   /// \todo add checks for a valid wavefield and lock the waek_ptr


### PR DESCRIPTION
Use `Eigen::Vector3d` instead of `cgal::Point3` in the `Wavefield::Height` function.

Partially completes #127
