### PR TITLE
Prevent duplicate textures being loaded in displacement map

### DIFF
--- a/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
+++ b/gz-waves/src/systems/waves/Ogre2DisplacementMap.cc
@@ -139,7 +139,7 @@ void Ogre2DisplacementMap::InitTextures()
 
   // Create displacement texture
   gzmsg << "Create HeightMap texture\n";
-  mHeightMapTex = ogre2TextureManager->createTexture(
+  mHeightMapTex = ogre2TextureManager->createOrRetrieveTexture(
       "HeightMapTex(" + std::to_string(this->entity) + ")",
       Ogre::GpuPageOutStrategy::SaveToSystemRam,
       Ogre::TextureFlags::ManualTexture,
@@ -153,7 +153,7 @@ void Ogre2DisplacementMap::InitTextures()
 
   // Create normal texture
   gzmsg << "Create NormalMap texture\n";
-  mNormalMapTex = ogre2TextureManager->createTexture(
+  mNormalMapTex = ogre2TextureManager->createOrRetrieveTexture(
       "NormalMapTex(" + std::to_string(this->entity) + ")",
       Ogre::GpuPageOutStrategy::SaveToSystemRam,
       Ogre::TextureFlags::ManualTexture,
@@ -167,7 +167,7 @@ void Ogre2DisplacementMap::InitTextures()
 
   // Create tangent texture
   gzmsg << "Create TangentMap texture\n";
-  mTangentMapTex = ogre2TextureManager->createTexture(
+  mTangentMapTex = ogre2TextureManager->createOrRetrieveTexture(
       "TangentMapTex(" + std::to_string(this->entity) + ")",
       Ogre::GpuPageOutStrategy::SaveToSystemRam,
       Ogre::TextureFlags::ManualTexture,


### PR DESCRIPTION
Fix an issue where the visual plugin attempted to load the height, normal and tangent map textures twice when using displacement map rendering.

There is still an upstream issue in the `GzSceneManager` (`gz-sim/src/gui/plugins/scene_manager`) whereby the visual plugin is loaded twice, causing performance issues, but this change prevents the segmentation fault that caused the GUI to crash.

Applies to the `ocean_world.sdf` model.