### PR TITLE
Remove patch number from Ogre2 version

### DIFF
--- a/gz-waves/CMakeLists.txt
+++ b/gz-waves/CMakeLists.txt
@@ -132,14 +132,14 @@ gz_find_package(GzOGRE VERSION 1.9.0
 # Find OGRE2: first try to find OGRE2 built with PlanarReflections support and
 # fallback to look for OGRE2 without it. Both seems to works for gz-rendering.
 # See https://github.com/gazebosim/gz-rendering/issues/597
-gz_find_package(GzOGRE2 VERSION 2.3.1
+gz_find_package(GzOGRE2 VERSION 2.3
     COMPONENTS HlmsPbs HlmsUnlit Overlay PlanarReflections
     PRIVATE_FOR ogre2
     QUIET)
 
 if ("${OGRE2-PlanarReflections}" STREQUAL "OGRE2-PlanarReflections-NOTFOUND")
   message(STATUS "PlanarReflections component was not found. Try looking without it:")
-  gz_find_package(GzOGRE2 VERSION 2.3.1
+  gz_find_package(GzOGRE2 VERSION 2.3
     COMPONENTS HlmsPbs HlmsUnlit Overlay
     REQUIRED_BY ogre2
     PRIVATE_FOR ogre2)


### PR DESCRIPTION
Require matching of major and minor versions only.

See: #164