### PR TITLE
WAM-V: update ArduPilot plugin

### DIFF
--- a/gz-waves-models/models/wam-v/model.sdf
+++ b/gz-waves-models/models/wam-v/model.sdf
@@ -354,7 +354,7 @@
     </plugin>
 
     <!-- ArduPilot plugin -->
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin.so">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>
       <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>

--- a/gz-waves-models/models/wam-v/model.sdf
+++ b/gz-waves-models/models/wam-v/model.sdf
@@ -360,7 +360,7 @@
       <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
       <lock_step>1</lock_step>
       <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <gazeboXYZToNED>0 0 0 3.141593 0 1.57079632</gazeboXYZToNED>
       <imuName>imu_sensor</imuName>
 
       <!--


### PR DESCRIPTION
Update the ArduPilot plugin in the WAM-V example.

- Correct the transform from the ENU to NED frame.
- Use the short form for the plugin library name.
