### PR TITLE
Fix compiler warnings

### DIFF
--- a/gz-waves/src/LinearRandomFFTWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomFFTWaveSimulation.cc
@@ -377,7 +377,7 @@ void LinearRandomFFTWaveSimulation::Impl::ComputeCurrentAmplitudes(
   auto psi_root = cap_psi_2s_root_.reshaped();
 
   // time update for unique omega_k (reduce number of calls to sincos)
-  for (Index uidx = 0; uidx < uomega_k_.size(); ++uidx)
+  for (size_t uidx = 0; uidx < uomega_k_.size(); ++uidx)
   {
     double wt = uomega_k_[uidx] * time;
     ucos_wt_(uidx) = cos(wt);

--- a/gz-waves/src/LinearRandomWaveSimulation.cc
+++ b/gz-waves/src/LinearRandomWaveSimulation.cc
@@ -144,10 +144,10 @@ LinearRandomWaveSimulation::Impl::~Impl() = default;
 //////////////////////////////////////////////////
 LinearRandomWaveSimulation::Impl::Impl(
   double lx, double ly, Index nx, Index ny) :
-  lx_(lx),
-  ly_(ly),
   nx_(nx),
-  ny_(ny)
+  ny_(ny),
+  lx_(lx),
+  ly_(ly)
 {
   InitGrid();
 }
@@ -155,12 +155,12 @@ LinearRandomWaveSimulation::Impl::Impl(
 //////////////////////////////////////////////////
 LinearRandomWaveSimulation::Impl::Impl(
   double lx, double ly, double lz, Index nx, Index ny, Index nz) :
-  lx_(lx),
-  ly_(ly),
-  lz_(lz),
   nx_(nx),
   ny_(ny),
-  nz_(nz)
+  nz_(nz),
+  lx_(lx),
+  ly_(ly),
+  lz_(lz)
 {
   InitGrid();
 }
@@ -218,7 +218,7 @@ void LinearRandomWaveSimulation::Impl::ElevationDeriv(
     dhdy += - dady * amplitude_(ik) * sa;
   }
   deta_dx = dhdx;
-  deta_dy = dhdx;
+  deta_dy = dhdy;
 }
 
 //////////////////////////////////////////////////

--- a/gz-waves/src/OceanTile.cc
+++ b/gz-waves/src/OceanTile.cc
@@ -640,7 +640,7 @@ void OceanTilePrivate<gz::math::Vector3d>::ComputeTBN(
   }
 
   // 2. Normalise each vertex's tangent space basis.
-  for (Index i=0; i < vertices.size(); ++i)
+  for (size_t i = 0; i < vertices.size(); ++i)
   {
     tangents[i].Normalize();
     bitangents[i].Normalize();
@@ -905,7 +905,7 @@ gz::common::Mesh* OceanTilePrivate<Vector3>::CreateMesh(
       new gz::common::SubMeshWithTangents());
 
   // Add position vertices
-  for (Index i=0; i < vertices_.size(); ++i)
+  for (size_t i = 0; i < vertices_.size(); ++i)
   {
     submesh->AddVertex(
         vertices_[i][0],
@@ -930,7 +930,7 @@ gz::common::Mesh* OceanTilePrivate<Vector3>::CreateMesh(
   }
 
   // Add indices
-  for (Index i=0; i < faces_.size(); ++i)
+  for (size_t i = 0; i < faces_.size(); ++i)
   {
     // Reverse orientation on faces
     if (reverse_orientation)
@@ -973,7 +973,7 @@ void OceanTilePrivate<gz::math::Vector3d>::UpdateMesh(
   }
 
   // Update positions, normals, texture coords etc.
-  for (Index i=0; i < vertices_.size(); ++i)
+  for (size_t i = 0; i < vertices_.size(); ++i)
   {
     submesh->SetVertex(i, vertices_[i]);
     submesh->SetNormal(i, normals_[i]);

--- a/gz-waves/src/Physics.cc
+++ b/gz-waves/src/Physics.cc
@@ -66,7 +66,8 @@ cgal::Point3 Physics::CenterOfForce(
 {
   /// \todo provide robust floating point checks
   double div = _fA + _fB;
-  if (div != 0)
+  constexpr double tol = 1.0E-16;
+  if (std::fabs(div) > tol)
   {
     double t = _fA / div;
     return _B + (_A - _B) * t;
@@ -114,7 +115,8 @@ cgal::Point3 Physics::CenterOfPressureApexUp(
   double h = _H.z() - _M.z();
   double tc = 2.0/3.0;
   double div = 6.0 * _z0 + 4.0 * h;
-  if (div != 0)
+  constexpr double tol = 1.0E-16;
+  if (std::fabs(div) > tol)
   {
     tc = (4.0 * _z0 + 3.0 * h) / div;
   }
@@ -133,7 +135,8 @@ cgal::Point3 Physics::CenterOfPressureApexDn(
   double h = _M.z() - _L.z();
   double tc = 1.0/3.0;
   double div = 6.0 * _z0 + 2.0 * h;
-  if (div != 0)
+  constexpr double tol = 1.0E-16;
+  if (std::fabs(div) > tol)
   {
     tc = (2.0 * _z0 + h) / div;
   }

--- a/gz-waves/src/TriangulatedGrid.cc
+++ b/gz-waves/src/TriangulatedGrid.cc
@@ -115,7 +115,6 @@ void TriangulatedGrid::Private::CreateMesh() {
   double lxm = - lx_ / 2.0;
   double lym = - ly_ / 2.0;
   const Index nx_plus1 = nx_ + 1;
-  const Index ny_plus1 = ny_ + 1;
 
   // Points - (nx_+1) points_ in each row / column
   for (int64_t iy=0; iy <= ny_; ++iy) {

--- a/gz-waves/src/TrochoidIrregularWaveSimulation.cc
+++ b/gz-waves/src/TrochoidIrregularWaveSimulation.cc
@@ -165,8 +165,8 @@ void TrochoidIrregularWaveSimulation::Impl::InitGrid()
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::Impl::Elevation(
-    double x, double y,
-    double &eta)
+    double /*x*/, double /*y*/,
+    double &/*eta*/)
 {
   /// \todo(srmainwaring) IMPLEMENT
   gzerr << "Elevation: Not implemented!\n";
@@ -174,9 +174,9 @@ void TrochoidIrregularWaveSimulation::Impl::Elevation(
 
 //////////////////////////////////////////////////
 void TrochoidIrregularWaveSimulation::Impl::Elevation(
-    const Eigen::Ref<const Eigen::ArrayXd>& x,
-    const Eigen::Ref<const Eigen::ArrayXd>& y,
-    Eigen::Ref<Eigen::ArrayXd> eta)
+    const Eigen::Ref<const Eigen::ArrayXd>& /*x*/,
+    const Eigen::Ref<const Eigen::ArrayXd>& /*y*/,
+    Eigen::Ref<Eigen::ArrayXd> /*eta*/)
 {
   /// \todo(srmainwaring) IMPLEMENT
   gzerr << "Elevation: Not implemented!\n";
@@ -360,7 +360,6 @@ void TrochoidIrregularWaveSimulation::Impl::DisplacementDerivAt(
         double x = ix * dx_ + lx_min_;
         double ddotx = x * cd_i + y * sd_i;
         double angle  = ddotx * k_i - w_i * time_ + phi_i;
-        double sa = std::sin(angle);
         double ca = std::cos(angle);
         double dsxdx1 = - cd_i * q_i * a_i * dadx * ca;
         double dsydy1 = - sd_i * q_i * a_i * dady * ca;
@@ -417,32 +416,32 @@ bool TrochoidIrregularWaveSimulation::Impl::CheckValid()
 
   is_valid_ = true;
 
-  if (amplitude_.size() != number_)
+  if (amplitude_.size() != static_cast<size_t>(number_))
   {
     gzerr << "Amplitude array must have size = " << number_ << ".\n";
     is_valid_ &= false;
   }
-  if (wavenumber_.size() != number_)
+  if (wavenumber_.size() != static_cast<size_t>(number_))
   {
     gzerr << "Wavenumber array must have size = " << number_ << ".\n";
     is_valid_ &= false;
   }
-  if (omega_.size() != number_)
+  if (omega_.size() != static_cast<size_t>(number_))
   {
     gzerr << "Angular frequency array must have size = " << number_ << ".\n";
     is_valid_ &= false;
   }
-  if (phase_.size() != number_)
+  if (phase_.size() != static_cast<size_t>(number_))
   {
     gzerr << "Phase array must have size = " << number_ << ".\n";
     is_valid_ &= false;
   }
-  if (q_.size() != number_)
+  if (q_.size() != static_cast<size_t>(number_))
   {
     gzerr << "Steepness array must have size = " << number_ << ".\n";
     is_valid_ &= false;
   }
-  if (direction_.size() != number_)
+  if (direction_.size() != static_cast<size_t>(number_))
   {
     gzerr << "Direction array must have size = " << number_ << ".\n";
     is_valid_ &= false;

--- a/gz-waves/src/WaveParameters.cc
+++ b/gz-waves/src/WaveParameters.cc
@@ -148,7 +148,8 @@ class WaveParametersPrivate
       const double omega = Physics::DeepWaterDispersionToOmega(k);
       const double phi = phase_;
       double q = 0.0;
-      if (a != 0)
+      constexpr double tol = 1.0E-16;
+      if (std::fabs(a) > tol)
       {
         q = std::min(1.0, steepness_ / (a * k * number_));
       }

--- a/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
+++ b/gz-waves/src/systems/hydrodynamics/Hydrodynamics.cc
@@ -606,7 +606,7 @@ bool HydrodynamicsPrivate::InitPhysics(EntityComponentManager &_ecm)
       << ", meshes: " << meshes.size()
       << ", collisions: " << collisions.size() << "\n";
 
-  for (waves::Index i=0; i < links.size(); ++i)
+  for (size_t i = 0; i < links.size(); ++i)
   {
     // Create storage
     waves::Index meshCount = meshes[i].size();
@@ -807,7 +807,7 @@ void HydrodynamicsPrivate::UpdatePhysics(const UpdateInfo &/*_info*/,
 
     // Meshes
     // waves::Index nSubTri = 0;
-    for (waves::Index j=0; j < hd->linkMeshes.size(); ++j)
+    for (size_t j = 0; j < hd->linkMeshes.size(); ++j)
     {
       // Update link mesh
       auto linkCollision = hd->linkCollisions[j];
@@ -1179,7 +1179,7 @@ void HydrodynamicsPrivate::InitWaterlineMarkers(
   waves::Index markerId = 1;
   for (auto&& hd : this->hydroData)
   {
-    for (waves::Index j=0; j < hd->linkMeshes.size(); ++j)
+    for (size_t j = 0; j < hd->linkMeshes.size(); ++j)
     {
       hd->waterlineMsgs[j].set_ns(modelName + "/waterline");
       hd->waterlineMsgs[j].set_id(markerId++);
@@ -1207,7 +1207,7 @@ void HydrodynamicsPrivate::InitUnderwaterSurfaceMarkers(
   waves::Index markerId = 1;
   for (auto&& hd : this->hydroData)
   {
-    for (waves::Index j=0; j < hd->linkMeshes.size(); ++j)
+    for (size_t j = 0; j < hd->linkMeshes.size(); ++j)
     {
       hd->underwaterSurfaceMsgs[j].set_ns(modelName + "/underwater_surface");
       hd->underwaterSurfaceMsgs[j].set_id(markerId++);
@@ -1322,7 +1322,7 @@ void HydrodynamicsPrivate::UpdateWaterlineMarkers()
 {
   for (auto&& hd : this->hydroData)
   {
-    for (waves::Index j=0; j < hd->linkMeshes.size(); ++j)
+    for (size_t j = 0; j < hd->linkMeshes.size(); ++j)
     {
       hd->waterlineMsgs[j].mutable_point()->Clear();
       hd->waterlineMsgs[j].set_action(gz::msgs::Marker::ADD_MODIFY);
@@ -1352,7 +1352,7 @@ void HydrodynamicsPrivate::UpdateUnderwaterSurfaceMarkers()
 {
   for (auto&& hd : this->hydroData)
   {
-    for (waves::Index j=0; j < hd->linkMeshes.size(); ++j)
+    for (size_t j = 0; j < hd->linkMeshes.size(); ++j)
     {
       hd->underwaterSurfaceMsgs[j].mutable_point()->Clear();
       hd->underwaterSurfaceMsgs[j].set_action(gz::msgs::Marker::ADD_MODIFY);
@@ -1395,7 +1395,7 @@ void HydrodynamicsPrivate::DeleteWaterlineMarkers()
 {
   for (auto&& hd : this->hydroData)
   {
-    for (waves::Index j=0; j < hd->linkMeshes.size(); ++j)
+    for (size_t j = 0; j < hd->linkMeshes.size(); ++j)
     {
       hd->waterlineMsgs[j].mutable_point()->Clear();
       hd->waterlineMsgs[j].set_action(gz::msgs::Marker::DELETE_MARKER);
@@ -1409,7 +1409,7 @@ void HydrodynamicsPrivate::DeleteUnderwaterSurfaceMarkers()
 {
   for (auto&& hd : this->hydroData)
   {
-    for (waves::Index j=0; j < hd->linkMeshes.size(); ++j)
+    for (size_t j = 0; j < hd->linkMeshes.size(); ++j)
     {
       hd->underwaterSurfaceMsgs[j].mutable_point()->Clear();
       hd->underwaterSurfaceMsgs[j].set_action(gz::msgs::Marker::DELETE_MARKER);

--- a/gz-waves/src/systems/waves/Ogre2OceanVisual.cc
+++ b/gz-waves/src/systems/waves/Ogre2OceanVisual.cc
@@ -219,7 +219,7 @@ void Ogre2OceanVisual::LoadOceanTile(waves::visual::OceanTilePtr _oceanTile)
   }
 
   // Add points and texture coordinates for each face
-  for (size_t i=0, v=0; i < _oceanTile->FaceCount(); i++, v+=3)
+  for (auto i = 0, v = 0; i < _oceanTile->FaceCount(); i++, v+=3)
   {
     auto face = _oceanTile->Face(i);
     // positions
@@ -240,7 +240,7 @@ void Ogre2OceanVisual::LoadOceanTile(waves::visual::OceanTilePtr _oceanTile)
 void Ogre2OceanVisual::UpdateOceanTile(waves::visual::OceanTilePtr _oceanTile)
 {
   // Update positions and texture coordinates for each face
-  for (size_t i=0, v=0; i < _oceanTile->FaceCount(); i++, v+=3)
+  for (auto i = 0, v = 0; i < _oceanTile->FaceCount(); i++, v+=3)
   {
     auto face = _oceanTile->Face(i);
     // positions

--- a/gz-waves/src/systems/waves/WavesVisual.cc
+++ b/gz-waves/src/systems/waves/WavesVisual.cc
@@ -591,7 +591,6 @@ void WavesVisualPrivate::OnUpdate()
   double simTime = this->currentSimTimeSeconds;
 
   // ocean tile parameters
-  auto [nx, ny] = this->waveParams->CellCount();
   auto [lx, ly] = this->waveParams->TileSize();
   double ux = this->waveParams->WindVelocity().X();
   double uy = this->waveParams->WindVelocity().Y();


### PR DESCRIPTION
Fix a number of compiler warnings highlighted in #132 that have crept in and don't appears to trigger a CI fail.

## Details

- Fix warnings for signed / unsigned comparison.
- Fix warnings for float zero comparison.
- Fix warnings for initialisation order.

There is also a bug fix for the derivative of the elevation in `LinearRandonWaveSimulation.cc`.