### PR TITLE
fix gazebo ionic build

### DIFF
--- a/gz-waves/CMakeLists.txt
+++ b/gz-waves/CMakeLists.txt
@@ -292,7 +292,7 @@ set(FAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/fake/install")
 # Configure the build
 #============================================================================
 
-gz_configure_build(QUIT_IF_BUILD_ERRORS)
+gz_configure_build(QUIT_IF_BUILD_ERRORS EXPOSE_SYMBOLS_BY_DEFAULT)
 
 # add_subdirectory(examples)
 


### PR DESCRIPTION
closes #188

EXPOSE_SYMBOLS_BY_DEFAULT does not exist as an option in older versions of gz-cmake but specifying it for those older versions does not appear to break anything. I'm not sure whatever this is good practice though.