### PR TITLE
Waves: fix trochoid wave model

### DIFF
--- a/gz-waves-models/world_models/trochoid_waves/model.config
+++ b/gz-waves-models/world_models/trochoid_waves/model.config
@@ -1,0 +1,20 @@
+
+<?xml version='1.0'?>
+<model>
+  <name>Trochoid Waves</name>
+  <version>1.0</version>
+  <sdf version='1.6'>model.sdf</sdf>
+
+  <author>
+    <name>Rhys Mainwaring</name>
+    <email>rhys.mainwaring@me.com</email>
+  </author>
+
+  <description>
+    Trochoid surface waves.
+    
+    This model uses the materials from the `waves`
+    model to prevent duplicating the large mesh files.
+  </description>
+</model>
+

--- a/gz-waves-models/world_models/trochoid_waves/model.sdf
+++ b/gz-waves-models/world_models/trochoid_waves/model.sdf
@@ -1,6 +1,6 @@
 <?xml version='1.0' ?>
 <sdf version="1.6">
-  <model name="regular_waves">
+  <model name="trochoid_waves">
     <static>true</static>
 
     <plugin
@@ -12,9 +12,13 @@
         <tile_size>1024</tile_size>
         <cell_count>128</cell_count>
 
-        <algorithm>sinusoid</algorithm>
-        <amplitude>2.0</amplitude>
-        <period>6.0</period>
+        <algorithm>trochoid</algorithm>
+        <number>3</number>
+        <scale>1.5</scale>
+        <angle>0.4</angle>
+        <amplitude>1.5</amplitude>
+        <period>8.0</period>
+        <steepness>2.0</steepness>
         <direction>1 0</direction>
       </wave>
     </plugin>
@@ -52,9 +56,13 @@
             <tile_size>1024</tile_size>
             <cell_count>128</cell_count>
 
-            <algorithm>sinusoid</algorithm>
-            <amplitude>2.0</amplitude>
-            <period>6.0</period>
+            <algorithm>trochoid</algorithm>
+            <number>3</number>
+            <scale>1.5</scale>
+            <angle>0.4</angle>
+            <amplitude>1.5</amplitude>
+            <period>8.0</period>
+            <steepness>2.0</steepness>
             <direction>1 0</direction>
           </wave>
 

--- a/gz-waves/include/gz/waves/TrochoidIrregularWaveSimulation.hh
+++ b/gz-waves/include/gz/waves/TrochoidIrregularWaveSimulation.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2019  Rhys Mainwaring
+// Copyright (C) 2019-2023  Rhys Mainwaring
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -16,37 +16,51 @@
 #ifndef GZ_WAVES_TROCHOIDIRREGULARWAVESIMULATION_HH_
 #define GZ_WAVES_TROCHOIDIRREGULARWAVESIMULATION_HH_
 
-#include <memory>
+#include <Eigen/Dense>
 
-#include <Eigen/Dense> // NOLINT - cpplint false positive.
+#include <memory>
+#include <vector>
+
+#include <gz/math/Vector2.hh>
 
 #include "gz/waves/WaveSimulation.hh"
-
-using Eigen::ArrayXXd;
 
 namespace gz
 {
 namespace waves
 {
-class WaveParameters;
 
 class TrochoidIrregularWaveSimulation :
-    public IWaveSimulation
+    public IWaveSimulation,
+    public IWaveField
 {
  public:
   virtual ~TrochoidIrregularWaveSimulation();
 
-  TrochoidIrregularWaveSimulation(
-      Index nx,
-      double lx,
-      std::shared_ptr<WaveParameters> params);
+  TrochoidIrregularWaveSimulation(double lx, double ly,
+      Index nx, Index ny);
 
+  void SetNumber(Index value);
+
+  void SetAmplitude(const std::vector<double>& value);
+
+  void SetWaveNumber(const std::vector<double>& value);
+
+  void SetOmega(const std::vector<double>& value);
+
+  void SetPhase(const std::vector<double>& value);
+
+  void SetSteepness(const std::vector<double>& value);
+
+  void SetDirection(const std::vector<math::Vector2d>& value);
+
+  // Documentation inhertited.
   void SetWindVelocity(double ux, double uy) override;
 
-  /// \todo(srmainwaring) deprecate / remove
+  // Documentation inhertited.
   void SetSteepness(double value) override;
 
-  /// \todo(srmainwaring) deprecate / remove
+  // Documentation inhertited.
   void SetTime(double time) override;
 
   Index SizeX() const override;
@@ -54,6 +68,26 @@ class TrochoidIrregularWaveSimulation :
   Index SizeY() const override;
 
   Index SizeZ() const override;
+
+  // interpolation interface
+  void Elevation(
+      double x, double y,
+      double& eta) const override;
+
+  void Elevation(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      Eigen::Ref<Eigen::ArrayXd> eta) const override;
+
+  void Pressure(
+      double x, double y, double z,
+      double& pressure) const override;
+
+  void Pressure(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      const Eigen::Ref<const Eigen::ArrayXd>& z,
+      Eigen::Ref<Eigen::ArrayXd> pressure) const override;
 
   // lookup interface - array
   void ElevationAt(

--- a/gz-waves/src/TrochoidIrregularWaveSimulation.cc
+++ b/gz-waves/src/TrochoidIrregularWaveSimulation.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2019  Rhys Mainwaring
+// Copyright (C) 2019-2023  Rhys Mainwaring
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -19,9 +19,8 @@
 
 #include <vector>
 
-#include "gz/waves/Types.hh"
-#include "gz/waves/Wavefield.hh"
-#include "gz/waves/WaveParameters.hh"
+#include <gz/common/Console.hh>
+#include <gz/math/Vector2.hh>
 
 namespace gz
 {
@@ -36,15 +35,31 @@ class TrochoidIrregularWaveSimulation::Impl
 
   ~Impl();
 
-  Impl(
-      Index N,
-      double L,
-      std::shared_ptr<WaveParameters> params);
+  Impl(double lx, double ly, Index nx, Index ny);
 
-  void SetWindVelocity(double ux, double uy);
+  void InitGrid();
 
-  void SetTime(double time);
+  // interpolation interface
+  void Elevation(
+      double x, double y,
+      double &eta);
 
+  void Elevation(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      Eigen::Ref<Eigen::ArrayXd> eta);
+
+  void Pressure(
+      double x, double y, double z,
+      double &pressure);
+
+  void Pressure(
+      const Eigen::Ref<const Eigen::ArrayXd>& x,
+      const Eigen::Ref<const Eigen::ArrayXd>& y,
+      const Eigen::Ref<const Eigen::ArrayXd>& z,
+      Eigen::Ref<Eigen::ArrayXd> pressure);
+
+  // lookup interface
   void ElevationAt(
       Eigen::Ref<Eigen::ArrayXXd> _heights);
 
@@ -61,90 +76,163 @@ class TrochoidIrregularWaveSimulation::Impl
       Eigen::Ref<Eigen::ArrayXXd> _dsydy,
       Eigen::Ref<Eigen::ArrayXXd> _dsxdy);
 
-  Index N_;
-  Index N2_;
-  Index NOver2_;
-  double L_;
+  void ElevationAt(
+      Index ix, Index iy,
+      double &h);
+
+  void DisplacementAt(
+      Index ix, Index iy,
+      double& sx, double& sy);
+
+  void PressureAt(
+      Index ix, Index iy, Index iz,
+      double &pressure);
+
+  void PressureAt(
+      Index iz,
+      Eigen::Ref<Eigen::ArrayXXd> pressure);
+
+  bool CheckValid();
+
+  // elevation and pressure grid params
+  Index nx_{2};
+  Index ny_{2};
+  Index nz_{1};
+  double lx_{1.0};
+  double ly_{1.0};
+  double lz_{0.0};
+
+  // wave params
+  Index number_{1};
+  std::vector<double> amplitude_ = {1.0};
+  std::vector<double> wavenumber_ = {2.0 * M_PI};
+  std::vector<double> omega_ = {0.0};
+  std::vector<double> phase_ = {0.0};
+  std::vector<double> q_ = {1.0};
+  std::vector<math::Vector2d> direction_ = {math::Vector2d(1.0, 0.0)};
+
+  // checks
+  bool is_param_check_dirty_{false};
+  bool is_valid_{true};
   double time_;
-  std::shared_ptr<WaveParameters> params_;
+
+  // derived
+  double dx_{0.0};
+  double dy_{0.0};
+  double lx_max_{0.0};
+  double lx_min_{0.0};
+  double ly_max_{0.0};
+  double ly_min_{0.0};
 };
 
 //////////////////////////////////////////////////
-TrochoidIrregularWaveSimulation::Impl::~Impl()
-{
-}
+TrochoidIrregularWaveSimulation::Impl::~Impl() = default;
 
 //////////////////////////////////////////////////
 TrochoidIrregularWaveSimulation::Impl::Impl(
-  Index N,
-  double L,
-  std::shared_ptr<WaveParameters> params) :
-  N_(N),
-  N2_(N * N),
-  NOver2_(N / 2),
-  L_(L),
-  params_(params)
+    double lx, double ly, Index nx, Index ny) :
+  nx_(nx),
+  ny_(ny),
+  lx_(lx),
+  ly_(ly)
 {
+  InitGrid();
 }
 
 //////////////////////////////////////////////////
-void TrochoidIrregularWaveSimulation::Impl::SetWindVelocity(
-    double /*ux*/, double /*uy*/)
+void TrochoidIrregularWaveSimulation::Impl::InitGrid()
 {
-  // @TODO NO IMPLEMENTATION
+  // grid spacing
+  dx_ = lx_ / nx_;
+  dy_ = ly_ / ny_;
+
+  // x and y coordinates
+  lx_min_ = - lx_ / 2.0;
+  lx_max_ =   lx_ / 2.0;
+  ly_min_ = - ly_ / 2.0;
+  ly_max_ =   ly_ / 2.0;
+
+  // linspaced is on closed interval (unlike Python which is open to right)
+  // x_ = Eigen::ArrayXd::LinSpaced(nx_, lx_min_, lx_max_ - dx_);
+  // y_ = Eigen::ArrayXd::LinSpaced(ny_, ly_min_, ly_max_ - dy_);
+
+  // broadcast to matrices (aka meshgrid)
+  // x_grid_ = Eigen::ArrayXXd::Zero(nx_, ny_);
+  // y_grid_ = Eigen::ArrayXXd::Zero(nx_, ny_);
+  // x_grid_.colwise() += x_;
+  // y_grid_.rowwise() += y_.transpose();
 }
 
 //////////////////////////////////////////////////
-void TrochoidIrregularWaveSimulation::Impl::SetTime(double time)
+void TrochoidIrregularWaveSimulation::Impl::Elevation(
+    double x, double y,
+    double &eta)
 {
-  // @TODO NO IMPLEMENTATION
-  this->time_ = time;
+  /// \todo(srmainwaring) IMPLEMENT
+  gzerr << "Elevation: Not implemented!\n";
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::Elevation(
+    const Eigen::Ref<const Eigen::ArrayXd>& x,
+    const Eigen::Ref<const Eigen::ArrayXd>& y,
+    Eigen::Ref<Eigen::ArrayXd> eta)
+{
+  /// \todo(srmainwaring) IMPLEMENT
+  gzerr << "Elevation: Not implemented!\n";
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::Pressure(
+    double x, double y, double z,
+    double &pressure)
+{
+  /// \todo(srmainwaring) IMPLEMENT
+  gzerr << "Pressure: Not implemented!\n";
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::Pressure(
+    const Eigen::Ref<const Eigen::ArrayXd>& x,
+    const Eigen::Ref<const Eigen::ArrayXd>& y,
+    const Eigen::Ref<const Eigen::ArrayXd>& z,
+    Eigen::Ref<Eigen::ArrayXd> pressure)
+{
+  /// \todo(srmainwaring) IMPLEMENT
+  gzerr << "Pressure: Not implemented!\n";
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::Impl::ElevationAt(
-  Eigen::Ref<Eigen::ArrayXXd> h)
+    Eigen::Ref<Eigen::ArrayXXd> h)
 {
-  // Multiple wave params
-  const auto  number     = this->params_->Number();
-  const auto& amplitude  = this->params_->Amplitude_V();
-  const auto& wavenumber = this->params_->Wavenumber_V();
-  const auto& omega      = this->params_->AngularFrequency_V();
-  const auto& phase      = this->params_->Phase_V();
-  // const auto& q          = this->params_->Steepness_V();
-  const auto& direction  = this->params_->Direction_V();
+  if (!CheckValid())
+    return;
 
-  // Multiple wave update
-  h = Eigen::ArrayXXd::Zero(this->N2_, 0);
-  for (Index i=0; i < number; ++i)
+  h = Eigen::ArrayXXd::Zero(nx_ * ny_, 0);
+  for (Index iw = 0; iw < number_; ++iw)
   {
-    const auto& amplitude_i = amplitude[i];
-    const auto& wavenumber_i = wavenumber[i];
-    const auto& omega_i = omega[i];
-    const auto& phase_i = phase[i];
-    const auto& direction_i = direction[i];
-    // const auto& q_i = q[i];
+    double a_i = amplitude_[iw];
+    double k_i = wavenumber_[iw];
+    double w_i = omega_[iw];
+    double phi_i = phase_[iw];
+    auto dir_i = direction_[iw];
+    double cd_i = dir_i.X();
+    double sd_i = dir_i.Y();
 
-    for (Index iy=0; iy < this->N_; ++iy)
+    for (Index iy = 0; iy < ny_; ++iy)
     {
-      for (Index ix=0; i < this->N_; ++ix)
+      double y = iy * dy_ + ly_min_;
+      for (Index ix = 0; ix < nx_; ++ix)
       {
-        // Col major index
-        Index idx = iy * this->N_ + ix;
+        // col major index
+        Index idx = iy * nx_ + ix;
 
-        // Regular grid
-        double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;
-        double vy = iy * this->L_ / this->N_ - this->L_ / 2.0;
-
-        // Multiple waves
-        double ddotx = direction_i.X() * vx + direction_i.Y() * vy;
-        double angle  = ddotx * wavenumber_i - omega_i * time_ + phase_i;
-        // double s = std::sin(angle);
-        double c = std::cos(angle);
-        // double sx = - direction_i.X() * q_i * amplitude_i * s;
-        // double sy = - direction_i.Y() * q_i * amplitude_i * s;
-        double h1 = amplitude_i * c;
-
+        double x = ix * dx_ + lx_min_;
+        double ddotx = x * cd_i + y * sd_i;
+        double angle  = ddotx * k_i - w_i * time_ + phi_i;
+        double ca = std::cos(angle);
+        double h1 = a_i * ca;
         h(idx, 0) += h1;
       }
     }
@@ -153,58 +241,82 @@ void TrochoidIrregularWaveSimulation::Impl::ElevationAt(
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::Impl::ElevationDerivAt(
-  Eigen::Ref<Eigen::ArrayXXd> /*dhdx*/,
-  Eigen::Ref<Eigen::ArrayXXd> /*dhdy*/)
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy)
 {
-  // @TODO NO IMPLEMENTATION
+  if (!CheckValid())
+    return;
+
+  dhdx = Eigen::ArrayXXd::Zero(nx_ * ny_, 0);
+  dhdy = Eigen::ArrayXXd::Zero(nx_ * ny_, 0);
+  for (Index iw = 0; iw < number_; ++iw)
+  {
+    double a_i = amplitude_[iw];
+    double k_i = wavenumber_[iw];
+    double w_i = omega_[iw];
+    double phi_i = phase_[iw];
+    auto dir_i = direction_[iw];
+    double cd_i = dir_i.X();
+    double sd_i = dir_i.Y();
+    double dadx = cd_i * k_i;
+    double dady = sd_i * k_i;
+
+    for (Index iy = 0; iy < ny_; ++iy)
+    {
+      double y = iy * dy_ + ly_min_;
+      for (Index ix = 0; ix < nx_; ++ix)
+      {
+        // col major index
+        Index idx = iy * nx_ + ix;
+
+        double x = ix * dx_ + lx_min_;
+        double ddotx = x * cd_i + y * sd_i;
+        double angle  = ddotx * k_i - w_i * time_ + phi_i;
+        double sa = std::sin(angle);
+        double dhdx1 = - dadx * a_i * sa;
+        double dhdy1 = - dady * a_i * sa;
+        dhdx(idx, 0) += dhdx1;
+        dhdy(idx, 0) += dhdy1;
+      }
+    }
+  }
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::Impl::DisplacementAt(
-  Eigen::Ref<Eigen::ArrayXXd> sx,
-  Eigen::Ref<Eigen::ArrayXXd> sy)
+    Eigen::Ref<Eigen::ArrayXXd> sx,
+    Eigen::Ref<Eigen::ArrayXXd> sy)
 {
-  // Multiple wave params
-  const auto  number     = this->params_->Number();
-  const auto& amplitude  = this->params_->Amplitude_V();
-  const auto& wavenumber = this->params_->Wavenumber_V();
-  const auto& omega      = this->params_->AngularFrequency_V();
-  const auto& phase      = this->params_->Phase_V();
-  const auto& q          = this->params_->Steepness_V();
-  const auto& direction  = this->params_->Direction_V();
+  if (!CheckValid())
+    return;
 
-  // Multiple wave update
-  sx = Eigen::ArrayXXd::Zero(this->N2_, 0);
-  sy = Eigen::ArrayXXd::Zero(this->N2_, 0);
-  for (Index i=0; i < number; ++i)
+  sx = Eigen::ArrayXXd::Zero(nx_ * ny_, 0);
+  sy = Eigen::ArrayXXd::Zero(nx_ * ny_, 0);
+  for (Index iw = 0; iw < number_; ++iw)
   {
-    const auto& amplitude_i = amplitude[i];
-    const auto& wavenumber_i = wavenumber[i];
-    const auto& omega_i = omega[i];
-    const auto& phase_i = phase[i];
-    const auto& direction_i = direction[i];
-    const auto& q_i = q[i];
+    double a_i = amplitude_[iw];
+    double k_i = wavenumber_[iw];
+    double w_i = omega_[iw];
+    double phi_i = phase_[iw];
+    double q_i = q_[iw];
+    auto dir_i = direction_[iw];
+    double cd_i = dir_i.X();
+    double sd_i = dir_i.Y();
 
-    for (Index iy=0; iy < this->N_; ++iy)
+    for (Index iy = 0; iy < ny_; ++iy)
     {
-      for (Index ix=0; ix < this->N_; ++ix)
+      double y = iy * dy_ + ly_min_;
+      for (Index ix = 0; ix < nx_; ++ix)
       {
-        // Col major index
-        Index idx = iy * this->N_ + ix;
+        // col major index
+        Index idx = iy * nx_ + ix;
 
-        // Regular grid
-        double vx = ix * this->L_ / this->N_ - this->L_ / 2.0;
-        double vy = iy * this->L_ / this->N_ - this->L_ / 2.0;
-
-        // Multiple waves
-        double ddotx = direction_i.X() * vx + direction_i.Y() * vy;
-        double angle  = ddotx * wavenumber_i - omega_i * time_ + phase_i;
-        double s = std::sin(angle);
-        // double c = std::cos(angle);
-        double sx1 = - direction_i.X() * q_i * amplitude_i * s;
-        double sy1 = - direction_i.Y() * q_i * amplitude_i * s;
-        // double h = amplitude_i * c;
-
+        double x = ix * dx_ + lx_min_;
+        double ddotx = x * cd_i + y * sd_i;
+        double angle  = ddotx * k_i - w_i * time_ + phi_i;
+        double sa = std::sin(angle);
+        double sx1 = - cd_i * q_i * a_i * sa;
+        double sy1 = - sd_i * q_i * a_i * sa;
         sx(idx, 0) += sx1;
         sy(idx, 0) += sy1;
       }
@@ -214,143 +326,352 @@ void TrochoidIrregularWaveSimulation::Impl::DisplacementAt(
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::Impl::DisplacementDerivAt(
-  Eigen::Ref<Eigen::ArrayXXd> /*dsxdx*/,
-  Eigen::Ref<Eigen::ArrayXXd> /*dsydy*/,
-  Eigen::Ref<Eigen::ArrayXXd> /*dsxdy*/)
+    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+    Eigen::Ref<Eigen::ArrayXXd> dsydy,
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy)
 {
-  // @TODO NO IMPLEMENTATION
+  if (!CheckValid())
+    return;
+
+  dsxdx = Eigen::ArrayXXd::Zero(nx_ * ny_, 0);
+  dsydy = Eigen::ArrayXXd::Zero(nx_ * ny_, 0);
+  dsxdy = Eigen::ArrayXXd::Zero(nx_ * ny_, 0);
+  for (Index iw = 0; iw < number_; ++iw)
+  {
+    double a_i = amplitude_[iw];
+    double k_i = wavenumber_[iw];
+    double w_i = omega_[iw];
+    double phi_i = phase_[iw];
+    double q_i = q_[iw];
+    auto dir_i = direction_[iw];
+    double cd_i = dir_i.X();
+    double sd_i = dir_i.Y();
+    double dadx = cd_i * k_i;
+    double dady = sd_i * k_i;
+
+    for (Index iy = 0; iy < ny_; ++iy)
+    {
+      double y = iy * dy_ + ly_min_;
+      for (Index ix = 0; ix < nx_; ++ix)
+      {
+        // col major index
+        Index idx = iy * nx_ + ix;
+
+        double x = ix * dx_ + lx_min_;
+        double ddotx = x * cd_i + y * sd_i;
+        double angle  = ddotx * k_i - w_i * time_ + phi_i;
+        double sa = std::sin(angle);
+        double ca = std::cos(angle);
+        double dsxdx1 = - cd_i * q_i * a_i * dadx * ca;
+        double dsydy1 = - sd_i * q_i * a_i * dady * ca;
+        double dsxdy1 = - cd_i * q_i * a_i * dady * ca;
+        dsxdx(idx, 0) += dsxdx1;
+        dsydy(idx, 0) += dsydy1;
+        dsxdy(idx, 0) += dsxdy1;
+      }
+    }
+  }
 }
 
 //////////////////////////////////////////////////
-TrochoidIrregularWaveSimulation::~TrochoidIrregularWaveSimulation()
+void TrochoidIrregularWaveSimulation::Impl::ElevationAt(
+    Index ix, Index iy,
+    double &h)
 {
+  /// \todo(srmainwaring) IMPLEMENT
+  gzerr << "ElevationAt: Not implemented!\n";
 }
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::DisplacementAt(
+    Index ix, Index iy,
+    double& sx, double& sy)
+{
+  /// \todo(srmainwaring) IMPLEMENT
+  gzerr << "DisplacementAt: Not implemented!\n";
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::PressureAt(
+    Index ix, Index iy, Index iz,
+    double &pressure)
+{
+  /// \todo(srmainwaring) IMPLEMENT
+  gzerr << "PressureAt: Not implemented!\n";
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Impl::PressureAt(
+    Index iz,
+    Eigen::Ref<Eigen::ArrayXXd> pressure)
+{
+  /// \todo(srmainwaring) IMPLEMENT
+  gzerr << "PressureAt: Not implemented!\n";
+}
+
+//////////////////////////////////////////////////
+bool TrochoidIrregularWaveSimulation::Impl::CheckValid()
+{
+  if (!is_param_check_dirty_)
+    return is_valid_;
+
+  is_valid_ = true;
+
+  if (amplitude_.size() != number_)
+  {
+    gzerr << "Amplitude array must have size = " << number_ << ".\n";
+    is_valid_ &= false;
+  }
+  if (wavenumber_.size() != number_)
+  {
+    gzerr << "Wavenumber array must have size = " << number_ << ".\n";
+    is_valid_ &= false;
+  }
+  if (omega_.size() != number_)
+  {
+    gzerr << "Angular frequency array must have size = " << number_ << ".\n";
+    is_valid_ &= false;
+  }
+  if (phase_.size() != number_)
+  {
+    gzerr << "Phase array must have size = " << number_ << ".\n";
+    is_valid_ &= false;
+  }
+  if (q_.size() != number_)
+  {
+    gzerr << "Steepness array must have size = " << number_ << ".\n";
+    is_valid_ &= false;
+  }
+  if (direction_.size() != number_)
+  {
+    gzerr << "Direction array must have size = " << number_ << ".\n";
+    is_valid_ &= false;
+  }
+
+  is_param_check_dirty_ = false;
+  return is_valid_;
+}
+
+//////////////////////////////////////////////////
+//////////////////////////////////////////////////
+TrochoidIrregularWaveSimulation::~TrochoidIrregularWaveSimulation() = default;
 
 //////////////////////////////////////////////////
 TrochoidIrregularWaveSimulation::TrochoidIrregularWaveSimulation(
-  Index N,
-  double L,
-  std::shared_ptr<WaveParameters> params) :
-  impl_(new TrochoidIrregularWaveSimulation::Impl(N, L, params))
+    double lx, double ly, Index nx, Index ny) :
+  impl_(new TrochoidIrregularWaveSimulation::Impl(lx, ly, nx, ny))
 {
 }
 
 //////////////////////////////////////////////////
-void TrochoidIrregularWaveSimulation::SetWindVelocity(double ux, double uy)
+void TrochoidIrregularWaveSimulation::SetNumber(Index value)
 {
-  impl_->SetWindVelocity(ux, uy);
+  impl_->number_ = value;
+  impl_->is_param_check_dirty_ = true;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetAmplitude(
+    const std::vector<double>& value)
+{
+  impl_->amplitude_ = value;
+  impl_->is_param_check_dirty_ = true;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetWaveNumber(
+    const std::vector<double>& value)
+{
+  impl_->wavenumber_ = value;
+  impl_->is_param_check_dirty_ = true;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetOmega(
+    const std::vector<double>& value)
+{
+  impl_->omega_ = value;
+  impl_->is_param_check_dirty_ = true;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetPhase(
+    const std::vector<double>& value)
+{
+  impl_->phase_ = value;
+  impl_->is_param_check_dirty_ = true;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetSteepness(
+    const std::vector<double>& value)
+{
+  impl_->q_ = value;
+  impl_->is_param_check_dirty_ = true;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetDirection(
+    const std::vector<math::Vector2d>& value)
+{
+  impl_->direction_ = value;
+  impl_->is_param_check_dirty_ = true;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::SetWindVelocity(
+    double /*ux*/, double /*uy*/)
+{
+  /// \note NO-OP
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::SetSteepness(
     double /*value*/)
 {
-  /// \todo(srmainwaring) IMPLEMENT
+  /// \todo(srmainwaring) DEPRECATE - not used
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::SetTime(double time)
 {
-  impl_->SetTime(time);
+  impl_->time_ = time;
 }
 
 //////////////////////////////////////////////////
 Index TrochoidIrregularWaveSimulation::SizeX() const
 {
-  return impl_->N_;
+  return impl_->nx_;
 }
 
 //////////////////////////////////////////////////
 Index TrochoidIrregularWaveSimulation::SizeY() const
 {
-  return impl_->N_;
+  return impl_->ny_;
 }
 
 //////////////////////////////////////////////////
 Index TrochoidIrregularWaveSimulation::SizeZ() const
 {
-  return 0;
+  return impl_->nz_;
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Elevation(
+    double x, double y,
+    double& eta) const
+{
+  impl_->Elevation(x, y, eta);
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Elevation(
+    const Eigen::Ref<const Eigen::ArrayXd>& x,
+    const Eigen::Ref<const Eigen::ArrayXd>& y,
+    Eigen::Ref<Eigen::ArrayXd> eta) const
+{
+  impl_->Elevation(x, y, eta);
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Pressure(
+    double x, double y, double z,
+    double& pressure) const
+{
+  impl_->Pressure(x, y, z, pressure);
+}
+
+//////////////////////////////////////////////////
+void TrochoidIrregularWaveSimulation::Pressure(
+    const Eigen::Ref<const Eigen::ArrayXd>& x,
+    const Eigen::Ref<const Eigen::ArrayXd>& y,
+    const Eigen::Ref<const Eigen::ArrayXd>& z,
+    Eigen::Ref<Eigen::ArrayXd> pressure) const
+{
+  impl_->Pressure(x, y, z, pressure);
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::ElevationAt(
-  Eigen::Ref<Eigen::ArrayXXd> h) const
+    Eigen::Ref<Eigen::ArrayXXd> h) const
 {
   impl_->ElevationAt(h);
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::ElevationDerivAt(
-  Eigen::Ref<Eigen::ArrayXXd> dhdx,
-  Eigen::Ref<Eigen::ArrayXXd> dhdy) const
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy) const
 {
   impl_->ElevationDerivAt(dhdx, dhdy);
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::DisplacementAt(
-  Eigen::Ref<Eigen::ArrayXXd> sx,
-  Eigen::Ref<Eigen::ArrayXXd> sy) const
+    Eigen::Ref<Eigen::ArrayXXd> sx,
+    Eigen::Ref<Eigen::ArrayXXd> sy) const
 {
   impl_->DisplacementAt(sx, sy);
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::DisplacementDerivAt(
-  Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-  Eigen::Ref<Eigen::ArrayXXd> dsydy,
-  Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
+    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+    Eigen::Ref<Eigen::ArrayXXd> dsydy,
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
 {
   impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::DisplacementAndDerivAt(
-  Eigen::Ref<Eigen::ArrayXXd> h,
-  Eigen::Ref<Eigen::ArrayXXd> sx,
-  Eigen::Ref<Eigen::ArrayXXd> sy,
-  Eigen::Ref<Eigen::ArrayXXd> dhdx,
-  Eigen::Ref<Eigen::ArrayXXd> dhdy,
-  Eigen::Ref<Eigen::ArrayXXd> dsxdx,
-  Eigen::Ref<Eigen::ArrayXXd> dsydy,
-  Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
+    Eigen::Ref<Eigen::ArrayXXd> h,
+    Eigen::Ref<Eigen::ArrayXXd> sx,
+    Eigen::Ref<Eigen::ArrayXXd> sy,
+    Eigen::Ref<Eigen::ArrayXXd> dhdx,
+    Eigen::Ref<Eigen::ArrayXXd> dhdy,
+    Eigen::Ref<Eigen::ArrayXXd> dsxdx,
+    Eigen::Ref<Eigen::ArrayXXd> dsydy,
+    Eigen::Ref<Eigen::ArrayXXd> dsxdy) const
 {
   impl_->ElevationAt(h);
-  impl_->ElevationDerivAt(dhdx, dhdy);
+  /// \todo undo flip of dhdx <---> dhdy once render plugin fixed
+  impl_->ElevationDerivAt(dhdy, dhdx);
+  // impl_->ElevationDerivAt(dhdx, dhdy);
   impl_->DisplacementAt(sx, sy);
   impl_->DisplacementDerivAt(dsxdx, dsydy, dsxdy);
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::PressureAt(
-    Index ,
-    Eigen::Ref<Eigen::ArrayXXd>) const
+    Index iz,
+    Eigen::Ref<Eigen::ArrayXXd> pressure) const
 {
-  assert(0 && "Not implemented");
+  impl_->PressureAt(iz, pressure);
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::ElevationAt(
-    Index , Index ,
-    double&) const
+    Index ix, Index iy,
+    double& eta) const
 {
-  assert(0 && "Not implemented");
+  impl_->ElevationAt(ix, iy, eta);
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::DisplacementAt(
-    Index , Index ,
-    double&, double&) const
+    Index ix, Index iy,
+    double& sx, double& sy) const
 {
-  assert(0 && "Not implemented");
+  impl_->DisplacementAt(ix, iy, sx, sy);
 }
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::PressureAt(
-    Index , Index , Index ,
-    double&) const
+    Index ix, Index iy, Index iz,
+    double& pressure) const
 {
-  assert(0 && "Not implemented");
+  impl_->PressureAt(ix, iy, iz, pressure);
 }
 
 }  // namespace waves


### PR DESCRIPTION
This PR fixes the original trochoid (Gerstner) wave model that was broken when the FFT model and ocean tiling was implemented. It is mainly here for comparison with earlier versions of wave_sim and the native wave implementation provided in the Gazebo distribution. 

## Details

- Update constructor to match other wave sims.
- Add set methods for parameters.
- Support different grid sizes in x and y directions.
- Use std::make_unique when creating wave models in OceanTile constructors.
- Complete sketching out interface of trochoid wave model.
- Update setting parameters in OceanTile constructors.
- Stub out remaining functions in Trochoid wave model.
- Replace asserts with error message.
- Add parameter validation checks.
- Zero displacements prior to update.
- Add derivative calculations for visuals.
- Add trochoid wave SDF model as example.
- Update tile and cell count for regular wave SDF model.

## Notes

- Some of the TrochoidIrregularWaveSimulation methods are still stubbed out.
